### PR TITLE
Task T: finding triage — Rego engine + binary vulnerability gate

### DIFF
--- a/data/vuln-dispositions.json
+++ b/data/vuln-dispositions.json
@@ -1,0 +1,13 @@
+{
+  "_note": "Operator disposition register for VULNERABILITIES (CVEs from ZAP/Grype/Dependabot). The build FAILS on any scanner-reported vulnerability of any severity (Critical/High/Medium/Low) that is not handled. A vulnerability is handled ONLY if it is (a) remediated/gone, or (b) dispositioned here as 'false-positive' (no real risk / N/A) or 'operational-requirement' (real risk, deliberately accepted). A risk-adjusted vulnerability still has a severity, so it does NOT pass the gate — fix it. Config-scanner suppressions (Checkov) live in .checkov.yaml + the VDR maps, not here.",
+  "_pass_dispositions": ["false-positive", "operational-requirement"],
+  "_example": {
+    "CVE-2025-00000": {
+      "disposition": "false-positive",
+      "justification": "Vulnerable code path is not reachable in the deployed app; the package is a build-time-only transitive dependency.",
+      "decided_by": "Sam Aydlette",
+      "decided_on": "2026-06-13"
+    }
+  },
+  "dispositions": {}
+}

--- a/policies/triage.rego
+++ b/policies/triage.rego
@@ -1,0 +1,254 @@
+# =============================================================================
+# FINDING TRIAGE ENGINE  (policy-as-code)
+# =============================================================================
+# Triages a single finding (a Checkov config suppression OR a vulnerability from
+# ZAP/Grype/Dependabot) into a disposition and, when remediation is required, a
+# remediation timeline derived from the risk score through a layered policy
+# chain. Pure policy: human decisions arrive as `input.asserted` (sourced from
+# the disposition register); this module decides nothing a human must own, it
+# applies the operator's recorded decision and computes the consequences.
+#
+# DISPOSITIONS (exactly one per finding):
+#   false-positive         no real risk / not applicable
+#   operational-requirement risk is accurate but accepted (tracked, not patched)
+#   risk-adjustment         risk is real but lower than the CVSS (preferred) /
+#                           scanner severity; severity is adjusted down
+#   remediate               (default for a real vulnerability) fix on a timeline
+#
+# REMEDIATION-TIMELINE CHAIN (only for remediate / risk-adjustment), in order:
+#   1. contextual   PAIN from effective severity, bumped by reachability (IRV) +
+#                   exploitability (LEV)
+#   2. immutable    CISA KEV (is_kev) => must patch now, overrides thresholds
+#   3. threshold    Class C SLA table keyed by (PAIN, LEV, IRV) => days
+#   4. historical   if similar past cases set a shorter timeline, use it
+#   5. escalation   unprecedented risk or architectural change => route to human
+#
+# Output: data.vdr.triage.decision  (see bottom).
+# =============================================================================
+package vdr.triage
+
+import future.keywords.in
+
+# Boolean rules default to false so they are always defined (an undefined rule
+# referenced inside `decision` would make the whole object undefined).
+default remediation_required := false
+default must_patch_now := false
+default escalate := false
+default invalid_risk_adjustment := false
+default historical_present := false
+default tighter_history := false
+
+# Context flags read with defaults so a finding that omits them is still defined.
+irv := object.get(input, "internet_reachable", false)
+lev := object.get(input, "likely_exploitable", false)
+
+# ---- severity helpers -------------------------------------------------------
+sev_rank := {"NONE": 0, "LOW": 1, "MEDIUM": 2, "MODERATE": 2, "HIGH": 3, "CRITICAL": 4}
+
+# CVSS base score -> severity bucket (CVSS v3 ranges).
+cvss_severity(score) = "CRITICAL" { score >= 9.0 }
+cvss_severity(score) = "HIGH"     { score >= 7.0; score < 9.0 }
+cvss_severity(score) = "MEDIUM"   { score >= 4.0; score < 7.0 }
+cvss_severity(score) = "LOW"      { score > 0.0;  score < 4.0 }
+cvss_severity(score) = "NONE"     { score <= 0.0 }
+
+# Baseline anchor, in preference order:
+#   1. the CVE's base CVSS score          (preferred)
+#   2. the scanner's own numeric score    (0-10 scale)
+#   3. the scanner's severity label
+default has_cvss := false
+has_cvss { is_number(input.cvss) }
+
+default has_scanner_score := false
+has_scanner_score { is_number(input.scanner_score) }
+
+base_severity := cvss_severity(input.cvss) { has_cvss }
+
+base_severity := cvss_severity(input.scanner_score) {
+	not has_cvss
+	has_scanner_score
+}
+
+base_severity := upper(object.get(input, "scanner_severity", "MEDIUM")) {
+	not has_cvss
+	not has_scanner_score
+}
+
+# ---- disposition ------------------------------------------------------------
+valid_dispositions := {"false-positive", "operational-requirement", "risk-adjustment", "remediate"}
+
+default disposition := "remediate"
+
+disposition := d {
+	d := object.get(input.asserted, "disposition", null)
+	d != null
+	d in valid_dispositions
+}
+
+# ---- effective severity (what the timeline is computed against) -------------
+effective_severity := "NONE" { disposition == "false-positive" }
+
+effective_severity := base_severity {
+	disposition == "operational-requirement"
+}
+
+# Risk adjustment may only LOWER severity, and is anchored to the base (CVSS
+# preferred). A valid adjustment uses the adjusted value; an adjustment at or
+# above the base is invalid (flagged) and falls back to the base severity.
+effective_severity := adj {
+	disposition == "risk-adjustment"
+	adj := upper(object.get(input.asserted, "adjusted_severity", base_severity))
+	sev_rank[adj] < sev_rank[base_severity]
+}
+
+effective_severity := base_severity {
+	disposition == "risk-adjustment"
+	adj := upper(object.get(input.asserted, "adjusted_severity", base_severity))
+	sev_rank[adj] >= sev_rank[base_severity]
+}
+
+effective_severity := base_severity { disposition == "remediate" }
+
+# An invalid risk adjustment (tried to raise or keep severity) is flagged.
+invalid_risk_adjustment {
+	disposition == "risk-adjustment"
+	adj := upper(object.get(input.asserted, "adjusted_severity", base_severity))
+	sev_rank[adj] >= sev_rank[base_severity]
+}
+
+remediation_required {
+	disposition in {"remediate", "risk-adjustment"}
+}
+
+# ---- 1. contextual: PAIN rating --------------------------------------------
+pain_base := {"NONE": 1, "LOW": 1, "MEDIUM": 2, "MODERATE": 2, "HIGH": 3, "CRITICAL": 4}
+
+# Reachable AND exploitable bumps PAIN one notch (capped at N5).
+default reachable_and_exploitable := false
+
+reachable_and_exploitable {
+	irv
+	lev
+}
+
+pain_n := n {
+	reachable_and_exploitable
+	n := min([5, pain_base[effective_severity] + 1])
+}
+
+pain_n := pain_base[effective_severity] {
+	not reachable_and_exploitable
+}
+
+pain := sprintf("N%d", [pain_n])
+
+# ---- 2. immutable: CISA KEV must-patch-now ---------------------------------
+must_patch_now {
+	remediation_required
+	input.is_kev
+}
+
+# ---- 3. threshold: Class C SLA (days) keyed by (pain, lev, irv) -------------
+# Mirrors CLASS_C_SLA_DAYS in build-vdr-report.py (VDR-TFR-PVR). N1 has no fixed
+# SLA (routine ops); represented as 365 (review within a year).
+sla_table := {
+	"N1|x|x": 365,
+	"N2|true|true": 48, "N2|true|false": 128, "N2|false|true": 192, "N2|false|false": 192,
+	"N3|true|true": 16, "N3|true|false": 32, "N3|false|true": 128, "N3|false|false": 128,
+	"N4|true|true": 4, "N4|true|false": 8, "N4|false|true": 64, "N4|false|false": 64,
+	"N5|true|true": 2, "N5|true|false": 4, "N5|false|true": 16, "N5|false|false": 16,
+}
+
+sla_key := k {
+	pain == "N1"
+	k := "N1|x|x"
+}
+
+sla_key := k {
+	pain != "N1"
+	k := sprintf("%s|%v|%v", [pain, lev, irv])
+}
+
+threshold_days := object.get(sla_table, sla_key, 365)
+
+# ---- 4. historical: similar past cases may tighten the timeline -------------
+historical_days := d {
+	d := input.historical.median_days
+	is_number(d)
+}
+
+# ---- 5. escalation ----------------------------------------------------------
+escalate {
+	remediation_required
+	object.get(input.asserted, "architectural_change_required", false)
+}
+
+escalate {
+	remediation_required
+	effective_severity == "CRITICAL"
+	not historical_present
+}
+
+historical_present {
+	is_number(input.historical.median_days)
+}
+
+escalation_reason := "architectural change required" {
+	object.get(input.asserted, "architectural_change_required", false)
+}
+
+escalation_reason := "unprecedented critical risk, no historical precedent" {
+	not object.get(input.asserted, "architectural_change_required", false)
+	effective_severity == "CRITICAL"
+	not historical_present
+}
+
+# ---- final SLA + deciding layer --------------------------------------------
+sla_days := 0 { must_patch_now }
+
+sla_days := d {
+	not must_patch_now
+	remediation_required
+	historical_present
+	historical_days < threshold_days
+	d := historical_days
+}
+
+sla_days := threshold_days {
+	not must_patch_now
+	remediation_required
+	not tighter_history
+}
+
+tighter_history {
+	historical_present
+	historical_days < threshold_days
+}
+
+decided_by := "disposition" { not remediation_required }
+decided_by := "immutable" { must_patch_now }
+decided_by := "escalation" { not must_patch_now; remediation_required; escalate }
+decided_by := "historical" { not must_patch_now; remediation_required; not escalate; tighter_history }
+decided_by := "threshold" { not must_patch_now; remediation_required; not escalate; not tighter_history }
+
+# ---- decision ---------------------------------------------------------------
+decision := {
+	"id": object.get(input, "id", ""),
+	"disposition": disposition,
+	"effective_severity": effective_severity,
+	"remediation_required": remediation_required,
+	"pain": pain,
+	"must_patch_now": must_patch_now,
+	"sla_days": sla_days_out,
+	"escalate": escalate,
+	"escalation_reason": reason_out,
+	"decided_by": decided_by,
+	"invalid_risk_adjustment": invalid_risk_adjustment,
+}
+
+# sla_days only meaningful when remediation is required.
+sla_days_out := sla_days { remediation_required }
+sla_days_out := null { not remediation_required }
+
+reason_out := escalation_reason { escalate }
+reason_out := "" { not escalate }

