### PR TITLE
Task 8 (part 1) / POAM-003,004,008,014,016: false-positive reclassification

### DIFF
--- a/data/component-definitions/samaydlette-com-component-definition.json
+++ b/data/component-definitions/samaydlette-com-component-definition.json
@@ -683,7 +683,7 @@
               {
                 "uuid": "c947d181-472f-58a6-ae55-08eadbd418dc",
                 "control-id": "au-2",
-                "description": "Event logging is provided by CloudTrail (account-wide, captures all AWS API calls including the deployer's), Lambda execution logs (CloudWatch Logs), and GitHub Actions workflow run history (immutable, GitHub-side). The system configures Lambda logging via the runtime's standard integration. CloudFront access logging is consciously excluded for cost; see README 'Conscious Trade-offs'.",
+                "description": "Event logging is provided by CloudTrail (account-wide, captures all AWS API calls including the deployer's), Lambda execution logs (CloudWatch Logs), and GitHub Actions workflow run history (immutable, GitHub-side). The system configures Lambda logging via the runtime's standard integration. CloudFront access logging is consciously excluded for cost; see README 'Conscious Trade-offs'. S3 event notifications (CKV_AWS_23 / POAM-004) and Lambda X-Ray tracing (CKV_AWS_50 / POAM-014) are not audit mechanisms \u2014 the former is event-driven integration, the latter performance tracing \u2014 so their absence does not affect AU-2 coverage, which is satisfied by CloudTrail and CloudWatch Logs. Both are false positives.",
                 "props": [
                   {
                     "name": "implementation-status",
@@ -1583,7 +1583,7 @@
               {
                 "uuid": "460b0557-d405-5904-b0e4-907cdfddb58e",
                 "control-id": "si-3",
-                "description": "Malicious code protection: the system has no executable upload paths. The S3 bucket holds static content authored by the operator and delivered via CloudFront; the Lambda runs only operator-authored JavaScript and AWS-provided SDK code (verified via Sigstore signature on the deploy-time signal). There is no surface for end-user uploads, macros, or executable email attachments.",
+                "description": "Malicious code protection: the system has no executable upload paths. The S3 bucket holds static content authored by the operator and delivered via CloudFront; the Lambda runs only operator-authored JavaScript and AWS-provided SDK code (verified via Sigstore signature on the deploy-time signal). There is no surface for end-user uploads, macros, or executable email attachments. Known-vulnerability detection in the dependency trees is provided by Grype + Dependabot scanning on every deploy (feeding the VDR); the stack contains no Java or Log4j runtime, so Log4j-class WAF rules (CKV_AWS_174 / POAM-008) are not applicable \u2014 a false positive, not an open weakness.",
                 "props": [
                   {
                     "name": "implementation-status",

--- a/docs/poam.md
+++ b/docs/poam.md
@@ -91,20 +91,15 @@ The source of truth for the rationale is the inline `#checkov:skip=ID:reason` an
 
 | POA&M ID | Controls | Weakness Name | Detector Source | Source Identifier | Asset Identifier | PAIN | Original Risk | Adj. Risk | Risk Adj. | Status |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| POAM-003 | CP-9 | S3 cross-region replication not configured | Checkov | CKV_AWS_144 | aws-s3-bucket::website-prod | N1 | Low | — | No | Risk-accepted |
-| POAM-004 | AU-2 | S3 event notifications not configured | Checkov | CKV_AWS_23 | aws-s3-bucket::website-prod | N1 | Low | — | No | Risk-accepted |
 | POAM-005 | AU-2, AU-3 | S3 access logging not enabled | Checkov | CKV_AWS_18 | aws-s3-bucket::website-prod | N1 | Low | — | No | Risk-accepted |
 | POAM-006 | SI-12 | S3 lifecycle configuration not defined | Checkov | CKV_AWS_300 | aws-s3-bucket::website-prod | N1 | Low | — | No | Risk-accepted |
 | POAM-007 | SC-7, SI-4 | CloudFront WAF not attached | Checkov | CKV_AWS_68 | aws-cloudfront-distribution | N2 | Moderate | Low | Yes | Risk-accepted |
-| POAM-008 | SI-3 | Log4j-specific WAF rules not configured | Checkov | CKV_AWS_174 | aws-cloudfront-distribution | N1 | Low | — | No | Risk-accepted |
 | POAM-009 | CP-2, CP-7 | CloudFront origin failover not configured | Checkov | CKV_AWS_86 | aws-cloudfront-distribution | N1 | Low | — | No | Risk-accepted |
 | POAM-010 | SC-7 | Lambda VPC configuration absent | Checkov | CKV_AWS_117 | aws-lambda::compliance-monitor | N1 | Low | — | No | Risk-accepted |
 | POAM-011 | SC-12, SC-28 | Lambda env vars not customer-key encrypted | Checkov | CKV_AWS_173 | aws-lambda::compliance-monitor | N1 | Low | — | No | Risk-accepted |
 | POAM-012 | SC-5 | Lambda concurrent execution limit not set | Checkov | CKV_AWS_115 | aws-lambda::compliance-monitor | N1 | Low | — | No | Risk-accepted |
 | POAM-013 | SI-4 | Lambda DLQ not configured | Checkov | CKV_AWS_116 | aws-lambda::compliance-monitor | N1 | Low | — | No | Risk-accepted |
-| POAM-014 | AU-2 | Lambda X-Ray tracing not enabled | Checkov | CKV_AWS_50 | aws-lambda::compliance-monitor | N1 | Low | — | No | Risk-accepted |
 | POAM-015 | SI-7, SA-12 | Lambda zip not signed via AWS Signer | Checkov | CKV_AWS_272 | aws-lambda::compliance-monitor | N2 | Moderate | Low | Yes | Risk-accepted |
-| POAM-016 | CP-2, CP-7 | Multi-region active-passive failover absent | Architectural decision | recovery-plan.md | aws-account::all-resources | N1 | Low | — | No | Risk-accepted |
 | POAM-017 | AU-11 | CloudWatch log retention < 1 year (7-day retention) | Checkov | CKV_AWS_338 | aws-cloudwatch-log-group | N1 | Low | — | No | Risk-accepted |
 | POAM-018 | SC-28 | CloudWatch log group not customer-key encrypted | Checkov | CKV_AWS_158 | aws-cloudwatch-log-group | N1 | Low | — | No | Risk-accepted |
 | POAM-019 | SC-12, SC-28 | Secrets Manager automatic rotation not enabled | Checkov | CKV2_AWS_57 | aws-secretsmanager::silk-reeling | N2 | Moderate | Low | Yes | Risk-accepted |
@@ -223,7 +218,18 @@ The Closed POA&M Items section uses the same field structure as Open items, plus
 
 ## False Positives
 
-None at this time.
+These scanner findings were investigated and dismissed as not representing a real
+weakness at this system's Moderate categorization. Each names the suppressed
+check, why it does not apply, and how the mapped control is actually met (in the
+SSP). They are distinct from risk-accepted items (real weaknesses with documented
+acceptance) and carry no `poam_ref` in the VDR.
+
+| Was | Control | Suppressed check | Why it is a false positive | Control met via |
+| --- | --- | --- | --- | --- |
+| POAM-003 | CP-9 | CKV_AWS_144 (S3 cross-region replication) | Cross-region replication is not a CP-9 requirement at Moderate for this system; the data is public static content. | S3 versioning + full reproducibility of the site from the Git repository (SSP CP-9 narrative). |
+| POAM-004 | AU-2 | CKV_AWS_23 (S3 event notifications) | S3 event notifications are an integration feature, not an audit control; AU-2 does not require them. | S3 server access logging (Task 7) + account-wide CloudTrail (SSP AU-2 narrative). |
+| POAM-008 | SI-3 | CKV_AWS_174 (Log4j-specific WAF rule) | No Java/Log4j anywhere in the stack (Lambda is Node.js/Python; site is static), and WAF is intentionally declined (Decision 3), so the rule cannot apply. | Dependency scanning (Grype + Dependabot) over the controlled execution surface (SSP SI-3 narrative). |
+| POAM-014 | AU-2 | CKV_AWS_50 (Lambda X-Ray tracing) | X-Ray is performance/latency observability, not a security audit control; AU-2 coverage does not depend on it. | CloudWatch Logs + CloudTrail (SSP AU-2 narrative). |
 
 False positives are tracked separately so an assessor can see which scanner findings were investigated and dismissed with rationale, distinct from risk-accepted items (which are real weaknesses with documented acceptance).
 

--- a/scripts/build-oscal-poam.py
+++ b/scripts/build-oscal-poam.py
@@ -137,7 +137,7 @@ POAM_ITEMS = [
         "weakness_detector_source": "Checkov", "weakness_source_identifier": "CKV_AWS_144",
         "asset_identifiers": ["aws-s3-bucket::website-prod"],
         "original_risk_rating": "low", "adjusted_risk_rating": None, "risk_adjustment": False,
-        "status": "risk-accepted", "category": "configuration",
+        "status": "false-positive", "category": "false-positive",
     },
     {
         "id": "POAM-004", "controls": ["au-2"],
@@ -146,7 +146,7 @@ POAM_ITEMS = [
         "weakness_detector_source": "Checkov", "weakness_source_identifier": "CKV_AWS_23",
         "asset_identifiers": ["aws-s3-bucket::website-prod"],
         "original_risk_rating": "low", "adjusted_risk_rating": None, "risk_adjustment": False,
-        "status": "risk-accepted", "category": "configuration",
+        "status": "false-positive", "category": "false-positive",
     },
     {
         "id": "POAM-005", "controls": ["au-2", "au-3"],
@@ -182,7 +182,7 @@ POAM_ITEMS = [
         "weakness_detector_source": "Checkov", "weakness_source_identifier": "CKV_AWS_174",
         "asset_identifiers": ["aws-cloudfront-distribution"],
         "original_risk_rating": "low", "adjusted_risk_rating": None, "risk_adjustment": False,
-        "status": "risk-accepted", "category": "configuration",
+        "status": "false-positive", "category": "false-positive",
     },
     {
         "id": "POAM-009", "controls": ["cp-2", "cp-7"],
@@ -236,7 +236,7 @@ POAM_ITEMS = [
         "weakness_detector_source": "Checkov", "weakness_source_identifier": "CKV_AWS_50",
         "asset_identifiers": ["aws-lambda::compliance-monitor"],
         "original_risk_rating": "low", "adjusted_risk_rating": None, "risk_adjustment": False,
-        "status": "risk-accepted", "category": "configuration",
+        "status": "false-positive", "category": "false-positive",
     },
     {
         "id": "POAM-015", "controls": ["si-7", "sa-12"],
@@ -245,16 +245,6 @@ POAM_ITEMS = [
         "weakness_detector_source": "Checkov", "weakness_source_identifier": "CKV_AWS_272",
         "asset_identifiers": ["aws-lambda::compliance-monitor"],
         "original_risk_rating": "moderate", "adjusted_risk_rating": "low", "risk_adjustment": True,
-        "status": "risk-accepted", "category": "configuration",
-    },
-    {
-        "id": "POAM-016", "controls": ["cp-2", "cp-7"],
-        "title": "Multi-region active-passive failover absent",
-        "description": "Cost trade-off (~$300/year). Declared 21-day RTO accommodates single-region AWS failure. Documented in docs/recovery-plan.md.",
-        "weakness_detector_source": "Architectural decision",
-        "weakness_source_identifier": "recovery-plan.md",
-        "asset_identifiers": ["aws-account::all-resources"],
-        "original_risk_rating": "low", "adjusted_risk_rating": None, "risk_adjustment": False,
         "status": "risk-accepted", "category": "configuration",
     },
     {

--- a/scripts/build-vdr-report.py
+++ b/scripts/build-vdr-report.py
@@ -57,18 +57,14 @@ from pathlib import Path
 # POAM entry will surface in the risk_accepted output without a poam_ref;
 # the policy is to back every suppression with a POAM entry.
 POAM_BY_CHECK_ID = {
-    "CKV_AWS_144": "POAM-003",
-    "CKV_AWS_23":  "POAM-004",
     "CKV_AWS_18":  "POAM-005",
     "CKV_AWS_300": "POAM-006",
     "CKV_AWS_68":  "POAM-007",
-    "CKV_AWS_174": "POAM-008",
     "CKV_AWS_86":  "POAM-009",
     "CKV_AWS_117": "POAM-010",
     "CKV_AWS_173": "POAM-011",
     "CKV_AWS_115": "POAM-012",
     "CKV_AWS_116": "POAM-013",
-    "CKV_AWS_50":  "POAM-014",  # Lambda X-Ray tracing
     "CKV_AWS_272": "POAM-015",  # Lambda code-signing validation
     "CKV_AWS_338": "POAM-017",  # CloudWatch log retention < 1 year
     "CKV_AWS_158": "POAM-018",  # CloudWatch log group not customer-key encrypted
@@ -81,18 +77,14 @@ POAM_BY_CHECK_ID = {
 # the table there). Ensures the VDR report carries the same VDR-EVA-* values an
 # auditor would see in the POA&M.
 SUPPRESSION_EVALUATION = {
-    "CKV_AWS_144": {"pain": "N1", "irv": False, "lev": False},
-    "CKV_AWS_23":  {"pain": "N1", "irv": False, "lev": False},
     "CKV_AWS_18":  {"pain": "N1", "irv": False, "lev": False},
     "CKV_AWS_300": {"pain": "N1", "irv": False, "lev": False},
     "CKV_AWS_68":  {"pain": "N2", "irv": True,  "lev": False},
-    "CKV_AWS_174": {"pain": "N1", "irv": False, "lev": False},
     "CKV_AWS_86":  {"pain": "N1", "irv": False, "lev": False},
     "CKV_AWS_117": {"pain": "N1", "irv": False, "lev": False},
     "CKV_AWS_173": {"pain": "N1", "irv": False, "lev": False},
     "CKV_AWS_115": {"pain": "N1", "irv": False, "lev": False},
     "CKV_AWS_116": {"pain": "N1", "irv": False, "lev": False},
-    "CKV_AWS_50":  {"pain": "N1", "irv": False, "lev": False},
     "CKV_AWS_272": {"pain": "N2", "irv": False, "lev": False},
     "CKV_AWS_338": {"pain": "N1", "irv": False, "lev": False},
     "CKV_AWS_158": {"pain": "N1", "irv": False, "lev": False},
@@ -104,18 +96,14 @@ SUPPRESSION_EVALUATION = {
 # Rationale per suppressed check, mirrored from .checkov.yaml comments and the
 # corresponding POA&M items. Used to populate VDR-RPT-AVI explanation field.
 SUPPRESSION_RATIONALE = {
-    "CKV_AWS_144": "Single-region static site. Cross-region replication adds cost without commensurate availability benefit at the declared 21-day RTO.",
-    "CKV_AWS_23":  "Lambda writes to S3 but does not subscribe to S3 events. No event-driven workflow in scope.",
     "CKV_AWS_18":  "CloudTrail covers the audit need account-wide. CloudFront access logs were similarly excluded for cost.",
     "CKV_AWS_300": "Static website assets have no expiration policy; lifecycle rules are not applicable.",
     "CKV_AWS_68":  "Cost trade-off (~$120/year). Static personal site has no forms, no auth endpoints; AWS Shield Standard is the baseline DDoS protection at zero marginal cost.",
-    "CKV_AWS_174": "No Java runtime in scope (Lambda runs Node.js; site is static HTML/CSS/JS). Log4j-class vulnerabilities cannot exist in this stack.",
     "CKV_AWS_86":  "Single S3 origin. No secondary origin to fail over to; multi-origin would require multi-region storage.",
     "CKV_AWS_117": "Lambda has no internet egress, no sensitive data, no private endpoint targets. NAT Gateway adds cost without commensurate isolation benefit.",
     "CKV_AWS_173": "Lambda env vars hold bucket name, distribution ID, system ID — all non-sensitive and visible in the public runtime signal. AWS-default encryption suffices.",
     "CKV_AWS_115": "Daily EventBridge invocation; no concurrent invocations realistic. Cost-control limit not required.",
     "CKV_AWS_116": "Daily idempotent run; failures are recoverable on the next day's invocation. DLQ adds cost for marginal observability benefit.",
-    "CKV_AWS_50":  "Observability concern, not a security control. Cost-driven exclusion; CloudWatch Logs covers the diagnostic need.",
     "CKV_AWS_272": "Source-level signing chain in place: deploy-time KSI signal is Sigstore-signed; Wasm policy bytes are verifiable via the canonical inventory's content hash. AWS Signer adds defense-in-depth at marginal cost; not currently justified.",
     "CKV_AWS_338": "7-day retention; operational debug logs only, no PII. Anything older than a week is not actionable for sole-operator IR.",
     "CKV_AWS_158": "AWS-default encryption (server-side AES-256) is on. No PII in log content; customer-managed KMS adds cost without commensurate benefit.",
@@ -291,12 +279,36 @@ def ingest_checkov(path):
     return findings
 
 
+def false_positive_checks():
+    """CKV ids dismissed as false positives, read from the docs/poam.md False
+    Positives register (the single source the reconciliation gate also reads).
+    A suppressed check listed there is the scanner being wrong, not an accepted
+    risk, so it carries no poam_ref and is reported separately."""
+    poam = Path(__file__).resolve().parent.parent / "docs" / "poam.md"
+    if not poam.exists():
+        return set()
+    text = poam.read_text()
+    fp, in_fp = set(), False
+    for line in text.splitlines():
+        low = line.lower()
+        if line.lstrip().startswith("#") and "false positive" in low:
+            in_fp = True
+            continue
+        if in_fp and line.lstrip().startswith("#") and "false positive" not in low:
+            in_fp = False
+        if in_fp:
+            fp.update(re.findall(r"CKV[_A-Z0-9]+", line))
+    return fp
+
+
 def ingest_suppressions(checkov_yaml):
     """Read .checkov.yaml's skip-check list and emit risk-accepted entries.
 
     Each entry becomes a risk-accepted record with VDR-RPT-AVI fields populated
     (PAIN/IRV/LEV from SUPPRESSION_EVALUATION, explanation from
-    SUPPRESSION_RATIONALE, POAM cross-reference from POAM_BY_CHECK_ID).
+    SUPPRESSION_RATIONALE, POAM cross-reference from POAM_BY_CHECK_ID). Checks
+    dismissed as false positives are excluded here and reported by
+    ingest_false_positives instead.
     """
     suppressions = []
     if not checkov_yaml:
@@ -309,7 +321,10 @@ def ingest_suppressions(checkov_yaml):
     except Exception as exc:
         print(f"warning: could not read {p}: {exc}", file=sys.stderr)
         return suppressions
+    fp = false_positive_checks()
     for check_id in ids:
+        if check_id in fp:
+            continue  # false positive — handled by ingest_false_positives
         evaluation = SUPPRESSION_EVALUATION.get(check_id, {"pain": "N1", "irv": False, "lev": False})
         rationale = SUPPRESSION_RATIONALE.get(check_id, "Suppressed in .checkov.yaml; see corresponding POA&M entry for rationale.")
         suppressions.append({
@@ -328,6 +343,32 @@ def ingest_suppressions(checkov_yaml):
             "explanation": rationale,
         })
     return suppressions
+
+
+def ingest_false_positives(checkov_yaml):
+    """Emit the false-positive records: suppressed checks listed in the
+    docs/poam.md False Positives register. Disposition is 'false-positive', no
+    poam_ref — a dismissed scanner finding, not an accepted weakness."""
+    fp = false_positive_checks()
+    if not checkov_yaml or not fp:
+        return []
+    p = Path(checkov_yaml)
+    if not p.exists():
+        return []
+    try:
+        ids = _read_checkov_skip_list(p)
+    except Exception:
+        return []
+    return [{
+        "tracking_id": c,
+        "poam_ref": None,
+        "source": "checkov-suppression",
+        "tool_id": c,
+        "title": f"{c} dismissed (false positive)",
+        "resource": ".checkov.yaml",
+        "current_disposition": "false-positive",
+        "explanation": "Investigated and dismissed; see docs/poam.md False Positives register.",
+    } for c in ids if c in fp]
 
 
 def ingest_tfsec(path):
@@ -820,10 +861,12 @@ def main():
 
     kev_cves = ingest_kev(args.kev)
     suppressions = ingest_suppressions(args.checkov_yaml)
+    false_positives = ingest_false_positives(args.checkov_yaml)
     ledger = ingest_previous_ledger(args.previous_vdr)
 
     report, blocking = build_report(findings, suppressions, kev_cves, ledger)
     report["ksi_signal_id"] = ksi_signal_id
+    report["false_positives"] = false_positives
 
     output_path = Path(args.output)
     output_path.write_text(json.dumps(report, indent=2, sort_keys=False))

--- a/tests/test_vdr_dispositions.py
+++ b/tests/test_vdr_dispositions.py
@@ -1,0 +1,54 @@
+# =============================================================================
+# Task 8: false-positive reclassification in the VDR.
+# The four checks moved to the docs/poam.md False Positives register
+# (CKV_AWS_144/23/174/50) must be reported as false-positives, NOT as
+# risk-accepted suppressions (which would carry a null poam_ref and overstate
+# open risk). Verifies the partition against the real .checkov.yaml + poam.md.
+# =============================================================================
+import importlib.util
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+FP_CKVS = {"CKV_AWS_144", "CKV_AWS_23", "CKV_AWS_174", "CKV_AWS_50"}
+
+
+def _vdr():
+    spec = importlib.util.spec_from_file_location("vdr", REPO / "scripts" / "build-vdr-report.py")
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+vdr = _vdr()
+CHECKOV = str(REPO / ".checkov.yaml")
+
+
+def test_fp_register_loaded_from_poam():
+    fp = vdr.false_positive_checks()
+    assert FP_CKVS <= fp, f"FP register missing some of {FP_CKVS}: got {fp}"
+
+
+def test_fp_checks_reported_as_false_positive_not_risk_accepted():
+    fps = vdr.ingest_false_positives(CHECKOV)
+    fp_ids = {r["tracking_id"] for r in fps}
+    assert FP_CKVS <= fp_ids
+    assert all(r["current_disposition"] == "false-positive" for r in fps if r["tracking_id"] in FP_CKVS)
+    assert all(r["poam_ref"] is None for r in fps)  # FP carries no poam_ref
+
+
+def test_fp_checks_excluded_from_risk_accepted():
+    supp = vdr.ingest_suppressions(CHECKOV)
+    ra_ids = {r["tracking_id"] for r in supp}
+    assert not (FP_CKVS & ra_ids), f"FP checks leaked into risk-accepted: {FP_CKVS & ra_ids}"
+
+
+def test_no_risk_accepted_suppression_has_null_poam_ref():
+    # every remaining risk-accepted suppression must still map to a POA&M item
+    supp = vdr.ingest_suppressions(CHECKOV)
+    null_refs = [r["tracking_id"] for r in supp if r.get("poam_ref") is None]
+    assert null_refs == [], f"risk-accepted suppressions with null poam_ref: {null_refs}"
+
+
+if __name__ == "__main__":
+    import pytest
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
First slice of Task 8 — the dispositions that need no deploy (independent of #102). Operationalizes the FP vs risk-accepted distinction from the triage model (Task T).

## Changed
**False positives** — moved to the `docs/poam.md` **False Positives register** with justification + how the mapped control is met; removed from the risk-accepted Configuration Findings table:
- **POAM-003** (`CKV_AWS_144`, CP-9): cross-region replication isn't required; CP-9 met via S3 versioning + Git reproducibility.
- **POAM-004** (`CKV_AWS_23`, AU-2): S3 event notifications aren't an audit control.
- **POAM-008** (`CKV_AWS_174`, SI-3): no Java/Log4j in the stack; WAF declined.
- **POAM-014** (`CKV_AWS_50`, AU-2): X-Ray is perf observability, not security.

**Removed** (SSP-addressed, no POA&M item): **POAM-016** (CP-2/CP-7) — multi-AZ + reproducibility + 21-day RTO.

**VDR is now disposition-aware:** `false_positive_checks()` reads the FP register (the same single source the reconciliation gate reads); `ingest_suppressions` excludes FP checks; new `ingest_false_positives` emits them as `current_disposition: false-positive` with no `poam_ref`; the report carries a `false_positives` list. Keeps `risk_accepted` free of null `poam_ref`s.

## Verified
- Reconciliation gate **invariant (c): 0 violations** (the 4 are FP-only, not double-categorized — running the gate's `check_c` against the real `.checkov.yaml` + reclassified maps + the FP register).
- **58 tests pass** (4 new in `test_vdr_dispositions.py`: FP reported as false-positive, excluded from risk-accepted, no null poam_refs).
- No live-AWS query applies — this is artifact-disposition logic, not infrastructure.
- **CodeGuard** ran: no security-sensitive surface in this diff (no creds, no untrusted input — parses trusted repo files only).

## Residual / needs human (remaining Task 8, follow-up PRs)
- **SSP narratives** for CP-9, CP-2, CP-7, AU-2, SI-3 to state the alternative implementations the FP entries reference (SSP-generator change).
- **POAM-007/010** rationale rewrite to Moderate-level (drop the "we're Low" basis).
- **POAM-009 split** — depends on Task 7 (CKV_AWS_86 is the CloudFront access-logging check, remediated there).
- **Infra remediations** (POAM-006/012/013/015 — S3 lifecycle, Lambda concurrency, DLQ, code signing) — separate PR; needs a deploy + `sqs`/`signer` perms on the deploy role.
- **POAM-019** closure depends on Tasks 3–4 (secrets removed).

## Couldn't verify
- The full live VDR (with the new `false_positives` field) only builds in CI with scanner inputs; the disposition logic is verified via the gate-(c) simulation + unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)