### PR TITLE
Task 5 (PR A fix 2): allow the emitter to publish the signing public key

### DIFF
--- a/infrastructure/lambda/index.js
+++ b/infrastructure/lambda/index.js
@@ -368,12 +368,15 @@ exports.handler = async (event, context) => {
     // against the underlying key ARN regardless of resolving via the alias. If
     // signing fails (e.g. the key is unavailable), the signal is published
     // unsigned rather than failing the compliance-monitor run.
+    // Publish the public key BEFORE signing, so a signed signal is never
+    // published without the key needed to verify it: if either step fails, the
+    // signal stays unsigned (the catch leaves runtimeSignal unmodified).
     const signingKeyAlias = 'alias/' + bucketName.replace(/\./g, '-') + '-runtime-signing';
     try {
         const kms = new KMSClient({ region });
-        runtimeSignal = await signSignal(runtimeSignal, kms, signingKeyAlias);
         await publishPublicKey(kms, s3, bucketName, signingKeyAlias);
-        console.log(`Runtime signal signed with ${signingKeyAlias}; public key published`);
+        runtimeSignal = await signSignal(runtimeSignal, kms, signingKeyAlias);
+        console.log(`Public key published; runtime signal signed with ${signingKeyAlias}`);
     } catch (err) {
         console.error(`Signing failed (${signingKeyAlias}); publishing unsigned`, err);
     }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -361,15 +361,16 @@ resource "aws_iam_role_policy" "lambda_opa" {
         ]
       },
       {
-        # The runtime KSI emitter publishes its signal back to /.well-known/ on
-        # the same bucket. Scoped to that single key prefix so the Lambda
-        # cannot overwrite arbitrary site content.
+        # The runtime KSI emitter publishes its signal and signing public key back
+        # to /.well-known/ on the same bucket. Scoped to exactly those two keys so
+        # the Lambda cannot overwrite arbitrary site content.
         Effect = "Allow"
         Action = [
           "s3:PutObject"
         ]
         Resource = [
-          "${data.aws_s3_bucket.website.arn}/.well-known/ksi-signal-runtime.json"
+          "${data.aws_s3_bucket.website.arn}/.well-known/ksi-signal-runtime.json",
+          "${data.aws_s3_bucket.website.arn}/.well-known/runtime-signing-pubkey.pem"
         ]
       },
       {


### PR DESCRIPTION
SCN-Type: Routine Recurring

## Changed
With #116 deployed, live tail-log verification showed the signing path now executes (alias resolved, `kms:Sign` succeeded) but `publishPublicKey` failed with `s3:PutObject` **AccessDenied** on `runtime-signing-pubkey.pem`. The Lambda role's write grant was scoped to exactly the runtime-signal key, not the public-key object (my earlier "same prefix" assumption was wrong — it's per-key).

- Add `.well-known/runtime-signing-pubkey.pem` to the role's `s3:PutObject` resource list (still exactly two named keys — the Lambda still cannot write arbitrary site content).
- Reorder the emitter to publish the public key **before** signing the signal, so a signed signal is never published without the key needed to verify it. If either step fails, the signal stays unsigned (the previous order could leave a signed-but-unverifiable signal and a misleading log line).

## Verified
- `node --check`, `terraform fmt`/`validate`, signature verifier test all pass.

## Couldn't verify until merge
- The live end-to-end. On merge I'll invoke the Lambda, confirm via tail log that both the key publish and signing succeed, then fetch the signal + public key and verify the signature with `openssl`.