### PR TITLE
Task 5 (PR A fix): derive runtime-signing alias from S3_BUCKET instead of a new env var

### DIFF
--- a/infrastructure/lambda/index.js
+++ b/infrastructure/lambda/index.js
@@ -361,17 +361,21 @@ exports.handler = async (event, context) => {
 
     let runtimeSignal = await buildRuntimeSignal(deploySignal, s3, cf, policy, policyVersion);
 
-    // Sign the signal (POAM-002) and publish the verifying public key. If no
-    // signing key is configured, the signal is published unsigned (the pre-Task-5
-    // behavior) rather than failing the run.
-    const signingKeyArn = process.env.RUNTIME_SIGNING_KEY_ARN;
-    if (signingKeyArn) {
+    // Sign the signal (POAM-002) and publish the verifying public key. The signing
+    // key is resolved by its stable alias, derived from the bucket/domain
+    // (alias/<domain-with-dashes>-runtime-signing). Deriving it from S3_BUCKET
+    // avoids depending on a separately-injected env var; kms:Sign is authorized
+    // against the underlying key ARN regardless of resolving via the alias. If
+    // signing fails (e.g. the key is unavailable), the signal is published
+    // unsigned rather than failing the compliance-monitor run.
+    const signingKeyAlias = 'alias/' + bucketName.replace(/\./g, '-') + '-runtime-signing';
+    try {
         const kms = new KMSClient({ region });
-        runtimeSignal = await signSignal(runtimeSignal, kms, signingKeyArn);
-        await publishPublicKey(kms, s3, bucketName, signingKeyArn);
-        console.log('Runtime signal signed; public key published');
-    } else {
-        console.warn('RUNTIME_SIGNING_KEY_ARN not set — publishing unsigned signal');
+        runtimeSignal = await signSignal(runtimeSignal, kms, signingKeyAlias);
+        await publishPublicKey(kms, s3, bucketName, signingKeyAlias);
+        console.log(`Runtime signal signed with ${signingKeyAlias}; public key published`);
+    } catch (err) {
+        console.error(`Signing failed (${signingKeyAlias}); publishing unsigned`, err);
     }
 
     await s3.send(new PutObjectCommand({

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -529,8 +529,11 @@ resource "aws_lambda_function" "opa_compliance" {
 
   environment {
     variables = {
-      S3_BUCKET               = data.aws_s3_bucket.website.id
-      RUNTIME_SIGNING_KEY_ARN = aws_kms_key.runtime_signing.arn
+      # The runtime emitter derives the signing-key alias from S3_BUCKET
+      # (alias/<domain-with-dashes>-runtime-signing); no separate key env var is
+      # injected. The kms:Sign / kms:GetPublicKey grant on the role is scoped to
+      # aws_kms_key.runtime_signing and authorizes use via that alias.
+      S3_BUCKET = data.aws_s3_bucket.website.id
     }
   }
 


### PR DESCRIPTION
SCN-Type: Routine Recurring

## Changed
After #115 merged and deployed, live verification found the runtime signal was still **unsigned** and no public key was published. Root cause: the `RUNTIME_SIGNING_KEY_ARN` environment variable added to the CMK-encrypted compliance Lambda **did not converge** — across two full deploys the new variable never reached the running function (the pre-existing `S3_BUCKET` kept working), so the emitter took its unsigned fallback path. Confirmed directly from the function's tail log (`WARN RUNTIME_SIGNING_KEY_ARN not set`), despite the Terraform plan/apply showing the variable being set with the explicit ARN. This appears to be a bad interaction between the ephemeral-state import flow and adding a variable to this Lambda's customer-key-encrypted environment.

Fix: stop depending on a newly-injected env var. The emitter now **derives the signing key's stable alias from `S3_BUCKET`** (`alias/<domain-with-dashes>-runtime-signing`) and signs with it. `kms:Sign`/`kms:GetPublicKey` are authorized against the underlying key ARN regardless of resolving via the alias, so the role grant is unchanged. Signing is wrapped in a try/catch so a key problem degrades to an unsigned signal rather than breaking the compliance monitor. The unused variable is removed from the Lambda config.

## Verified
- `node --check`, `terraform fmt`/`validate`, and the signature verifier test all pass.
- Alias derivation produces `alias/samaydlette-com-runtime-signing`, matching the deployed alias.

## Couldn't verify until merge
- The live signing path. On merge I'll invoke the Lambda and confirm via its tail log that it signs, then fetch the runtime signal + published public key and verify the signature end-to-end with `openssl`.

## Note
The underlying env-convergence anomaly is worked around here (the alias derivation is also simpler and removes a same-apply resource reference), not fully root-caused. I can dig into the provider/CMK-env interaction separately if you want a definitive answer, but it isn't on the critical path now.