### PR TITLE
Task 6 follow-up: encrypt the silk-reeling log group at rest (POAM-018)

### DIFF
--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -179,6 +179,7 @@ data "aws_iam_policy_document" "compliance_logs" {
     resources = [
       "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.domain_dashed}-opa-compliance*",
       "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/route53/${var.domain_name}*",
+      "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.domain_dashed}-silk-reeling*",
     ]
   }
 }

--- a/infrastructure/silk-reeling.tf
+++ b/infrastructure/silk-reeling.tf
@@ -83,6 +83,21 @@ resource "aws_kms_key" "silk_reeling" {
           }
         }
       },
+      {
+        # Allow CloudWatch Logs to encrypt this app's log group at rest with this
+        # CMK (POAM-018). Scoped via EncryptionContext to exactly the silk-reeling
+        # log group, so the grant cannot be used for any other log group.
+        Sid       = "AllowCloudWatchLogs"
+        Effect    = "Allow"
+        Principal = { Service = "logs.${var.aws_region}.amazonaws.com" }
+        Action    = ["kms:Encrypt", "kms:Decrypt", "kms:ReEncrypt*", "kms:GenerateDataKey*", "kms:DescribeKey"]
+        Resource  = "*"
+        Condition = {
+          ArnLike = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.silk_name}"
+          }
+        }
+      },
     ]
   })
 
@@ -183,6 +198,7 @@ resource "aws_cloudwatch_log_group" "silk_reeling" {
   count             = local.silk_create
   name              = "/aws/lambda/${local.silk_name}"
   retention_in_days = 7
+  kms_key_id        = aws_kms_key.silk_reeling[0].arn # customer-CMK at rest (POAM-018)
 
   tags = merge(local.silk_tags, { Name = "${var.domain_name}-silk-reeling-logs" })
 }


### PR DESCRIPTION
SCN-Type: Routine Recurring

## Changed
Live verification after #112 found the silk-reeling CloudWatch log group was still on AWS-default encryption — the one log group not on a customer CMK. POAM-018's closure states *every* log group uses a customer CMK, so this closes the gap (Checkov's report is non-blocking and the tracking suppression was removed, so it wasn't caught at deploy).

- Grant the CloudWatch Logs service use of the app CMK, scoped via encryption context to exactly this log group. The key previously served Secrets Manager only; a service principal reaches a key through the key policy, not IAM delegation, so this grant is required.
- Encrypt the log group with the app CMK.
- Extend the deploy role's log-group management grant to cover it (recorded in `infrastructure/bootstrap/main.tf`; applied live so the next deploy can associate the key).

## Verified
- `terraform fmt` and `terraform validate` pass (infra + bootstrap).
- Deploy-role grant confirmed in place; the silk key/alias/log group are already imported each run, so the apply updates the existing group rather than recreating it.

## Couldn't verify until merge
- The live association of the CMK to the log group — `Deploy Infrastructure` only runs on push to `main`. I'll confirm the log group shows the customer key after merge.