### PR TITLE
Task 2 / POAM-001: GitHub OIDC deploy role, retire long-lived access key

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -69,6 +69,7 @@ permissions:
   issues: write
   pull-requests: write
   security-events: write
+  id-token: write   # assume the deploy role via GitHub OIDC (POAM-001)
 
 jobs:
   # ===========================================================================
@@ -121,8 +122,9 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        # GitHub OIDC role assumption — no long-lived access key (POAM-001).
+        # Role ARN is a repo variable so the account ID stays out of the YAML.
+        role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
         aws-region: ${{ env.AWS_REGION }}
 
     # -------------------------------------------------------------------------
@@ -307,8 +309,9 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        # GitHub OIDC role assumption — no long-lived access key (POAM-001).
+        # Role ARN is a repo variable so the account ID stays out of the YAML.
+        role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
         aws-region: ${{ env.AWS_REGION }}
 
     # -------------------------------------------------------------------------

--- a/infrastructure/bootstrap/.gitignore
+++ b/infrastructure/bootstrap/.gitignore
@@ -1,0 +1,4 @@
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*

--- a/infrastructure/bootstrap/README.md
+++ b/infrastructure/bootstrap/README.md
@@ -1,0 +1,35 @@
+# Bootstrap: GitHub OIDC deploy role
+
+This module is **applied by an operator, not by CI** — it creates the IAM role the
+CI pipeline assumes, so it cannot be created by the pipeline it enables
+(chicken-and-egg). It has its own local state, separate from the main
+`infrastructure/` stack.
+
+What it creates (assessment POAM-001, Task 2):
+
+- An IAM OIDC identity provider for `token.actions.githubusercontent.com`.
+- An IAM role (`github-actions-deploy-oidc`) the workflow assumes via
+  `aws-actions/configure-aws-credentials` with `role-to-assume` — **no
+  long-lived access key**. Its trust policy restricts `sub` to **this repo's
+  `main` pushes and pull requests only** (not `:*`).
+- The same permission scope the legacy `github-actions-deploy` IAM user had
+  (its managed policies, reattached to the role) plus the reconciliation-gate
+  read permissions, so the deploy keeps working unchanged.
+
+After a green OIDC deploy proves the role works, the legacy IAM user and its
+access key are deleted and the `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
+repo secrets are removed (the POAM-001 closure). Until then both paths coexist.
+
+## Apply
+
+```
+cd infrastructure/bootstrap
+terraform init
+terraform plan
+terraform apply
+terraform output github_actions_role_arn   # set as the workflow's role-to-assume
+```
+
+Consolidating the legacy `github_*` managed policies into one least-privilege
+deploy policy is a tracked follow-up; this module preserves the existing scope
+verbatim to avoid a deploy regression at cutover.

--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -104,6 +104,7 @@ resource "aws_iam_role_policy_attachment" "legacy" {
 # during deploy). Mirrors the reconcile-gate-readonly inline policy that was on
 # the legacy user. Read-only; metadata only (no secretsmanager:GetSecretValue).
 data "aws_iam_policy_document" "reconcile_reads" {
+  # checkov:skip=CKV_AWS_356:Read-only account-enumeration actions (List*/Describe*/apigateway:GET) cannot be resource-scoped; the Action list is explicit and read-only, no write or admin. Documented false positive.
   statement {
     effect = "Allow"
     actions = [
@@ -125,6 +126,7 @@ data "aws_iam_policy_document" "reconcile_reads" {
 }
 
 resource "aws_iam_role_policy" "reconcile_reads" {
+  # checkov:skip=CKV_AWS_356:Read-only account-enumeration actions cannot be resource-scoped; explicit read-only Action list, no write or admin. Documented false positive.
   name   = "reconcile-gate-readonly"
   role   = aws_iam_role.deploy.id
   policy = data.aws_iam_policy_document.reconcile_reads.json

--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -1,0 +1,140 @@
+# =============================================================================
+# BOOTSTRAP: GitHub OIDC deploy role  (assessment POAM-001, Task 2)
+# =============================================================================
+# Operator-applied (not CI). Replaces the long-lived github-actions-deploy IAM
+# user/access-key with a role the workflow assumes via GitHub OIDC. See README.md.
+# =============================================================================
+
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+variable "aws_region" {
+  type    = string
+  default = "us-east-2"
+}
+
+variable "github_repo" {
+  type        = string
+  description = "owner/repo allowed to assume the deploy role"
+  default     = "sam-aydlette/samaydlette.com"
+}
+
+# The legacy IAM user's managed policies — reattached to the role so the deploy
+# keeps the exact same scope at cutover (no regression). Consolidating these
+# into one least-privilege policy is a tracked follow-up.
+variable "legacy_deploy_policy_names" {
+  type = list(string)
+  default = [
+    "GitHubActions-TerraformDataSources",
+    "GitHubActions-SilkReeling",
+    "github-actions-deploy",
+    "github_policy_3",
+    "github_actions_3",
+    "github_actions_read_write",
+    "github_action_read_2",
+  ]
+}
+
+data "aws_caller_identity" "current" {}
+
+# GitHub's OIDC identity provider. AWS validates the token against its own trust
+# store; the thumbprint is still required by the API.
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+# Trust policy: only this repo's main-branch pushes and pull requests may assume
+# the role — NOT a wildcard. PRs are included because the compliance-check job
+# (terraform plan + OPA) runs on pull_request and also needs AWS read access.
+data "aws_iam_policy_document" "trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values = [
+        "repo:${var.github_repo}:ref:refs/heads/main",
+        "repo:${var.github_repo}:pull_request",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "deploy" {
+  name                 = "github-actions-deploy-oidc"
+  description          = "CI deploy role assumed via GitHub OIDC (POAM-001). Trust restricted to this repo's main + PRs."
+  assume_role_policy   = data.aws_iam_policy_document.trust.json
+  max_session_duration = 3600
+}
+
+# Reattach the legacy user's managed policies to the role (same scope).
+resource "aws_iam_role_policy_attachment" "legacy" {
+  for_each   = toset(var.legacy_deploy_policy_names)
+  role       = aws_iam_role.deploy.name
+  policy_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${each.value}"
+}
+
+# Reconciliation-gate read permissions (the live-state enumeration the gate runs
+# during deploy). Mirrors the reconcile-gate-readonly inline policy that was on
+# the legacy user. Read-only; metadata only (no secretsmanager:GetSecretValue).
+data "aws_iam_policy_document" "reconcile_reads" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "lambda:ListFunctions",
+      "apigateway:GET",
+      "secretsmanager:ListSecrets",
+      "kms:ListKeys",
+      "kms:ListAliases",
+      "kms:DescribeKey",
+      "s3:ListAllMyBuckets",
+      "logs:DescribeLogGroups",
+    ]
+    # Resource "*" is required: these are account-wide enumeration actions
+    # (List*/Describe*/apigateway:GET) that do not support resource-level
+    # scoping. The Action list is explicit and read-only — no wildcard action,
+    # no write or admin permission. (CodeGuard iac-security: reviewed exception.)
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "reconcile_reads" {
+  name   = "reconcile-gate-readonly"
+  role   = aws_iam_role.deploy.id
+  policy = data.aws_iam_policy_document.reconcile_reads.json
+}
+
+output "github_actions_role_arn" {
+  value       = aws_iam_role.deploy.arn
+  description = "Set as the workflow's aws-actions/configure-aws-credentials role-to-assume."
+}
+
+output "oidc_provider_arn" {
+  value = aws_iam_openid_connect_provider.github.arn
+}


### PR DESCRIPTION
## Changed
Replaces the long-lived `github-actions-deploy` IAM access key (POAM-001) with **GitHub OIDC role assumption**.
- **`infrastructure/bootstrap/`** — an operator-applied Terraform module (separate local state; the deploy role can't be created by the deploy it enables). Creates the GitHub OIDC provider and a `github-actions-deploy-oidc` role. Trust policy pins `aud=sts.amazonaws.com` and `sub` to **this repo's `main` pushes + PRs only — not `:*`**. Role reuses the legacy user's 7 managed policies (identical scope, no deploy regression) + a read-only reconcile-gate inline policy.
- **`deploy-with-opa.yml`** — both `configure-aws-credentials` steps switched from access-key inputs to `role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}` (account ID stays out of committed YAML); `id-token: write` added at workflow level for the PR compliance-check job.

## Verified (live AWS)
Bootstrap applied locally (`Apply complete! Resources: 10 added, 0 changed, 0 destroyed`). Live role state:
```
$ aws iam get-role --role-name github-actions-deploy-oidc --query 'Role.AssumeRolePolicyDocument.Statement[0]'
  Principal: arn:aws:iam::<acct>:oidc-provider/token.actions.githubusercontent.com
  Action:    sts:AssumeRoleWithWebIdentity
  sub (StringLike): ["repo:sam-aydlette/samaydlette.com:ref:refs/heads/main",
                     "repo:sam-aydlette/samaydlette.com:pull_request"]
  aud (StringEquals): sts.amazonaws.com
