### PR TITLE
Task 5 (PR A): sign the runtime KSI signal with KMS (POAM-002)

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -444,6 +444,30 @@ jobs:
           echo "No existing at-rest CMK found - will be created"
         fi
 
+        # Import the runtime-signal signing CMK + alias if they exist (Task 5,
+        # POAM-002). Ephemeral state: resolve the key by its stable alias and
+        # adopt both so the asymmetric signing key is not recreated each run.
+        if aws kms describe-key --key-id alias/samaydlette-com-runtime-signing >/dev/null 2>&1; then
+          SIGNING_KEY_ID=$(aws kms describe-key --key-id alias/samaydlette-com-runtime-signing --query 'KeyMetadata.KeyId' --output text)
+          echo "Runtime-signing CMK exists in AWS ($SIGNING_KEY_ID)"
+          if ! terraform state show aws_kms_key.runtime_signing >/dev/null 2>&1; then
+            echo "Importing runtime-signing CMK..."
+            terraform import aws_kms_key.runtime_signing "$SIGNING_KEY_ID"
+            echo "✅ Runtime-signing CMK imported"
+          else
+            echo "Runtime-signing CMK already in Terraform state"
+          fi
+          if ! terraform state show aws_kms_alias.runtime_signing >/dev/null 2>&1; then
+            echo "Importing runtime-signing CMK alias..."
+            terraform import aws_kms_alias.runtime_signing "alias/samaydlette-com-runtime-signing"
+            echo "✅ Runtime-signing CMK alias imported"
+          else
+            echo "Runtime-signing CMK alias already in Terraform state"
+          fi
+        else
+          echo "No existing runtime-signing CMK found - will be created"
+        fi
+
         # Import the compliance Lambda's log group if it exists (auto-created by
         # Lambda; now managed for customer-CMK encryption + retention, POAM-018).
         # Must precede the Lambda import since the function depends_on it.

--- a/docs/continuous-monitoring-plan.md
+++ b/docs/continuous-monitoring-plan.md
@@ -27,7 +27,8 @@ Four mechanisms operate concurrently:
 Five artifacts are published continuously at `/.well-known/`:
 
 - `ksi-signal.json` — the FedRAMP 20x KSI signal (Sigstore-signed); per-deploy emission
-- `ksi-signal-runtime.json` — the daily runtime revalidation
+- `ksi-signal-runtime.json` — the daily runtime revalidation, signed with an asymmetric KMS key (ECC NIST P-256); the signature is carried in `provenance.attestation` and verifiable against `runtime-signing-pubkey.pem` (POAM-002)
+- `runtime-signing-pubkey.pem` — the public key for verifying the runtime signal's signature
 - `oscal-ssp.json` — the NIST OSCAL System Security Plan; per-deploy emission
 - `oscal-poam.json` — the NIST OSCAL Plan of Action and Milestones; per-deploy emission
 - `vdr-report.json` — the FedRAMP 20x VDR report; per-deploy emission

--- a/docs/poam.md
+++ b/docs/poam.md
@@ -20,34 +20,7 @@ Status values: **Open** · **In progress** · **Closed** · **Risk-accepted**.
 ## Open POA&M Items
 
 
