### PR TITLE
Task 6 deploy fix: import at-rest CMK each run + grant deploy role Lambda-env KMS perms

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -419,6 +419,31 @@ jobs:
           echo "No existing IAM role policy found - will be created"
         fi
         
+        # Import the at-rest CMK + its alias if they exist (Task 6, POAM-011/018).
+        # State is ephemeral per run, so the unconditional aws_kms_key.at_rest would
+        # otherwise be created fresh every run — orphaning keys and colliding on the
+        # alias. Resolve the key by its stable alias and adopt both into state.
+        if aws kms describe-key --key-id alias/samaydlette-com-at-rest >/dev/null 2>&1; then
+          AT_REST_KEY_ID=$(aws kms describe-key --key-id alias/samaydlette-com-at-rest --query 'KeyMetadata.KeyId' --output text)
+          echo "At-rest CMK exists in AWS ($AT_REST_KEY_ID)"
+          if ! terraform state show aws_kms_key.at_rest >/dev/null 2>&1; then
+            echo "Importing at-rest CMK..."
+            terraform import aws_kms_key.at_rest "$AT_REST_KEY_ID"
+            echo "✅ At-rest CMK imported"
+          else
+            echo "At-rest CMK already in Terraform state"
+          fi
+          if ! terraform state show aws_kms_alias.at_rest >/dev/null 2>&1; then
+            echo "Importing at-rest CMK alias..."
+            terraform import aws_kms_alias.at_rest "alias/samaydlette-com-at-rest"
+            echo "✅ At-rest CMK alias imported"
+          else
+            echo "At-rest CMK alias already in Terraform state"
+          fi
+        else
+          echo "No existing at-rest CMK found - will be created"
+        fi
+
         # Import the compliance Lambda's log group if it exists (auto-created by
         # Lambda; now managed for customer-CMK encryption + retention, POAM-018).
         # Must precede the Lambda import since the function depends_on it.

--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -52,6 +52,12 @@ variable "legacy_deploy_policy_names" {
   ]
 }
 
+variable "domain_name" {
+  type        = string
+  default     = "samaydlette.com"
+  description = "Site domain; used to build the log-group ARNs and CMK alias names the deploy role manages."
+}
+
 data "aws_caller_identity" "current" {}
 
 # GitHub's OIDC identity provider. AWS validates the token against its own trust
@@ -141,6 +147,80 @@ resource "aws_iam_role_policy" "reconcile_reads" {
   name   = "reconcile-gate-readonly"
   role   = aws_iam_role.deploy.id
   policy = data.aws_iam_policy_document.reconcile_reads.json
+}
+
+# Task 6 (POAM-011/018): permissions the deploy role needs to manage the at-rest
+# CMK-encrypted log groups and to encrypt the Lambda env blocks. Added here (not
+# in the main state) because this is the deploy identity itself; applied live and
+# recorded here so live and IaC stay in sync. Mirrors the inline policies on the
+# role: compliance-logs-management and compliance-kms-encrypt.
+locals {
+  domain_dashed = replace(var.domain_name, ".", "-")
+}
+
+# Manage the compliance Lambda + route53 query log groups (tags, retention, KMS
+# association). Scoped to exactly those two log-group ARNs — least privilege.
+data "aws_iam_policy_document" "compliance_logs" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:DeleteLogGroup",
+      "logs:PutRetentionPolicy",
+      "logs:DeleteRetentionPolicy",
+      "logs:AssociateKmsKey",
+      "logs:DisassociateKmsKey",
+      "logs:ListTagsForResource",
+      "logs:TagResource",
+      "logs:UntagResource",
+      "logs:TagLogGroup",
+      "logs:UntagLogGroup",
+    ]
+    resources = [
+      "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.domain_dashed}-opa-compliance*",
+      "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/route53/${var.domain_name}*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "compliance_logs" {
+  name   = "compliance-logs-management"
+  role   = aws_iam_role.deploy.id
+  policy = data.aws_iam_policy_document.compliance_logs.json
+}
+
+# Encrypt the Lambda environment blocks with the app CMKs. KMS alias-based
+# scoping requires Resource "*" plus a kms:ResourceAliases condition that limits
+# the grant to exactly the two app keys (at-rest + silk-reeling) — this is the
+# AWS-recommended pattern for alias-scoped access and avoids embedding rotation-
+# unstable key IDs in IaC.
+data "aws_iam_policy_document" "compliance_kms" {
+  # checkov:skip=CKV_AWS_356:KMS alias-based scoping requires Resource "*"; the kms:ResourceAliases condition restricts the grant to two specific app-key aliases. No write to key policy, no admin. Documented exception.
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+      "kms:CreateGrant",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      variable = "kms:ResourceAliases"
+      values = [
+        "alias/${local.domain_dashed}-at-rest",
+        "alias/${local.domain_dashed}-silk-reeling",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "compliance_kms" {
+  # checkov:skip=CKV_AWS_356:KMS alias-scoped grant; Resource "*" is constrained by the kms:ResourceAliases condition to two specific app keys. Documented exception.
+  name   = "compliance-kms-encrypt"
+  role   = aws_iam_role.deploy.id
+  policy = data.aws_iam_policy_document.compliance_kms.json
 }
 
 output "github_actions_role_arn" {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -476,7 +476,10 @@ resource "aws_lambda_function" "opa_compliance" {
   # Customer-CMK encryption of the environment variables (POAM-011).
   kms_key_arn = aws_kms_key.at_rest.arn
 
-  depends_on = [aws_cloudwatch_log_group.opa_compliance]
+  # The deploy role's kms:Encrypt grant is scoped by alias, so the alias must
+  # exist before this function's env is encrypted (otherwise a from-scratch
+  # apply could race the Lambda update ahead of alias creation).
+  depends_on = [aws_cloudwatch_log_group.opa_compliance, aws_kms_alias.at_rest]
 
   environment {
     variables = {

--- a/infrastructure/silk-reeling.tf
+++ b/infrastructure/silk-reeling.tf
@@ -228,7 +228,9 @@ resource "aws_lambda_function" "silk_reeling" {
     }
   }
 
-  depends_on = [aws_cloudwatch_log_group.silk_reeling]
+  # Alias must exist before the env is encrypted — the deploy role's kms:Encrypt
+  # grant is scoped by alias (see bootstrap compliance-kms-encrypt).
+  depends_on = [aws_cloudwatch_log_group.silk_reeling, aws_kms_alias.silk_reeling]
 
   tags = merge(local.silk_tags, { Name = "${var.domain_name}-silk-reeling" })
 }


### PR DESCRIPTION
SCN-Type: Routine Recurring

Restores the `Deploy Infrastructure` job on `main` after #108.

## Changed
This pipeline rebuilds Terraform state from live AWS each run (the workflow's import step), so any new top-level resource must be imported each run or it gets recreated. #108 added the at-rest CMK without importing it, and the deploy role lacked permission to encrypt the Lambda environments.

- Import the at-rest KMS key and its alias each run (resolved via the stable alias), alongside the existing log-group / Lambda imports.
- Add two least-privilege inline policies to the deploy role, recorded in `infrastructure/bootstrap/main.tf`: one to encrypt the Lambda environments with the app CMKs (alias-scoped), one to manage the two CMK-encrypted log groups.
- Make both Lambdas `depend_on` their KMS alias, so a from-scratch apply cannot encrypt the environment before the alias exists.

## Verified
- `terraform fmt` and `terraform validate` pass (infra + bootstrap).
- The deploy role's new permissions are confirmed in place.

`Deploy Infrastructure` only runs on push to `main`; I'll confirm it green on merge.