### PR TITLE
Task 5 (PR B fix): KSK caller KMS perms + robust DNSSEC import

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -474,12 +474,18 @@ jobs:
         # recreated each run. All are no-ops on the first deploy (created then).
         if aws kms describe-key --region us-east-1 --key-id alias/samaydlette-com-dnssec-ksk >/dev/null 2>&1; then
           DNSSEC_KEY_ID=$(aws kms describe-key --region us-east-1 --key-id alias/samaydlette-com-dnssec-ksk --query 'KeyMetadata.KeyId' --output text)
-          ZONE_ID=$(aws route53 list-hosted-zones-by-name --dns-name samaydlette.com --query 'HostedZones[0].Id' --output text | sed 's#/hostedzone/##')
+          # Resolve the zone via list-hosted-zones (the deploy role has this; it
+          # does not have ListHostedZonesByName).
+          ZONE_ID=$(aws route53 list-hosted-zones --query "HostedZones[?Name=='samaydlette.com.'].Id | [0]" --output text | sed 's#/hostedzone/##')
           echo "DNSSEC KSK exists ($DNSSEC_KEY_ID), zone $ZONE_ID"
           terraform state show 'aws_kms_key.dnssec_ksk[0]' >/dev/null 2>&1 || terraform import 'aws_kms_key.dnssec_ksk[0]' "$DNSSEC_KEY_ID"
           terraform state show 'aws_kms_alias.dnssec_ksk[0]' >/dev/null 2>&1 || terraform import 'aws_kms_alias.dnssec_ksk[0]' "alias/samaydlette-com-dnssec-ksk"
-          terraform state show 'aws_route53_key_signing_key.this[0]' >/dev/null 2>&1 || terraform import 'aws_route53_key_signing_key.this[0]' "${ZONE_ID},samaydlette_com_ksk"
-          terraform state show 'aws_route53_hosted_zone_dnssec.this[0]' >/dev/null 2>&1 || terraform import 'aws_route53_hosted_zone_dnssec.this[0]' "$ZONE_ID"
+          # The KSK and zone-signing association may not exist yet (created on the
+          # run that first enables signing), so tolerate a failed import.
+          if [ -n "$ZONE_ID" ] && [ "$ZONE_ID" != "None" ]; then
+            terraform state show 'aws_route53_key_signing_key.this[0]' >/dev/null 2>&1 || terraform import 'aws_route53_key_signing_key.this[0]' "${ZONE_ID},samaydlette_com_ksk" || echo "KSK not created yet - will be created"
+            terraform state show 'aws_route53_hosted_zone_dnssec.this[0]' >/dev/null 2>&1 || terraform import 'aws_route53_hosted_zone_dnssec.this[0]' "$ZONE_ID" || echo "zone signing not enabled yet - will be enabled"
+          fi
           echo "✅ DNSSEC resources imported (where present)"
         else
           echo "No existing DNSSEC KSK found - will be created"

--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -250,6 +250,20 @@ data "aws_iam_policy_document" "dnssec_management" {
     actions   = ["route53:GetChange"]
     resources = ["arn:aws:route53:::change/*"]
   }
+  statement {
+    # CreateKeySigningKey requires the *caller* (not just the key policy) to hold
+    # these KMS actions on the KSK. Scoped to us-east-1 KMS keys, where Route 53
+    # DNSSEC keys must live and the only SIGN_VERIFY key is the DNSSEC KSK.
+    sid    = "UseKskForDNSSEC"
+    effect = "Allow"
+    actions = [
+      "kms:DescribeKey",
+      "kms:GetPublicKey",
+      "kms:Sign",
+      "kms:CreateGrant",
+    ]
+    resources = ["arn:aws:kms:us-east-1:${data.aws_caller_identity.current.account_id}:key/*"]
+  }
 }
 
 resource "aws_iam_role_policy" "dnssec_management" {


### PR DESCRIPTION
SCN-Type: Routine Recurring

Fixes the failed DNSSEC deploy from #118 (two issues, both surfaced live).

## Changed
1. **`CreateKeySigningKey` rejected the KSK** — AWS requires the *caller* (the deploy role), not just the key policy, to hold `kms:DescribeKey`/`GetPublicKey`/`Sign`/`CreateGrant` on the key. (The key policy was already correct — verified live.) Added those to the deploy role's `dnssec-management` policy, **scoped to us-east-1 KMS keys** (`key/*` in that region — where Route 53 DNSSEC keys must live, and the only SIGN_VERIFY key there is the KSK; no bare `*`). Applied live and recorded in bootstrap.
2. **Import step robustness** — it used `route53:ListHostedZonesByName` (which the role lacks) to resolve the zone id, and imported the KSK / zone-signing association unconditionally even though they don't exist until signing is first enabled. Now resolves the zone via `list-hosted-zones` (granted) and tolerates the not-yet-created imports.

## Verified
- `terraform fmt` + `validate` pass (bootstrap).
- The KSK key policy already grants `dnssec-route53.amazonaws.com` the required actions (confirmed live); the gap was purely caller-side.
- Live `dnssec-management` grant updated.

## Couldn't verify until merge
- The full DNSSEC apply. On merge I'll confirm the KSK is created, `aws route53 get-dnssec` → `SIGNING`, and `dig +dnssec` returns the keys — then hand you the DS record for the Route 53 registrar step.