### PR TITLE
Task 5 (PR B): enable DNSSEC zone signing (D-3)

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -468,6 +468,23 @@ jobs:
           echo "No existing runtime-signing CMK found - will be created"
         fi
 
+        # Import DNSSEC resources if they exist (Task 5 PR B, D-3). Ephemeral
+        # state: the KSK (us-east-1 KMS key), its alias, the Route 53 key-signing
+        # key, and the hosted-zone-dnssec association are adopted so they are not
+        # recreated each run. All are no-ops on the first deploy (created then).
+        if aws kms describe-key --region us-east-1 --key-id alias/samaydlette-com-dnssec-ksk >/dev/null 2>&1; then
+          DNSSEC_KEY_ID=$(aws kms describe-key --region us-east-1 --key-id alias/samaydlette-com-dnssec-ksk --query 'KeyMetadata.KeyId' --output text)
+          ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name samaydlette.com --query 'HostedZones[0].Id' --output text | sed 's#/hostedzone/##')
+          echo "DNSSEC KSK exists ($DNSSEC_KEY_ID), zone $ZONE_ID"
+          terraform state show 'aws_kms_key.dnssec_ksk[0]' >/dev/null 2>&1 || terraform import 'aws_kms_key.dnssec_ksk[0]' "$DNSSEC_KEY_ID"
+          terraform state show 'aws_kms_alias.dnssec_ksk[0]' >/dev/null 2>&1 || terraform import 'aws_kms_alias.dnssec_ksk[0]' "alias/samaydlette-com-dnssec-ksk"
+          terraform state show 'aws_route53_key_signing_key.this[0]' >/dev/null 2>&1 || terraform import 'aws_route53_key_signing_key.this[0]' "${ZONE_ID},samaydlette_com_ksk"
+          terraform state show 'aws_route53_hosted_zone_dnssec.this[0]' >/dev/null 2>&1 || terraform import 'aws_route53_hosted_zone_dnssec.this[0]' "$ZONE_ID"
+          echo "✅ DNSSEC resources imported (where present)"
+        else
+          echo "No existing DNSSEC KSK found - will be created"
+        fi
+
         # Import the compliance Lambda's log group if it exists (auto-created by
         # Lambda; now managed for customer-CMK encryption + retention, POAM-018).
         # Must precede the Lambda import since the function depends_on it.