--- a/policies/triage_test.rego
+++ b/policies/triage_test.rego
@@ -1,0 +1,112 @@
+package vdr.triage
+
+# false-positive: no risk, no remediation, no SLA
+test_false_positive {
+	d := decision with input as {
+		"id": "CKV_AWS_144", "scanner_severity": "LOW",
+		"asserted": {"disposition": "false-positive"},
+	}
+	d.disposition == "false-positive"
+	d.remediation_required == false
+	d.sla_days == null
+	d.effective_severity == "NONE"
+	d.decided_by == "disposition"
+}
+
+# operational requirement: real risk, accepted, not patched
+test_operational_requirement {
+	d := decision with input as {
+		"id": "CKV_AWS_68", "scanner_severity": "MEDIUM", "internet_reachable": true,
+		"asserted": {"disposition": "operational-requirement"},
+	}
+	d.disposition == "operational-requirement"
+	d.remediation_required == false
+	d.sla_days == null
+}
+
+# risk adjustment: HIGH cvss adjusted down to LOW is valid; remediates on the
+# adjusted (lower) timeline
+test_risk_adjustment_valid {
+	d := decision with input as {
+		"id": "CVE-2026-1", "cvss": 7.5,
+		"internet_reachable": false, "likely_exploitable": false,
+		"asserted": {"disposition": "risk-adjustment", "adjusted_severity": "LOW"},
+	}
+	d.effective_severity == "LOW"
+	d.remediation_required == true
+	d.invalid_risk_adjustment == false
+	d.pain == "N1"
+}
+
+# risk adjustment that tries to keep/raise severity is flagged invalid
+test_risk_adjustment_invalid {
+	d := decision with input as {
+		"id": "CVE-2026-2", "cvss": 4.0,
+		"asserted": {"disposition": "risk-adjustment", "adjusted_severity": "HIGH"},
+	}
+	d.invalid_risk_adjustment == true
+}
+
+# immutable: a KEV vulnerability must be patched now regardless of thresholds
+test_kev_must_patch_now {
+	d := decision with input as {
+		"id": "CVE-2026-3", "cvss": 9.8, "is_kev": true,
+		"internet_reachable": true, "likely_exploitable": true,
+		"asserted": {"disposition": "remediate"},
+	}
+	d.must_patch_now == true
+	d.sla_days == 0
+	d.decided_by == "immutable"
+}
+
+# threshold: HIGH, reachable + exploitable -> PAIN bumped, SLA from table
+test_threshold_high_reachable_exploitable {
+	d := decision with input as {
+		"id": "CVE-2026-4", "cvss": 7.5, "is_kev": false,
+		"internet_reachable": true, "likely_exploitable": true,
+		"asserted": {"disposition": "remediate"},
+	}
+	d.pain == "N4" # HIGH(3) + reachable&exploitable bump = 4
+	d.decided_by == "threshold"
+	d.sla_days == 4 # N4|true|true
+}
+
+# historical: a shorter precedent tightens the timeline
+test_historical_tightens {
+	d := decision with input as {
+		"id": "CVE-2026-5", "cvss": 5.0, "is_kev": false,
+		"internet_reachable": false, "likely_exploitable": false,
+		"historical": {"median_days": 10},
+		"asserted": {"disposition": "remediate"},
+	}
+	d.decided_by == "historical"
+	d.sla_days == 10
+}
+
+# escalation: architectural change required routes to a human
+test_escalation_architectural {
+	d := decision with input as {
+		"id": "CVE-2026-6", "cvss": 6.0,
+		"asserted": {"disposition": "remediate", "architectural_change_required": true},
+	}
+	d.escalate == true
+	d.decided_by == "escalation"
+	d.escalation_reason == "architectural change required"
+}
+
+# escalation: unprecedented critical risk with no history
+test_escalation_unprecedented_critical {
+	d := decision with input as {
+		"id": "CVE-2026-7", "cvss": 9.5, "is_kev": false,
+		"asserted": {"disposition": "remediate"},
+	}
+	d.escalate == true
+	d.escalation_reason == "unprecedented critical risk, no historical precedent"
+}
+
+# default disposition is remediate when none asserted
+test_default_disposition_remediate {
+	d := decision with input as {"id": "CVE-2026-8", "cvss": 5.0, "asserted": {}}
+	d.disposition == "remediate"
+	d.remediation_required == true
+}