-### POAM-002 — Runtime KSI signal not cryptographically signed
-
-| Field | Value |
-| --- | --- |
-| POA&M ID | POAM-002 |
-| Controls | AU-10, SI-7, SC-12, SC-13 |
-| Weakness Name | Runtime KSI signal not cryptographically signed |
-| Weakness Description | The runtime KSI signal at `/.well-known/ksi-signal-runtime.json` is published by the Lambda without a cryptographic signature. Consumers trust it implicitly via "AWS has not lied about what is at the well-known URL." That is the standard static-site CDN trust model, but it does not reduce to the public Sigstore transparency log the deploy-time signal does. |
-| Weakness Detector Source | Internal review during initial implementation. |
-| Weakness Source Identifier | internal-review-2026-05-06 |
-| Asset Identifier | `aws-lambda::compliance-monitor`; `aws-s3-key::.well-known/ksi-signal-runtime.json` |
-| Point of Contact | Sam Aydlette (operator) |
-| Resources Required | Operator time (~half day); ~$1/month KMS cost. |
-| Remediation Plan | AWS KMS asymmetric signing in the Lambda — provision an ECC NIST P-256 key with `key_usage = "SIGN_VERIFY"`, grant the Lambda role `kms:Sign` and `kms:GetPublicKey`, sign the canonical-form bytes, and embed the signature in `provenance.attestation`. Publish the public key at `/.well-known/runtime-signing-pubkey.pem`. An alternative path is federating an OIDC identity into the Lambda for Sigstore-keyless signing, but that requires more new infrastructure for the same end state. |
-| Original Detection Date | 2026-05-06 |
-| Scheduled Completion Date | When an external consumer asks to verify the runtime signal end-to-end. Low priority for the PoC. |
-| Status Date | 2026-05-08 |
-| Vendor Dependency | No |
-| Last Vendor Check-in Date | — |
-| Vendor Dependent Product Name | — |
-| Original Risk Rating | Low |
-| Adjusted Risk Rating | — |
-| Risk Adjustment | No |
-| Status | Open |
-
-**Compensating controls.** The Lambda's IAM role can write only to the single S3 key for the runtime signal — a compromised Lambda cannot tamper with other site content. The runtime signal carries `provenance.builder.id` identifying its execution context. Drift between the (signed) deploy-time signal and the (unsigned) runtime signal is detectable from outside; mismatched components or validations are high-confidence signal of either real drift or a tampered runtime signal. All other published artifacts (OSCAL SSP, OSCAL POA&M, VDR report, IIW CSV) are now Sigstore-signed in CI; this POA&M item applies only to the runtime KSI signal.
-
-**Risk if not remediated.** A consumer pulling the runtime signal cannot independently verify it has not been tampered with. For a fully public site with no consuming agency, the risk is reputational. In any portfolio context where multiple agencies consume signals across CSPs, runtime signal forgery becomes a credible attack and signing closes it.
+*No items are currently open.* POAM-001 (deployer credentials) and POAM-002 (runtime-signal signing) are Closed below; the remaining assessment findings are tracked as Configuration Findings (risk-accepted), False Positives, or PL-2 Findings.
 
 ---
 
@@ -218,6 +191,36 @@ If the threat profile or scope changes — for example, if the system starts pro
 
 
 **Closed 2026-06-15.** Migrated to GitHub OIDC role assumption (`github-actions-deploy-oidc`); the workflow now uses `role-to-assume`. After a fully green OIDC deploy (compliance-check + Deploy Infrastructure jobs both assuming the role), the legacy `github-actions-deploy` IAM user and its access key were deleted and the `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` repo secrets removed. No long-lived AWS credential remains on the deploy path.
+
+---
+
+### POAM-002 — Runtime KSI signal not cryptographically signed
+
+| Field | Value |
+| --- | --- |
+| POA&M ID | POAM-002 |
+| Controls | AU-10, SI-7, SC-12, SC-13 |
+| Weakness Name | Runtime KSI signal not cryptographically signed |
+| Weakness Description | The runtime KSI signal at `/.well-known/ksi-signal-runtime.json` was published by the Lambda without a cryptographic signature; consumers trusted it implicitly via the well-known URL rather than a verifiable cryptographic root. |
+| Weakness Detector Source | Internal review during initial implementation. |
+| Weakness Source Identifier | internal-review-2026-05-06 |
+| Asset Identifier | `aws-lambda::compliance-monitor`; `aws-s3-key::.well-known/ksi-signal-runtime.json` |
+| Point of Contact | Sam Aydlette (operator) |
+| Resources Required | Operator time (~half day); ~$1/month KMS cost. |
+| Remediation Plan | AWS KMS asymmetric signing in the Lambda — ECC NIST P-256 `SIGN_VERIFY` key, Lambda role granted `kms:Sign` + `kms:GetPublicKey`, sign the canonical signal bytes, embed the signature in `provenance.attestation`, publish the public key at `/.well-known/runtime-signing-pubkey.pem`. |
+| Original Detection Date | 2026-05-06 |
+| Scheduled Completion Date | 2026-06-17 |
+| Status Date | 2026-06-17 |
+| Vendor Dependency | No |
+| Last Vendor Check-in Date | — |
+| Vendor Dependent Product Name | — |
+| Original Risk Rating | Low |
+| Adjusted Risk Rating | — |
+| Risk Adjustment | No |
+| Status | Closed |
+| False Positive | No |
+
+**Closed 2026-06-17 (Task 5).** The runtime emitter (`infrastructure/lambda/index.js`) now signs the runtime signal with an asymmetric KMS key (`aws_kms_key.runtime_signing`, ECC NIST P-256, `SIGN_VERIFY`). It canonicalizes the signal with `provenance.attestation` absent (sorted-keys JSON, no whitespace), signs the SHA-256 digest (`ECDSA_SHA_256`), and places the signature in `provenance.attestation`; the verifying public key is published at `/.well-known/runtime-signing-pubkey.pem`. A consumer verifies by stripping `provenance.attestation`, recomputing the canonical bytes, and checking the signature against the published key — no trust in the well-known URL required. **Residual (operational):** asymmetric KMS keys do not auto-rotate; key rotation is a manual new-key + re-publish-pubkey step, tracked in the [secure-configuration guide](policies/secure-configuration-guide.md).
 
 ---
 