--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -228,7 +228,6 @@ resource "aws_iam_role_policy" "compliance_kms" {
 # key-signing key and enable/disable zone signing. KMS create/manage for the KSK
 # is already covered by the role's account-wide kms:CreateKey/PutKeyPolicy grant.
 data "aws_iam_policy_document" "dnssec_management" {
-  # checkov:skip=CKV_AWS_356:route53:GetChange has no scopable resource; the zone-scoped DNSSEC actions are restricted to hostedzone/* (this account has a single zone). Documented exception.
   statement {
     sid    = "ManageZoneDNSSEC"
     effect = "Allow"
@@ -244,15 +243,16 @@ data "aws_iam_policy_document" "dnssec_management" {
     resources = ["arn:aws:route53:::hostedzone/*"]
   }
   statement {
+    # Provider polls change status after enabling/disabling signing.
+    # GetChange supports the change resource type, so scope it rather than "*".
     sid       = "ReadChangeStatus"
     effect    = "Allow"
     actions   = ["route53:GetChange"]
-    resources = ["*"]
+    resources = ["arn:aws:route53:::change/*"]
   }
 }
 
 resource "aws_iam_role_policy" "dnssec_management" {
-  # checkov:skip=CKV_AWS_356:route53:GetChange cannot be resource-scoped; zone DNSSEC actions scoped to hostedzone/*. Documented exception.
   name   = "dnssec-management"
   role   = aws_iam_role.deploy.id
   policy = data.aws_iam_policy_document.dnssec_management.json

--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -224,6 +224,40 @@ resource "aws_iam_role_policy" "compliance_kms" {
   policy = data.aws_iam_policy_document.compliance_kms.json
 }
 
+# Route 53 DNSSEC management for the deploy role (Task 5 PR B / D-3): create the
+# key-signing key and enable/disable zone signing. KMS create/manage for the KSK
+# is already covered by the role's account-wide kms:CreateKey/PutKeyPolicy grant.
+data "aws_iam_policy_document" "dnssec_management" {
+  # checkov:skip=CKV_AWS_356:route53:GetChange has no scopable resource; the zone-scoped DNSSEC actions are restricted to hostedzone/* (this account has a single zone). Documented exception.
+  statement {
+    sid    = "ManageZoneDNSSEC"
+    effect = "Allow"
+    actions = [
+      "route53:CreateKeySigningKey",
+      "route53:DeleteKeySigningKey",
+      "route53:ActivateKeySigningKey",
+      "route53:DeactivateKeySigningKey",
+      "route53:GetDNSSEC",
+      "route53:EnableHostedZoneDNSSEC",
+      "route53:DisableHostedZoneDNSSEC",
+    ]
+    resources = ["arn:aws:route53:::hostedzone/*"]
+  }
+  statement {
+    sid       = "ReadChangeStatus"
+    effect    = "Allow"
+    actions   = ["route53:GetChange"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "dnssec_management" {
+  # checkov:skip=CKV_AWS_356:route53:GetChange cannot be resource-scoped; zone DNSSEC actions scoped to hostedzone/*. Documented exception.
+  name   = "dnssec-management"
+  role   = aws_iam_role.deploy.id
+  policy = data.aws_iam_policy_document.dnssec_management.json
+}
+
 output "github_actions_role_arn" {
   value       = aws_iam_role.deploy.arn
   description = "Set as the workflow's aws-actions/configure-aws-credentials role-to-assume."

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -492,6 +492,84 @@ resource "aws_kms_alias" "runtime_signing" {
   target_key_id = aws_kms_key.runtime_signing.key_id
 }
 
+# =============================================================================
+# DNSSEC (D-3)
+# =============================================================================
+# Signs the hosted zone so resolvers can authenticate DNS answers for the domain.
+# Route 53 DNSSEC requires the key-signing key (KSK) to be a customer-managed
+# asymmetric ECC_NIST_P256 key IN us-east-1, with a key policy that lets the
+# Route 53 DNSSEC service use it. Enabling zone signing is safe without the parent
+# DS record (validators treat the zone as unsigned until the DS is published); the
+# DS record is emitted as an output and published at the registrar as a separate,
+# operator-gated step. All gated on manage_dns.
+resource "aws_kms_key" "dnssec_ksk" {
+  count                    = var.manage_dns ? 1 : 0
+  provider                 = aws.us_east_1
+  description              = "DNSSEC key-signing key for ${var.domain_name} (D-3)"
+  customer_master_key_spec = "ECC_NIST_P256"
+  key_usage                = "SIGN_VERIFY"
+  deletion_window_in_days  = 7
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "EnableIAMUserPermissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "AllowRoute53DNSSECService"
+        Effect    = "Allow"
+        Principal = { Service = "dnssec-route53.amazonaws.com" }
+        Action    = ["kms:DescribeKey", "kms:GetPublicKey", "kms:Sign"]
+        Resource  = "*"
+      },
+      {
+        Sid       = "AllowRoute53DNSSECCreateGrant"
+        Effect    = "Allow"
+        Principal = { Service = "dnssec-route53.amazonaws.com" }
+        Action    = "kms:CreateGrant"
+        Resource  = "*"
+        Condition = { Bool = { "kms:GrantIsForAWSResource" = "true" } }
+      },
+    ]
+  })
+
+  tags = {
+    Name               = "${var.domain_name}-dnssec-ksk"
+    Environment        = var.environment
+    DataClassification = "Internal"
+    Owner              = var.owner
+  }
+}
+
+resource "aws_kms_alias" "dnssec_ksk" {
+  count         = var.manage_dns ? 1 : 0
+  provider      = aws.us_east_1
+  name          = "alias/${replace(var.domain_name, ".", "-")}-dnssec-ksk"
+  target_key_id = aws_kms_key.dnssec_ksk[0].key_id
+}
+
+resource "aws_route53_key_signing_key" "this" {
+  count                      = var.manage_dns ? 1 : 0
+  hosted_zone_id             = data.aws_route53_zone.website[0].zone_id
+  key_management_service_arn = aws_kms_key.dnssec_ksk[0].arn
+  name                       = "${replace(var.domain_name, ".", "_")}_ksk"
+  status                     = "ACTIVE"
+}
+
+# Turns on zone signing (ServeSignature = SIGNING). Safe without a parent DS
+# record. To DISABLE later, remove the DS at the registrar first, wait the TTL,
+# then disable signing — otherwise resolvers that cached the DS will fail.
+resource "aws_route53_hosted_zone_dnssec" "this" {
+  count          = var.manage_dns ? 1 : 0
+  hosted_zone_id = data.aws_route53_zone.website[0].zone_id
+  depends_on     = [aws_route53_key_signing_key.this]
+}
+
 # Explicit, customer-CMK-encrypted log group for the compliance Lambda (POAM-018)
 # with an explicit Moderate retention. Lambda would otherwise auto-create this
 # group unencrypted; it already exists, so the deploy imports it before apply.

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -63,6 +63,24 @@ output "route53_name_servers" {
   value       = var.manage_dns ? data.aws_route53_zone.website[0].name_servers : []
 }
 
+# DNSSEC DS record to publish at the registrar (D-3). Until this is published in
+# the parent (.com) zone, the zone is signed but resolvers do not validate it.
+output "dnssec_ds_record" {
+  description = "DS record to publish at the registrar to complete the DNSSEC chain of trust"
+  value       = var.manage_dns ? aws_route53_key_signing_key.this[0].ds_record : "DNS not managed"
+}
+
+output "dnssec_ksk_details" {
+  description = "Key-signing-key fields for the registrar's 'add DNSSEC key' form (flag, algorithm, public key)"
+  value = var.manage_dns ? {
+    flag                       = aws_route53_key_signing_key.this[0].flag
+    signing_algorithm_mnemonic = aws_route53_key_signing_key.this[0].signing_algorithm_mnemonic
+    digest_algorithm_mnemonic  = aws_route53_key_signing_key.this[0].digest_algorithm_mnemonic
+    public_key                 = aws_route53_key_signing_key.this[0].public_key
+    ds_record                  = aws_route53_key_signing_key.this[0].ds_record
+  } : null
+}
+
 # The SSL certificate that secures my website
 output "ssl_certificate_arn" {
   description = "ARN of the existing SSL certificate"


### PR DESCRIPTION
SCN-Type: Routine Recurring

## Changed
Signs the hosted zone so resolvers can authenticate DNS answers for the domain (D-3). Route 53 DNSSEC requires a customer-managed asymmetric **ECC_NIST_P256** key-signing key in **us-east-1** whose policy lets the Route 53 DNSSEC service use it.

- New `aws_kms_key.dnssec_ksk` (us-east-1, ECC_NIST_P256, SIGN_VERIFY) + alias; key policy grants `dnssec-route53.amazonaws.com` `Sign`/`GetPublicKey`/`DescribeKey` + `CreateGrant` (`GrantIsForAWSResource`).
- `aws_route53_key_signing_key` + `aws_route53_hosted_zone_dnssec` turn on signing (`ServeSignature = SIGNING`). Gated on `manage_dns`.
- Outputs the **DS record** + KSK fields for the registrar step.
- Deploy role gains a scoped `dnssec-management` policy (Route 53 KSK + zone-DNSSEC actions on `hostedzone/*`, `GetChange` on `*`) — applied live and recorded in `bootstrap`.
- DNSSEC resources added to the workflow import step (ephemeral state).

**Enabling zone signing without the parent DS record is safe** — validators treat the zone as unsigned until the DS is published, so there is **no resolution impact**. Publishing the DS at the registrar is a separate, operator-gated step.

## Verified
- `terraform fmt` + `terraform validate` pass (infra + bootstrap).
- Deploy-role `dnssec-management` grant confirmed applied live.

## Couldn't verify until merge
- The live zone signing. On merge I'll confirm `aws route53 get-dnssec` → `SIGNING`, check `dig +dnssec DNSKEY samaydlette.com` returns DNSKEY + RRSIG, and capture the DS-record output — then walk through publishing the DS (the domain is registered via Route 53, so it's done in the console under Registered domains → DNSSEC keys). **I will not publish the DS** until you confirm the zone is signing healthily.