--- a/scripts/vuln-gate.py
+++ b/scripts/vuln-gate.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# =============================================================================
+# VULNERABILITY GATE  (fail closed on any uncategorized vulnerability)
+# =============================================================================
+# The rule, by operator decision: a scanner-reported vulnerability of ANY
+# severity (Critical/High/Medium/Low) fails the build unless it is handled.
+# A vulnerability is handled only if it is:
+#   - remediated  (no longer reported by the scanner — it simply isn't here), or
+#   - dispositioned in data/vuln-dispositions.json as one of:
+#       false-positive          (no real risk / not applicable), or
+#       operational-requirement (real risk, deliberately accepted).
+#
+# A risk-adjusted vulnerability still has a severity, so it does NOT pass — fix
+# it. There is no SLA-with-a-future-date pass state for vulnerabilities: you
+# either fix it, prove it is a false positive, or accept it as an operational
+# requirement. The gate forces that choice on every build.
+#
+# Config-scanner suppressions (Checkov) are governed separately (.checkov.yaml +
+# the VDR maps + the reconciliation gate); this gate is for vulnerabilities only.
+#
+# Usage:
+#   vuln-gate.py --vdr infrastructure/vdr-report.json        # read VDR CVEs
+#   vuln-gate.py --findings findings.json                    # raw list (tests)
+#   [--register data/vuln-dispositions.json]
+#
+# Exit 0 if every vulnerability is handled; exit 1 (with a remediate-or-
+# categorize report) if any is not.
+# =============================================================================
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# The only two dispositions that let a vulnerability pass the build.
+PASS_DISPOSITIONS = {"false-positive", "operational-requirement"}
+
+
+def load_register(path):
+    doc = json.loads(Path(path).read_text())
+    return doc.get("dispositions", {})
+
+
+def vulns_from_vdr(vdr):
+    """Extract vulnerability findings (those carrying a real severity) from a VDR
+    report's aggregated CVE list. Robust to minor field-name variation."""
+    out = []
+    for c in vdr.get("cve_findings", []) or []:
+        vid = c.get("cve") or c.get("id") or c.get("tracking_id")
+        if not vid:
+            continue
+        sev = (c.get("severity") or c.get("max_severity") or "").upper()
+        out.append({"id": vid, "severity": sev, "source": c.get("source", "vdr")})
+    return out
+
+
+def disposition_of(vuln_id, register):
+    entry = register.get(vuln_id) or {}
+    return entry.get("disposition")
+
+
+def find_unhandled(vulns, register):
+    """Return the vulnerabilities that are neither false-positive nor
+    operational-requirement in the register."""
+    unhandled = []
+    for v in vulns:
+        if disposition_of(v["id"], register) not in PASS_DISPOSITIONS:
+            unhandled.append(v)
+    return unhandled
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("--vdr", help="VDR report JSON; vulnerabilities read from cve_findings")
+    src.add_argument("--findings", help="JSON array of {id, severity, source} (tests/manual)")
+    ap.add_argument("--register", default=str(REPO / "data" / "vuln-dispositions.json"))
+    args = ap.parse_args()
+
+    register = load_register(args.register)
+
+    if args.vdr:
+        vdr = json.loads(Path(args.vdr).read_text())
+        vulns = vulns_from_vdr(vdr)
+    else:
+        vulns = json.loads(Path(args.findings).read_text())
+
+    unhandled = find_unhandled(vulns, register)
+
+    if not unhandled:
+        print(f"vulnerability gate: OK — {len(vulns)} scanned, all remediated or dispositioned (FP/OR)")
+        return 0
+
+    print(f"VULNERABILITY GATE FAILED — {len(unhandled)} uncategorized vulnerability(ies):", file=sys.stderr)
+    for v in unhandled:
+        sev = v.get("severity") or "?"
+        print(f"  ✗ {v['id']} [{sev}] (source: {v.get('source','?')})", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Each must be either fixed (so the scanner stops reporting it) or added to", file=sys.stderr)
+    print(f"  {Path(args.register).name}  with a disposition of 'false-positive' or", file=sys.stderr)
+    print("  'operational-requirement' and a justification. Risk-adjustment does NOT pass.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_vuln_gate.py
+++ b/tests/test_vuln_gate.py
@@ -1,0 +1,81 @@
+# =============================================================================
+# Vulnerability gate: any uncategorized vulnerability fails the build. Only
+# false-positive and operational-requirement pass; risk-adjustment does not.
+# =============================================================================
+import importlib.util
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("vuln_gate", REPO / "scripts" / "vuln-gate.py")
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+vg = _load()
+
+V_CRIT = {"id": "CVE-2026-1", "severity": "CRITICAL", "source": "grype"}
+V_LOW = {"id": "CVE-2026-2", "severity": "LOW", "source": "zap"}
+
+
+def test_no_vulns_passes():
+    assert vg.find_unhandled([], {}) == []
+
+
+def test_uncategorized_fails():
+    assert vg.find_unhandled([V_CRIT], {}) == [V_CRIT]
+
+
+def test_low_severity_still_fails_uncategorized():
+    # "Low of any kind" must be fixed unless FP/OR
+    assert vg.find_unhandled([V_LOW], {}) == [V_LOW]
+
+
+def test_false_positive_passes():
+    reg = {"CVE-2026-1": {"disposition": "false-positive", "justification": "x"}}
+    assert vg.find_unhandled([V_CRIT], reg) == []
+
+
+def test_operational_requirement_passes():
+    reg = {"CVE-2026-1": {"disposition": "operational-requirement", "justification": "x"}}
+    assert vg.find_unhandled([V_CRIT], reg) == []
+
+
+def test_risk_adjustment_does_not_pass():
+    # a risk-adjusted vuln still has a severity -> must be fixed
+    reg = {"CVE-2026-1": {"disposition": "risk-adjustment", "adjusted_severity": "LOW"}}
+    assert vg.find_unhandled([V_CRIT], reg) == [V_CRIT]
+
+
+def test_remediate_disposition_does_not_pass():
+    reg = {"CVE-2026-1": {"disposition": "remediate"}}
+    assert vg.find_unhandled([V_CRIT], reg) == [V_CRIT]
+
+
+def test_mixed_reports_only_unhandled():
+    reg = {
+        "CVE-2026-1": {"disposition": "false-positive"},
+        "CVE-2026-2": {"disposition": "risk-adjustment"},  # does not pass
+    }
+    out = vg.find_unhandled([V_CRIT, V_LOW], reg)
+    assert out == [V_LOW]
+
+
+def test_vulns_from_vdr_extracts_cves():
+    vdr = {"cve_findings": [
+        {"cve": "CVE-2026-9", "severity": "HIGH", "source": "grype"},
+        {"id": "CVE-2026-10", "max_severity": "medium"},
+        {"title": "no id — skipped"},
+    ]}
+    vulns = vg.vulns_from_vdr(vdr)
+    ids = {v["id"] for v in vulns}
+    assert ids == {"CVE-2026-9", "CVE-2026-10"}
+    assert any(v["severity"] == "MEDIUM" for v in vulns)
+
+
+if __name__ == "__main__":
+    import pytest
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Builds the finding-triage model you specified, in two layers.

## 1. Rego policy engine — `policies/triage.rego` (`data.vdr.triage.decision`)
Disposition: **false-positive / operational-requirement / risk-adjustment / remediate**. Risk-adjustment may only *lower* severity (flagged `invalid_risk_adjustment` if it tries to raise).

Baseline severity, your preference order: **CVE base CVSS** → scanner numeric score → scanner severity label.

Layered remediation-timeline chain (for items that track a timeline), `decided_by` records the ruling layer: contextual (PAIN from severity, +1 if reachable&exploitable) → immutable (KEV must-patch-now) → threshold (Class C SLA by PAIN/LEV/IRV) → historical (a shorter precedent tightens) → escalation (architectural / unprecedented-critical → human). **10/10 `opa test`.**

## 2. Binary vulnerability gate — `scripts/vuln-gate.py`
Per your simplification: a scanner vulnerability of **any** severity fails the build unless it is **remediated (gone)** or dispositioned **false-positive** or **operational-requirement** in `data/vuln-dispositions.json`. **Risk-adjustment does not pass** — a risk-adjusted vuln still has a severity, so it must be fixed. Fails with a remediate-or-categorize report. **9 tests** (FP/OR pass; RA/remediate/uncategorized fail; low-severity still fails).

## Verified
53 tests pass; `opa test` 10/10; demo gate fails correctly on an uncategorized CVE.

## Not yet wired (ties to Task 1.5)
The gate reads vulnerabilities from the VDR's `cve_findings`. It only *bites* once Task 1.5 ingests real ZAP/Grype/Dependabot findings into the VDR — until then `cve_findings` is empty and the gate passes trivially. So the CI step + the scanner ingest land together in Task 1.5, to avoid a false-green gate.

## Open question (in the PR thread / chat)
You simplified vulnerabilities to a binary FP/OR gate, which doesn't use most of the Rego engine's SLA chain. Keep the full engine (useful for config-finding disposition + SLA reporting), or strip it to just the disposition concept?

🤖 Generated with [Claude Code](https://claude.com/claude-code)