--- a/infrastructure/lambda/canonical.js
+++ b/infrastructure/lambda/canonical.js
@@ -1,0 +1,24 @@
+// Deterministic JSON canonicalization for signing the runtime KSI signal
+// (POAM-002). Isolated from index.js so it has no AWS-SDK dependency and can be
+// exercised directly by tests and by external verifiers porting the recipe.
+//
+// Recipe (must be reproduced byte-for-byte by any verifier):
+//   1. Remove `provenance.attestation` from the signal.
+//   2. Serialize with object keys sorted lexicographically at every level,
+//      arrays kept in order, and no insignificant whitespace.
+//   3. The resulting UTF-8 bytes are what gets SHA-256'd and signed.
+//
+// This matches Python `json.dumps(obj, sort_keys=True, separators=(',', ':'),
+// ensure_ascii=False)` for the ASCII-only content of the signal.
+function canonicalize(value) {
+    if (Array.isArray(value)) {
+        return '[' + value.map(canonicalize).join(',') + ']';
+    }
+    if (value && typeof value === 'object') {
+        const keys = Object.keys(value).sort();
+        return '{' + keys.map((k) => JSON.stringify(k) + ':' + canonicalize(value[k])).join(',') + '}';
+    }
+    return JSON.stringify(value);
+}
+
+module.exports = { canonicalize };

--- a/infrastructure/lambda/index.js
+++ b/infrastructure/lambda/index.js
@@ -37,6 +37,12 @@ const {
     CloudFrontClient,
     GetDistributionConfigCommand,
 } = require('@aws-sdk/client-cloudfront');
+const {
+    KMSClient,
+    SignCommand,
+    GetPublicKeyCommand,
+} = require('@aws-sdk/client-kms');
+const { canonicalize } = require('./canonical');
 
 const SIGNAL_VERSION = '1.0.0';
 const SCHEMA_URL = 'https://samaydlette.com/.well-known/ksi-signal.schema.json';
@@ -261,6 +267,64 @@ async function buildRuntimeSignal(deploySignal, s3, cf, policy, policyVersion) {
 }
 
 // =============================================================================
+// SIGNING (POAM-002)
+// =============================================================================
+// The runtime signal is signed with an AWS KMS asymmetric key (ECC NIST P-256,
+// SIGN_VERIFY) so a consumer can verify it cryptographically rather than trust
+// the well-known URL implicitly. The signature covers the canonical form of the
+// signal with `provenance.attestation` absent; the signature object is then
+// placed in `provenance.attestation`. A verifier reproduces the canonical bytes
+// by deleting `provenance.attestation`, canonicalizing, and checking the
+// signature against the published public key. The canonicalization recipe lives
+// in ./canonical.js so verifiers and tests can reuse it without the AWS SDK.
+
+// Wrap SPKI DER public-key bytes as PEM.
+function derToPem(der) {
+    const b64 = Buffer.from(der).toString('base64');
+    const lines = b64.match(/.{1,64}/g).join('\n');
+    return `-----BEGIN PUBLIC KEY-----\n${lines}\n-----END PUBLIC KEY-----\n`;
+}
+
+// Sign the signal in place: returns a copy with provenance.attestation set.
+async function signSignal(signal, kms, keyArn) {
+    const canonical = Buffer.from(canonicalize(signal), 'utf8');
+    const digest = crypto.createHash('sha256').update(canonical).digest();
+    const { Signature } = await kms.send(new SignCommand({
+        KeyId: keyArn,
+        Message: digest,
+        MessageType: 'DIGEST',
+        SigningAlgorithm: 'ECDSA_SHA_256',
+    }));
+    return {
+        ...signal,
+        provenance: {
+            ...signal.provenance,
+            attestation: {
+                type: 'kms-ecdsa-p256',
+                algorithm: 'ECDSA_SHA_256',
+                key_id: keyArn,
+                canonicalization: 'sorted-keys JSON, no whitespace; provenance.attestation omitted before signing',
+                signature: Buffer.from(Signature).toString('base64'),
+                public_key_url: 'https://samaydlette.com/.well-known/runtime-signing-pubkey.pem',
+                signed_at: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+            },
+        },
+    };
+}
+
+// Publish the signing public key so consumers can verify without trusting us.
+async function publishPublicKey(kms, s3, bucketName, keyArn) {
+    const { PublicKey } = await kms.send(new GetPublicKeyCommand({ KeyId: keyArn }));
+    await s3.send(new PutObjectCommand({
+        Bucket: bucketName,
+        Key: '.well-known/runtime-signing-pubkey.pem',
+        Body: derToPem(PublicKey),
+        ContentType: 'application/x-pem-file',
+        CacheControl: 'public, max-age=300',
+    }));
+}
+
+// =============================================================================
 // HANDLER
 // =============================================================================
 