$ aws iam list-attached-role-policies --role-name github-actions-deploy-oidc
  [the 7 legacy deploy policies]   + inline: reconcile-gate-readonly
```
Workflow: zero `aws-access-key-id` / `AWS_ACCESS_KEY_ID` refs remain; `role-to-assume` in both jobs; `id-token: write` at workflow + deploy-job level; YAML valid. Repo variable `AWS_DEPLOY_ROLE_ARN` set.

**CodeGuard ran** (iac-security, hardcoded-credentials, devops-ci-cd, authorization): no hardcoded secrets; OIDC trust defends confused-deputy (sub+aud pinned); net elimination of long-lived creds. `Resource:"*"` on reconcile-reads is a documented exception (account-enumeration read actions; Action list explicit, no write/admin).

## Residual / needs human
- **Cutover (after merge):** once a green OIDC deploy proves the role works, delete the `github-actions-deploy` IAM user + access key and remove the `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` repo secrets, then move POAM-001 → Closed. I'll do this as a follow-up once the first OIDC deploy is green (keeping the old path until then).
- **Least-privilege follow-up:** the PR/compliance-check job assumes the deploy-scoped role though it only plans/reads (not a regression — the old key was shared too). Recommend a separate read-only role for the PR path.
- **Policy consolidation follow-up:** the 7 legacy `github_*` managed policies are reused verbatim; consolidating into one least-privilege deploy policy is tracked.

## Couldn't verify
- The OIDC deploy itself only exercises on push to `main` (validated at merge). `checkov` isn't installed locally; the CI lint job runs it against `.checkov.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)