@@ -295,7 +359,20 @@ exports.handler = async (event, context) => {
         };
     }
 
-    const runtimeSignal = await buildRuntimeSignal(deploySignal, s3, cf, policy, policyVersion);
+    let runtimeSignal = await buildRuntimeSignal(deploySignal, s3, cf, policy, policyVersion);
+
+    // Sign the signal (POAM-002) and publish the verifying public key. If no
+    // signing key is configured, the signal is published unsigned (the pre-Task-5
+    // behavior) rather than failing the run.
+    const signingKeyArn = process.env.RUNTIME_SIGNING_KEY_ARN;
+    if (signingKeyArn) {
+        const kms = new KMSClient({ region });
+        runtimeSignal = await signSignal(runtimeSignal, kms, signingKeyArn);
+        await publishPublicKey(kms, s3, bucketName, signingKeyArn);
+        console.log('Runtime signal signed; public key published');
+    } else {
+        console.warn('RUNTIME_SIGNING_KEY_ARN not set — publishing unsigned signal');
+    }
 
     await s3.send(new PutObjectCommand({
         Bucket: bucketName,

--- a/infrastructure/lambda/package-lock.json
+++ b/infrastructure/lambda/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.0.0",
       "dependencies": {
         "@aws-sdk/client-cloudfront": "^3.658.0",
+        "@aws-sdk/client-kms": "^3.658.0",
         "@aws-sdk/client-s3": "^3.658.0",
         "@open-policy-agent/opa-wasm": "^1.9.0"
       }
@@ -267,6 +268,27 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-kms": {
+      "version": "3.1071.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1071.0.tgz",
+      "integrity": "sha512-0lOi8OolN8+ylb4o8rj+v0atdP/IcsuqIOMthAB72C2ujbdlfPjd3iSd1/9BZDHiCrZUDwz3hHaesyRCH8FMYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/credential-provider-node": "^3.972.57",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.1042.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1042.0.tgz",
@@ -334,24 +356,18 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
-      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
+      "version": "3.974.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.22.tgz",
+      "integrity": "sha512-YofH63shc6YRdXjz80BJkpJW+Bkn0Cuu2dn4Rv7s9G2Idt58tgtzQEWxrR2xVljlVfIBeUjPuULnSVYLke3sUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.22",
-        "@smithy/core": "^3.23.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/types": "^3.973.13",
+        "@aws-sdk/xml-builder": "^3.972.30",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -372,15 +388,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
-      "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.48.tgz",
+      "integrity": "sha512-h6FEC95fbexUd6zxm4PdgS82bTcI2PRtUb2ZwMipb/Xr8bPwtf0G8rBo2jp7NA24Mbx2JA8/WingiYpA9RCCyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -388,20 +404,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
-      "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.50.tgz",
+      "integrity": "sha512-lJO3OLpjvz5m/RSBQmsG/CEUGsvCy5ruxKwPQaOCqxqCMuyYT2BZwQUTDZVVwqQ9LrZKuK24JSa6r31hL/tvkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.25",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -409,24 +422,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
-      "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.55.tgz",
+      "integrity": "sha512-TBoF4buBGYhXjdZAryayY2TrkQj2B2KfE/msG4V53XCt+w0EhEwM2JRjx8p2grJ2C6gtH5++SAwEvGMRdi0yyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-env": "^3.972.34",
-        "@aws-sdk/credential-provider-http": "^3.972.36",
-        "@aws-sdk/credential-provider-login": "^3.972.38",
-        "@aws-sdk/credential-provider-process": "^3.972.34",
-        "@aws-sdk/credential-provider-sso": "^3.972.38",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
-        "@aws-sdk/nested-clients": "^3.997.6",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/credential-provider-env": "^3.972.48",
+        "@aws-sdk/credential-provider-http": "^3.972.50",
+        "@aws-sdk/credential-provider-login": "^3.972.54",
+        "@aws-sdk/credential-provider-process": "^3.972.48",
+        "@aws-sdk/credential-provider-sso": "^3.972.54",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.54",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -434,18 +446,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
-      "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.54.tgz",
+      "integrity": "sha512-hBWI3wZTdTGiuMfmPts6AWbAjFfRniOQnqx68tc2cQvRKWawFbN9wkLOVPWM1FAOyowZU73mC6Fi+rHSHNyLFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/nested-clients": "^3.997.6",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -453,22 +463,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
-      "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.57.tgz",
+      "integrity": "sha512-u6dClpzNdWf1HGWz4wwhdXi1wiOofCLniM9S4BQQGlLAN9TW7VB+ld5V533GdKrYMaFeBGFqKnj0JCYvynLqwQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.34",
-        "@aws-sdk/credential-provider-http": "^3.972.36",
-        "@aws-sdk/credential-provider-ini": "^3.972.38",
-        "@aws-sdk/credential-provider-process": "^3.972.34",
-        "@aws-sdk/credential-provider-sso": "^3.972.38",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/credential-provider-env": "^3.972.48",
+        "@aws-sdk/credential-provider-http": "^3.972.50",
+        "@aws-sdk/credential-provider-ini": "^3.972.55",
+        "@aws-sdk/credential-provider-process": "^3.972.48",
+        "@aws-sdk/credential-provider-sso": "^3.972.54",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.54",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -476,16 +485,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
-      "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.48.tgz",
+      "integrity": "sha512-w6VZwojPt12WnEkAUy6Nu4K6sWCbBmR7QX390b0nE6vRvkXbrYr9Lq9VySGkfjiMjpUA87op+J4EgvRmtWIDoQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -493,18 +501,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
-      "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.54.tgz",
+      "integrity": "sha512-23uZpIpF2SIFDCa1fcWa202tK4gGeyvX6GIIAjiB8WBsvsVRBMnJ/7dCxHzxf7eZT7GToJg837LDIBnZsl/VUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/nested-clients": "^3.997.6",
-        "@aws-sdk/token-providers": "3.1041.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/token-providers": "3.1071.0",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -512,17 +519,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
-      "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.54.tgz",
+      "integrity": "sha512-0Iv5QttS6wcATlodYKgvQj6B9Db51rx7NU9fqu0PoLeS4BIgdYMc/QK4smwLwpm5RFrs02V/eLyEFp3FklvlNQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/nested-clients": "^3.997.6",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -705,49 +711,20 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
-      "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
+      "version": "3.997.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.22.tgz",
+      "integrity": "sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.17",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.49",
-        "@smithy/util-defaults-mode-node": "^4.2.54",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -771,16 +748,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
-      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
+      "version": "3.996.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -788,17 +763,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1041.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
-      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+      "version": "3.1071.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1071.0.tgz",
+      "integrity": "sha512-4LDW2Qob6LoLFuqYSYZq2AyTE9koSE9+i+n5UZcm10GpmQOK0zRD9L4uYlzItiTKksIWgC/qMFChAi3RvKYtMg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/nested-clients": "^3.997.6",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/nested-clients": "^3.997.22",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -806,12 +780,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.1",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -896,14 +870,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
-      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.30.tgz",
+      "integrity": "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@nodable/entities": "2.1.0",
-        "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.2",
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -920,9 +893,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
       "funding": [
         {
           "type": "github",
@@ -984,20 +957,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.17",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
-      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.25.1.tgz",
+      "integrity": "sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1005,15 +971,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
-      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.1.tgz",
+      "integrity": "sha512-TSAF5NHgxEsllbErYWbK8aLnl5L601NGc5VYJlSPsKnf3YlkhdoBN+geGcaU00oiw2OK3QO5LA3QNXiiWhCidQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1091,15 +1055,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.17",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
-      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.1.tgz",
+      "integrity": "sha512-96JrD1q71anokymx9Iblb+zKmNQYNstlV/25A9ZYIJ2A0rp1r7/GZAIm0bDWSmVvz3DpNOCZuabzsiL+w0UHhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/querystring-builder": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1287,14 +1249,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
-      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.1.tgz",
+      "integrity": "sha512-emtXvoky671puri18ETf64AFIQUGIEA093F2drXpBgB0OGnBLjcwNR3CA2mYu62IAqNsS56xa5lnTxAgPq7cjw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/querystring-builder": "^4.2.14",
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1321,20 +1282,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
-      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1380,18 +1327,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
-      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.1.tgz",
+      "integrity": "sha512-X9rVls3En0z3NtrmguTmpRM0/NqtWUxBjal6fcAkwtsub+gOdLZ6kD+V7xhUgFMGdG14bHbZ7M5QjaRI1+DatQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1417,9 +1359,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1610,18 +1552,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
-      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/util-utf8": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
@@ -1660,6 +1590,18 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
@@ -1667,9 +1609,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.8.tgz",
-      "integrity": "sha512-sDVBc2gg8pSKvcbE8rBmOyjSGQf0AdsbqvHeIOv3D/uYNoV4eCReQXyDF8Pdv8+m1FHazACypSz2hR7O2S1LLw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -1678,13 +1620,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
-      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -1694,7 +1637,7 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
@@ -1724,22 +1667,40 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/yaml": {
       "version": "1.10.3",

--- a/infrastructure/lambda/package.json
+++ b/infrastructure/lambda/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.658.0",
     "@aws-sdk/client-cloudfront": "^3.658.0",
+    "@aws-sdk/client-kms": "^3.658.0",
     "@open-policy-agent/opa-wasm": "^1.9.0"
   }
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -334,6 +334,13 @@ resource "aws_iam_role_policy" "lambda_opa" {
         Resource = [aws_kms_key.at_rest.arn]
       },
       {
+        # Sign the runtime KSI signal and read the public key for publication
+        # (POAM-002). Scoped to the asymmetric signing key only.
+        Effect   = "Allow"
+        Action   = ["kms:Sign", "kms:GetPublicKey"]
+        Resource = [aws_kms_key.runtime_signing.arn]
+      },
+      {
         # Minimum read access the runtime KSI emitter needs to build the
         # {resource: {...}} input that policies.rego (compiled to Wasm)
         # evaluates. The actions match the bucket-attribute checks the Rego
@@ -445,6 +452,45 @@ resource "aws_kms_alias" "at_rest" {
   target_key_id = aws_kms_key.at_rest.key_id
 }
 
+# Asymmetric signing key for the runtime KSI signal (POAM-002). The Lambda signs
+# the canonical signal bytes so a consumer can verify the runtime signal against
+# the published public key instead of trusting the well-known URL. ECC NIST P-256
+# / SIGN_VERIFY; asymmetric keys do not support automatic rotation (rotation is a
+# manual new-key + re-publish-pubkey operation, recorded as a residual in
+# docs/poam.md). Key policy is root-enabled / IAM-governed; the Lambda role holds
+# kms:Sign + kms:GetPublicKey (above).
+resource "aws_kms_key" "runtime_signing" {
+  description              = "Asymmetric key for signing the runtime KSI signal (POAM-002)"
+  customer_master_key_spec = "ECC_NIST_P256"
+  key_usage                = "SIGN_VERIFY"
+  deletion_window_in_days  = 7
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "EnableIAMUserPermissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+    ]
+  })
+
+  tags = {
+    Name               = "${var.domain_name}-runtime-signing"
+    Environment        = var.environment
+    DataClassification = "Internal"
+    Owner              = var.owner
+  }
+}
+
+resource "aws_kms_alias" "runtime_signing" {
+  name          = "alias/${replace(var.domain_name, ".", "-")}-runtime-signing"
+  target_key_id = aws_kms_key.runtime_signing.key_id
+}
+
 # Explicit, customer-CMK-encrypted log group for the compliance Lambda (POAM-018)
 # with an explicit Moderate retention. Lambda would otherwise auto-create this
 # group unencrypted; it already exists, so the deploy imports it before apply.
@@ -483,7 +529,8 @@ resource "aws_lambda_function" "opa_compliance" {
 
   environment {
     variables = {
-      S3_BUCKET = data.aws_s3_bucket.website.id
+      S3_BUCKET               = data.aws_s3_bucket.website.id
+      RUNTIME_SIGNING_KEY_ARN = aws_kms_key.runtime_signing.arn
     }
   }
 

--- a/scripts/build-oscal-poam.py
+++ b/scripts/build-oscal-poam.py
@@ -92,16 +92,14 @@ POAM_ITEMS = [
         "id": "POAM-002",
         "title": "Runtime KSI signal not cryptographically signed",
         "description": (
-            "The runtime KSI signal at /.well-known/ksi-signal-runtime.json is "
-            "published by the Lambda without a cryptographic signature. Consumers "
-            "trust it implicitly via 'AWS has not lied about what is at the "
-            "well-known URL.' That is the standard static-site CDN trust model, "
-            "but it does not reduce to the public Sigstore transparency log the "
-            "deploy-time signal does. (As of this revision, the deploy-time KSI "
-            "signal, OSCAL SSP, OSCAL POA&M, VDR report, and IIW CSV are all "
-            "Sigstore-signed in CI; this POA&M item is now narrowed to the "
-            "runtime signal specifically, which still requires a separate "
-            "signing mechanism since the Lambda cannot use GitHub OIDC.)"
+            "Closed under Task 5 (2026-06-17): the runtime emitter now signs the "
+            "runtime signal with an asymmetric KMS key (ECC NIST P-256, SIGN_VERIFY). "
+            "It canonicalizes the signal with provenance.attestation absent "
+            "(sorted-keys JSON, no whitespace), signs the SHA-256 digest with "
+            "ECDSA_SHA_256, places the signature in provenance.attestation, and "
+            "publishes the verifying public key at "
+            "/.well-known/runtime-signing-pubkey.pem. A consumer verifies the "
+            "runtime signal cryptographically without trusting the well-known URL."
         ),
         "controls": ["au-10", "si-7", "sc-12", "sc-13"],
         "weakness_detector_source": "Internal review",
@@ -120,14 +118,14 @@ POAM_ITEMS = [
             "/.well-known/runtime-signing-pubkey.pem."
         ),
         "original_detection_date": "2026-05-06",
-        "scheduled_completion_date": "When an external consumer asks to verify the runtime signal end-to-end.",
-        "status_date": "2026-05-08",
+        "scheduled_completion_date": "2026-06-17",
+        "status_date": "2026-06-17",
         "vendor_dependency": False,
         "original_risk_rating": "low",
         "adjusted_risk_rating": None,
         "risk_adjustment": False,
-        "status": "open",
-        "category": "open",
+        "status": "closed",
+        "category": "closed",
     },
     # Configuration Findings (Checkov suppressions; all currently risk-accepted)
     {

--- a/tests/test_runtime_signature.py
+++ b/tests/test_runtime_signature.py
@@ -1,0 +1,127 @@
+"""Verifier-side test for the signed runtime KSI signal (POAM-002, Task 5).
+
+This reproduces, in Python, exactly what an external consumer does to verify the
+runtime signal published at /.well-known/ksi-signal-runtime.json:
+
+  1. strip provenance.attestation,
+  2. canonicalize (sorted keys, compact separators, UTF-8),
+  3. SHA-256 + ECDSA-verify the DER signature against the published P-256 key.
+
+The canonicalization here is byte-identical to the Lambda's signer
+(infrastructure/lambda/canonical.js) — verified independently and pinned below —
+so this proves the signature is verifiable cross-language, not just by re-running
+the JS that produced it.
+"""
+
+import base64
+import copy
+import json
+
+import pytest
+
+cryptography = pytest.importorskip("cryptography")
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+
+def canonical_bytes(signal):
+    """The exact bytes the signer hashes — provenance.attestation removed."""
+    s = copy.deepcopy(signal)
+    if isinstance(s.get("provenance"), dict):
+        s["provenance"].pop("attestation", None)
+    return json.dumps(
+        s, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+def verify(signal, public_key):
+    """Return True iff provenance.attestation.signature is valid for `signal`."""
+    sig = base64.b64decode(signal["provenance"]["attestation"]["signature"])
+    public_key.verify(sig, canonical_bytes(signal), ec.ECDSA(hashes.SHA256()))
+    return True
+
+
+SAMPLE = {
+    "signal_version": "1.0.0",
+    "emitted_at": "2026-06-17T00:00:00Z",
+    "emitter": "runtime",
+    "system_id": "sys-1",
+    "csp": "aws",
+    "provenance": {
+        "source": {"repository": "r", "commit": "abc", "ref": "runtime"},
+        "builder": {"id": "b", "run_id": "x", "version": "1"},
+    },
+    "components": [{"id": "c2", "type": "t"}, {"id": "c1", "type": "t"}],
+    "validations": [{"id": "v1", "result": "pass"}],
+    "unicode": "café—ok",
+}
+
+# Pinned canonical form — must stay byte-identical to canonical.js (cross-checked
+# with `node -e "require('./canonical').canonicalize(...)"`). A drift here means
+# the JS signer and any verifier have diverged.
+EXPECTED_CANONICAL = (
+    '{"components":[{"id":"c2","type":"t"},{"id":"c1","type":"t"}],'
+    '"csp":"aws","emitted_at":"2026-06-17T00:00:00Z","emitter":"runtime",'
+    '"provenance":{"builder":{"id":"b","run_id":"x","version":"1"},'
+    '"source":{"commit":"abc","ref":"runtime","repository":"r"}},'
+    '"signal_version":"1.0.0","system_id":"sys-1","unicode":"café—ok",'
+    '"validations":[{"id":"v1","result":"pass"}]}'
+)
+
+
+def _sign(signal, private_key):
+    sig = private_key.sign(canonical_bytes(signal), ec.ECDSA(hashes.SHA256()))
+    signed = copy.deepcopy(signal)
+    signed["provenance"]["attestation"] = {
+        "type": "kms-ecdsa-p256",
+        "algorithm": "ECDSA_SHA_256",
+        "signature": base64.b64encode(sig).decode(),
+    }
+    return signed
+
+
+def test_canonical_form_is_pinned():
+    assert canonical_bytes(SAMPLE).decode("utf-8") == EXPECTED_CANONICAL
+
+
+def test_attestation_is_excluded_from_canonical_bytes():
+    base = canonical_bytes(SAMPLE)
+    withatt = copy.deepcopy(SAMPLE)
+    withatt["provenance"]["attestation"] = {"signature": "anything"}
+    assert canonical_bytes(withatt) == base
+
+
+def test_valid_signature_verifies():
+    key = ec.generate_private_key(ec.SECP256R1())
+    signed = _sign(SAMPLE, key)
+    assert verify(signed, key.public_key()) is True
+
+
+def test_tampered_signal_fails():
+    key = ec.generate_private_key(ec.SECP256R1())
+    signed = _sign(SAMPLE, key)
+    signed["validations"][0]["result"] = "fail"  # flip a claim after signing
+    with pytest.raises(InvalidSignature):
+        verify(signed, key.public_key())
+
+
+def test_wrong_key_fails():
+    signed = _sign(SAMPLE, ec.generate_private_key(ec.SECP256R1()))
+    other = ec.generate_private_key(ec.SECP256R1()).public_key()
+    with pytest.raises(InvalidSignature):
+        verify(signed, other)
+
+
+def test_pem_roundtrip_matches_published_form():
+    """The Lambda publishes SPKI PEM; ensure that round-trips to a usable key."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    pem = key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    loaded = serialization.load_pem_public_key(pem)
+    signed = _sign(SAMPLE, key)
+    # verify against the key reconstructed from PEM (what a consumer loads)
+    sig = base64.b64decode(signed["provenance"]["attestation"]["signature"])
+    loaded.verify(sig, canonical_bytes(signed), ec.ECDSA(hashes.SHA256()))


### PR DESCRIPTION
SCN-Type: Routine Recurring

## Changed
The runtime signal (`/.well-known/ksi-signal-runtime.json`, published by the daily Lambda) was unsigned — consumers trusted the well-known URL implicitly rather than a verifiable cryptographic root. It is now signed.

- New asymmetric signing key `aws_kms_key.runtime_signing` (ECC NIST P-256, `SIGN_VERIFY`) + alias. The compliance Lambda's role gains `kms:Sign` + `kms:GetPublicKey` **scoped to that key**; the key ARN is passed in env.
- The emitter canonicalizes the signal with `provenance.attestation` absent (sorted-keys JSON, no whitespace — recipe isolated in `lambda/canonical.js`), signs the SHA-256 digest (`ECDSA_SHA_256`), and places the signature in `provenance.attestation`. It publishes the verifying public key to `/.well-known/runtime-signing-pubkey.pem` each run. No key configured → falls back to unsigned rather than failing the run.
- Ephemeral-state pipeline: the signing key + alias are added to the workflow import step so they're adopted, not recreated, each run.
- POAM-002 → **Closed** in `docs/poam.md` and the OSCAL POA&M generator; published-artifacts list updated.

This is PR A of Task 5; DNSSEC (PR B) follows separately.

## Verified
- A Python verifier test (`tests/test_runtime_signature.py`) reproduces the **consumer** recipe (strip attestation → canonicalize → ECDSA-SHA256 verify), round-trips sign/verify, and asserts tamper + wrong-key detection. The canonical form is pinned and was confirmed **byte-identical** between the JS signer and an independent Python implementation (including non-ASCII) — so the signature is verifiable cross-language, not just by re-running the signer.
- `terraform fmt`/`validate` clean; `node --check` on both JS files; `validate-locally.sh` 12/12; full test suite green.
- CodeGuard self-review: modern crypto only (ECDSA P-256 / SHA-256), no hardcoded secrets (private key never leaves KMS; only the public key is published), least-privilege IAM.

## Residual
- Asymmetric KMS keys don't auto-rotate; rotation is a manual new-key + re-publish-pubkey step (noted in the POAM-002 closure).
- ~$1/mo for the new key (within the approved Task 5 budget).

## Couldn't verify until merge
- The live signing path (`Deploy Infrastructure` runs only on `main`). On merge I'll fetch the runtime signal + public key and verify the signature end-to-end with `openssl`, and confirm no key was orphaned (the import adopted the existing key).