### PR TITLE
Task 7 (PR A): 1-year log retention + API Gateway access logging (POAM-017, POAM-024)

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -58,8 +58,8 @@ skip-check:
   # POAM-015 — Lambda zip not signed via AWS Signer (SI-7, SA-12). Source-level Sigstore signing in place. Risk-adjusted to Low.
   - CKV_AWS_272
 
-  # POAM-017 — CloudWatch log retention < 1 year (AU-11). 7-day retention; operational debug logs only, no PII.
-  - CKV_AWS_338
+  # POAM-017 CLOSED (Task 7) — every log group now has 365-day retention (AU-11);
+  # CKV_AWS_338 passes on its own, so the skip is removed.
 
   # POAM-018 CLOSED (Task 6) — every CloudWatch log group is now encrypted with a
   # customer-managed CMK (compliance Lambda + route53 query logs → at_rest CMK;
@@ -79,8 +79,6 @@ skip-check:
   # without valid credentials. Risk-accepted.
   - CKV_AWS_309
 
-  # POAM-024 — API Gateway HTTP API access logging not enabled (AU-2, AU-3).
-  # HTTP API access logs require a CloudWatch Logs delivery resource-policy; the
-  # Lambda's own execution log group plus CloudFront access logs provide request
-  # coverage in the interim. Planned enhancement; risk-adjusted to Low.
-  - CKV_AWS_76
+  # POAM-024 CLOSED (Task 7) — the HTTP API stage now emits access logs to a
+  # CMK-encrypted CloudWatch log group (with the required delivery resource
+  # policy); CKV_AWS_76 passes on its own, so the skip is removed.

--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -668,6 +668,8 @@ jobs:
           import_silk 'aws_iam_role_policy.silk_reeling[0]' 'samaydlette-com-silk-reeling-role:samaydlette-com-silk-reeling-policy'
         aws logs describe-log-groups --log-group-name-prefix /aws/lambda/samaydlette-com-silk-reeling --query 'logGroups[0].logGroupName' --output text 2>/dev/null | grep -q silk-reeling && \
           import_silk 'aws_cloudwatch_log_group.silk_reeling[0]' '/aws/lambda/samaydlette-com-silk-reeling'
+        aws logs describe-log-groups --log-group-name-prefix /aws/apigateway/samaydlette-com-silk-reeling --query 'logGroups[0].logGroupName' --output text 2>/dev/null | grep -q silk-reeling && \
+          import_silk 'aws_cloudwatch_log_group.silk_apigw[0]' '/aws/apigateway/samaydlette-com-silk-reeling'
         aws secretsmanager describe-secret --secret-id samaydlette-com-silk-reeling-basic-auth >/dev/null 2>&1 && \
           import_silk 'aws_secretsmanager_secret.silk_basic_auth[0]' 'samaydlette-com-silk-reeling-basic-auth'
         aws secretsmanager describe-secret --secret-id samaydlette-com-silk-reeling-anthropic-api-key >/dev/null 2>&1 && \

--- a/docs/poam.md
+++ b/docs/poam.md
@@ -26,7 +26,7 @@ Status values: **Open** · **In progress** · **Closed** · **Risk-accepted**.
 
 ## Configuration Findings (POAM-003 through POAM-018)
 
-Configuration Findings are findings about how software and infrastructure are configured, surfaced by IaC and configuration scanners (Checkov, tfsec) rather than by vulnerability scanners. They are tracked as POA&M items but live on a separate tab in the FedRAMP Excel template because the lifecycle is different from vulnerability findings. Each entry below is either a Checkov-reported configuration weakness or an explicit architectural decision; all are risk-accepted with documented rationale **except POAM-011 and POAM-018, which were closed under Task 6** (see closure note below the table).
+Configuration Findings are findings about how software and infrastructure are configured, surfaced by IaC and configuration scanners (Checkov, tfsec) rather than by vulnerability scanners. They are tracked as POA&M items but live on a separate tab in the FedRAMP Excel template because the lifecycle is different from vulnerability findings. Each entry below is either a Checkov-reported configuration weakness or an explicit architectural decision; all are risk-accepted with documented rationale **except POAM-011 and POAM-018 (closed under Task 6) and POAM-017 and POAM-024 (closed under Task 7)** (see closure notes below the table).
 
 The source of truth for the rationale is the inline `#checkov:skip=ID:reason` annotation in `infrastructure/main.tf` (or, for POAM-016, the architectural decision record in [`docs/recovery-plan.md`](recovery-plan.md)). All entries have been evaluated per VDR-EVA-* (PAIN N1-N5, internet-reachability, likely-exploitability) and carry the corresponding `VDR-RPT-AVI` fields in the published `/.well-known/vdr-report.json`. None is in CISA KEV.
 
@@ -41,14 +41,14 @@ The source of truth for the rationale is the inline `#checkov:skip=ID:reason` an
 | POAM-012 | SC-5 | Lambda concurrent execution limit not set | Checkov | CKV_AWS_115 | aws-lambda::compliance-monitor | N1 | Low | — | No | Risk-accepted |
 | POAM-013 | SI-4 | Lambda DLQ not configured | Checkov | CKV_AWS_116 | aws-lambda::compliance-monitor | N1 | Low | — | No | Risk-accepted |
 | POAM-015 | SI-7, SA-12 | Lambda zip not signed via AWS Signer | Checkov | CKV_AWS_272 | aws-lambda::compliance-monitor | N2 | Moderate | Low | Yes | Risk-accepted |
-| POAM-017 | AU-11 | CloudWatch log retention < 1 year (7-day retention) | Checkov | CKV_AWS_338 | aws-cloudwatch-log-group | N1 | Low | — | No | Risk-accepted |
+| POAM-017 | AU-11 | CloudWatch log retention < 1 year (7-day retention) | Checkov | CKV_AWS_338 | aws-cloudwatch-log-group | N1 | Low | — | No | Closed (Task 7) |
 | POAM-018 | SC-28 | CloudWatch log group not customer-key encrypted | Checkov | CKV_AWS_158 | aws-cloudwatch-log-group | N1 | Low | — | No | Closed (Task 6) |
 | POAM-019 | SC-12, SC-28 | Secrets Manager automatic rotation not enabled | Checkov | CKV2_AWS_57 | aws-secretsmanager::silk-reeling | N2 | Moderate | Low | Yes | Risk-accepted |
 | POAM-020 | SA-9, CA-3 | Interconnection with Anthropic API (non-FedRAMP-authorized external service) | Architectural decision | silk-reeling-deploy.md | interconnection::anthropic-api | N2 | Moderate | Low | Yes | Risk-accepted |
 | POAM-021 | IA-2(2), AC-7 | App access via single-factor shared-credential HTTP Basic Auth (no MFA, no lockout) | Architectural decision | silk-reeling-deploy.md | silk-reeling::access-control | N2 | Moderate | Low | Yes | Risk-accepted |
 | POAM-022 | IA-2, AC-3 | API Gateway HTTP API route specifies no authorizer (app-layer Basic Auth is the access control) | Checkov | CKV_AWS_309 | aws-apigatewayv2::silk-reeling | N2 | Moderate | Low | Yes | Risk-accepted |
 | POAM-023 | AC-7, SC-5 | No brute-force / rate-limit protection on the Basic Auth endpoint (no lockout, no WAF) | Security review | security-review.md | silk-reeling::access-control | N2 | Moderate | Low | Yes | Risk-accepted |
-| POAM-024 | AU-2, AU-3 | API Gateway HTTP API access logging not enabled | Checkov | CKV_AWS_76 | aws-apigatewayv2::silk-reeling | N1 | Low | — | No | Risk-accepted |
+| POAM-024 | AU-2, AU-3 | API Gateway HTTP API access logging not enabled | Checkov | CKV_AWS_76 | aws-apigatewayv2::silk-reeling | N1 | Low | — | No | Closed (Task 7) |
 
 **POAM-011 and POAM-018 closed (Task 6, 2026-06-16) — encryption-consistency remediation.** Both were risk-accepted on the rationale that the contents were non-sensitive and AWS-default encryption sufficed. Rather than carry them as standing acceptances, the system was brought to a single at-rest standard: *every* Lambda environment block and *every* CloudWatch log group is now encrypted with a customer-managed CMK. Specifically — the compliance Lambda's environment and log group use a new `aws_kms_key.at_rest` CMK; the route53 query-log group (when enabled) uses the same CMK; and the silk-reeling Lambda's environment uses the existing `aws_kms_key.silk_reeling` CMK (its role already held `kms:Decrypt` on that key). With no Lambda env or log group left unencrypted, the global Checkov suppressions for `CKV_AWS_173` and `CKV_AWS_158` were **removed** from `.checkov.yaml` — the checks now pass on their own, so the remediation is enforced by the gate rather than asserted. The website S3 bucket remains on SSE-S3 (AES-256, AWS-managed keys) by deliberate decision: it holds only public static content and persists no user data, so a customer CMK there would add cost and key-management burden without protecting anything sensitive (the app's pose extraction is client-side; nothing is stored at rest).
 
@@ -130,14 +130,16 @@ rate-based rule to the CloudFront distribution, or add an API Gateway usage-plan
 throttle; deferred on cost (~$120/yr WAF, consistent with POAM-007). Applies only
 while the app is deployed.
 
-**POAM-024 (API Gateway access logging not enabled):** The HTTP API stage does not
-emit access logs (Checkov CKV_AWS_76). HTTP API access logging requires a CloudWatch
-Logs delivery resource-policy that this deployment does not yet provision; the
-Lambda's own execution log group (`/aws/lambda/samaydlette-com-silk-reeling`) and
-CloudFront access logs provide request-level coverage in the interim. Risk-adjusted
-Low (operational observability, not an access-control gap). **Remediation:** add the
-delivery resource-policy and a stage `access_log_settings` block. Applies only while
-the app is deployed.
+**POAM-017 and POAM-024 closed (Task 7) — audit logging + retention.** *POAM-017:*
+every CloudWatch log group now has 365-day retention (AU-11) — the route53 query-log
+and silk-reeling Lambda groups were raised from 7 days; the compliance group was
+already 365 (Task 6). *POAM-024:* the silk-reeling HTTP API stage now emits one JSON
+access-log line per request to a new CMK-encrypted, 365-day log group
+(`/aws/apigateway/samaydlette-com-silk-reeling`), authorized by a scoped CloudWatch
+Logs delivery resource policy. With these in place the global `CKV_AWS_338` and
+`CKV_AWS_76` suppressions were **removed** from `.checkov.yaml`, so both checks now
+pass on their own. (Website S3 server access logging, POAM-005, and CloudFront access
+logging close separately under Task 7.)
 
 **Standard fields for all of POAM-003 through POAM-018:**
 

--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -161,6 +161,7 @@ locals {
 # Manage the compliance Lambda + route53 query log groups (tags, retention, KMS
 # association). Scoped to exactly those two log-group ARNs — least privilege.
 data "aws_iam_policy_document" "compliance_logs" {
+  # checkov:skip=CKV_AWS_356:logs:PutResourcePolicy/DescribeResourcePolicies are account-level actions that do not support resource-level scoping; the log-group management statement is ARN-scoped. Documented exception.
   statement {
     effect = "Allow"
     actions = [
@@ -180,11 +181,22 @@ data "aws_iam_policy_document" "compliance_logs" {
       "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.domain_dashed}-opa-compliance*",
       "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/route53/${var.domain_name}*",
       "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.domain_dashed}-silk-reeling*",
+      "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/${local.domain_dashed}-silk-reeling*",
     ]
+  }
+  statement {
+    # API Gateway access logging needs an account log-resource-policy granting the
+    # logs delivery service. These actions are account-level and do not support
+    # resource scoping.
+    sid       = "ManageApiGwLogResourcePolicy"
+    effect    = "Allow"
+    actions   = ["logs:PutResourcePolicy", "logs:DeleteResourcePolicy", "logs:DescribeResourcePolicies"]
+    resources = ["*"]
   }
 }
 
 resource "aws_iam_role_policy" "compliance_logs" {
+  # checkov:skip=CKV_AWS_356:logs:PutResourcePolicy is account-level and cannot be resource-scoped; log-group actions are ARN-scoped. Documented exception.
   name   = "compliance-logs-management"
   role   = aws_iam_role.deploy.id
   policy = data.aws_iam_policy_document.compliance_logs.json

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -242,7 +242,7 @@ resource "aws_s3_bucket_policy" "website" {
 resource "aws_cloudwatch_log_group" "route53_query_log" {
   count             = var.manage_dns && var.enable_route53_logging ? 1 : 0
   name              = "/aws/route53/${var.domain_name}"
-  retention_in_days = 7
+  retention_in_days = 365                     # 1-year retention (AU-11, POAM-017)
   kms_key_id        = aws_kms_key.at_rest.arn # customer-CMK at rest (POAM-018)
 
   tags = {

--- a/infrastructure/silk-reeling.tf
+++ b/infrastructure/silk-reeling.tf
@@ -84,9 +84,10 @@ resource "aws_kms_key" "silk_reeling" {
         }
       },
       {
-        # Allow CloudWatch Logs to encrypt this app's log group at rest with this
+        # Allow CloudWatch Logs to encrypt this app's log groups at rest with this
         # CMK (POAM-018). Scoped via EncryptionContext to exactly the silk-reeling
-        # log group, so the grant cannot be used for any other log group.
+        # Lambda + API Gateway access log groups, so the grant cannot be used for
+        # any other log group.
         Sid       = "AllowCloudWatchLogs"
         Effect    = "Allow"
         Principal = { Service = "logs.${var.aws_region}.amazonaws.com" }
@@ -94,7 +95,10 @@ resource "aws_kms_key" "silk_reeling" {
         Resource  = "*"
         Condition = {
           ArnLike = {
-            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.silk_name}"
+            "kms:EncryptionContext:aws:logs:arn" = [
+              "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.silk_name}",
+              "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/apigateway/${local.silk_name}",
+            ]
           }
         }
       },
@@ -197,7 +201,7 @@ resource "aws_iam_role_policy" "silk_reeling" {
 resource "aws_cloudwatch_log_group" "silk_reeling" {
   count             = local.silk_create
   name              = "/aws/lambda/${local.silk_name}"
-  retention_in_days = 7
+  retention_in_days = 365                             # 1-year retention (AU-11, POAM-017)
   kms_key_id        = aws_kms_key.silk_reeling[0].arn # customer-CMK at rest (POAM-018)
 
   tags = merge(local.silk_tags, { Name = "${var.domain_name}-silk-reeling-logs" })
@@ -284,15 +288,61 @@ resource "aws_apigatewayv2_route" "silk_reeling" {
   target    = "integrations/${aws_apigatewayv2_integration.silk_reeling[0].id}"
 }
 
+# Access-log group for the HTTP API stage (POAM-024). CMK-encrypted + 1-year
+# retention, consistent with the rest of the system.
+resource "aws_cloudwatch_log_group" "silk_apigw" {
+  count             = local.silk_create
+  name              = "/aws/apigateway/${local.silk_name}"
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.silk_reeling[0].arn
+
+  tags = merge(local.silk_tags, { Name = "${var.domain_name}-silk-reeling-apigw-logs" })
+}
+
+# HTTP API access logging delivers to CloudWatch Logs via the logs delivery
+# service, which requires an account log-resource-policy granting it write access
+# to the destination group. Scoped to exactly this access-log group.
+resource "aws_cloudwatch_log_resource_policy" "silk_apigw" {
+  count       = local.silk_create
+  policy_name = "${local.silk_name}-apigw-access-logs"
+  policy_document = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = ["delivery.logs.amazonaws.com", "apigateway.amazonaws.com"] }
+        Action    = ["logs:CreateLogStream", "logs:PutLogEvents"]
+        Resource  = "${aws_cloudwatch_log_group.silk_apigw[0].arn}:*"
+        Condition = { StringEquals = { "aws:SourceAccount" = data.aws_caller_identity.current.account_id } }
+      },
+    ]
+  })
+}
+
 resource "aws_apigatewayv2_stage" "silk_reeling" {
   count       = local.silk_create
   api_id      = aws_apigatewayv2_api.silk_reeling[0].id
   name        = "$default"
   auto_deploy = true
 
-  # Access logging deferred (POAM-024): HTTP API access logs need a CloudWatch
-  # Logs delivery resource-policy; Lambda execution logs + CloudFront logs give
-  # partial coverage until then.
+  # Access logging (POAM-024): one JSON line per request to the CMK-encrypted
+  # access-log group. depends_on the resource policy so the delivery service is
+  # authorized before the stage starts emitting.
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.silk_apigw[0].arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      routeKey       = "$context.routeKey"
+      status         = "$context.status"
+      protocol       = "$context.protocol"
+      responseLength = "$context.responseLength"
+    })
+  }
+
+  depends_on = [aws_cloudwatch_log_resource_policy.silk_apigw]
 
   tags = merge(local.silk_tags, { Name = "${var.domain_name}-silk-reeling-api-stage" })
 }

--- a/scripts/build-oscal-poam.py
+++ b/scripts/build-oscal-poam.py
@@ -249,11 +249,12 @@ POAM_ITEMS = [
     {
         "id": "POAM-017", "controls": ["au-11"],
         "title": "CloudWatch log retention shorter than 1 year (7-day retention)",
-        "description": "7-day CloudWatch log retention is intentional. Logs are operational debug content, contain no PII, and have no security-correlation requirement that depends on >7-day retention for a sole-operator system. Anything older than a week is not actionable for IR. Cost-driven; deliberate scope decision documented in AU-1 policy.",
+        "description": "Closed under Task 7 (2026-06-18): every CloudWatch log group now has 365-day retention (AU-11). The route53 query-log and silk-reeling Lambda groups were raised from 7 days; the compliance group was already 365 (Task 6). The global CKV_AWS_338 Checkov suppression was removed; the check passes on its own.",
         "weakness_detector_source": "Checkov", "weakness_source_identifier": "CKV_AWS_338",
         "asset_identifiers": ["aws-cloudwatch-log-group::route53-query-log", "aws-cloudwatch-log-group::lambda-execution"],
         "original_risk_rating": "low", "adjusted_risk_rating": None, "risk_adjustment": False,
-        "status": "risk-accepted", "category": "configuration",
+        "status_date": "2026-06-18",
+        "status": "closed", "category": "closed",
     },
     {
         "id": "POAM-018", "controls": ["sc-28"],

--- a/scripts/build-vdr-report.py
+++ b/scripts/build-vdr-report.py
@@ -67,12 +67,11 @@ POAM_BY_CHECK_ID = {
     "CKV_AWS_115": "POAM-012",
     "CKV_AWS_116": "POAM-013",
     "CKV_AWS_272": "POAM-015",  # Lambda code-signing validation
-    "CKV_AWS_338": "POAM-017",  # CloudWatch log retention < 1 year
-    # CKV_AWS_158 (POAM-018) closed under Task 6 — suppression removed from
-    # .checkov.yaml; every CloudWatch log group is now customer-CMK encrypted.
+    # CKV_AWS_338 (POAM-017) + CKV_AWS_158 (POAM-018) closed — suppressions removed
+    # from .checkov.yaml (Task 7 retention; Task 6 CMK encryption).
     "CKV2_AWS_57": "POAM-019",  # Secrets Manager automatic rotation not enabled
     "CKV_AWS_309": "POAM-022",  # API Gateway route specifies no authorizer
-    "CKV_AWS_76":  "POAM-024",  # API Gateway access logging not enabled
+    # CKV_AWS_76 (POAM-024) closed under Task 7 — HTTP API access logging enabled.
 }
 
 # Per-suppression PAIN/IRV/LEV evaluations from docs/poam.md (kept in sync with
@@ -87,10 +86,8 @@ SUPPRESSION_EVALUATION = {
     "CKV_AWS_115": {"pain": "N1", "irv": False, "lev": False},
     "CKV_AWS_116": {"pain": "N1", "irv": False, "lev": False},
     "CKV_AWS_272": {"pain": "N2", "irv": False, "lev": False},
-    "CKV_AWS_338": {"pain": "N1", "irv": False, "lev": False},
     "CKV2_AWS_57": {"pain": "N1", "irv": False, "lev": False},
     "CKV_AWS_309": {"pain": "N2", "irv": True,  "lev": False},
-    "CKV_AWS_76":  {"pain": "N1", "irv": False, "lev": False},
 }
 
 # Rationale per suppressed check, mirrored from .checkov.yaml comments and the
@@ -104,10 +101,8 @@ SUPPRESSION_RATIONALE = {
     "CKV_AWS_115": "Daily EventBridge invocation; no concurrent invocations realistic. Cost-control limit not required.",
     "CKV_AWS_116": "Daily idempotent run; failures are recoverable on the next day's invocation. DLQ adds cost for marginal observability benefit.",
     "CKV_AWS_272": "Source-level signing chain in place: deploy-time KSI signal is Sigstore-signed; Wasm policy bytes are verifiable via the canonical inventory's content hash. AWS Signer adds defense-in-depth at marginal cost; not currently justified.",
-    "CKV_AWS_338": "7-day retention; operational debug logs only, no PII. Anything older than a week is not actionable for sole-operator IR.",
     "CKV2_AWS_57": "The two Silk Reeling app secrets (a third-party Anthropic API key and an operator-set basic-auth credential) have no programmatic rotation source; rotated manually via put-secret-value. Mooted once the secrets are removed (Tasks 3-4).",
     "CKV_AWS_309": "Access control is enforced at the application layer; the API fronts a Lambda whose middleware rejects any request without valid credentials. Remediated by the Cognito JWT authorizer (Task 3).",
-    "CKV_AWS_76":  "HTTP API access logs require a CloudWatch Logs delivery resource-policy; the Lambda execution log group plus CloudFront access logs cover requests in the interim. Remediated by enabling API Gateway access logging (Task 3).",
 }
 
 # Read .checkov.yaml as YAML if PyYAML is available; fall back to a forgiving


### PR DESCRIPTION
SCN-Type: Routine Recurring

First of two Task 7 PRs (the in-Terraform logging fixes). PR B adds S3 server access logging + the log bucket; CloudFront access logging (C-3) follows out-of-band.

## Changed
**POAM-017 (AU-11) — log retention.** The route53 query-log and silk-reeling Lambda groups go from 7-day to **365-day** retention. Every log group is now ≥ 1 year (the compliance group was already 365 from Task 6), so the global `CKV_AWS_338` suppression is **removed**.

**POAM-024 (AU-2/AU-3) — API Gateway access logging.** The silk HTTP API stage now emits one JSON access-log line per request to a new **CMK-encrypted, 365-day** log group (`/aws/apigateway/…-silk-reeling`), authorized by a scoped CloudWatch Logs delivery resource policy. The silk CMK key policy's logs grant is extended to the new group; the global `CKV_AWS_76` suppression is **removed**.

- Deploy role: `compliance-logs-management` extended to the apigw log group + account-level `logs:PutResourcePolicy`/`DescribeResourcePolicies` (these don't support resource scoping — documented `CKV_AWS_356` exception, same class as the existing `reconcile_reads` policy). Applied live + recorded in bootstrap.
- Ephemeral state: apigw log group added to the workflow import step.
- POAM-017/024 closed in `docs/poam.md`; POAM-017 closed in the OSCAL generator; stale `CKV_AWS_338`/`76` entries removed from the VDR builder maps.

## Verified
- `terraform fmt` + `validate` (infra + bootstrap), `py_compile`, `validate-locally.sh` **12/12** (VDR risk-accepted 12 → 10), reconcile gate green.
- CodeGuard self-review: no secrets/hardcoded IDs; new perms least-privilege/ARN-scoped except the un-scopable account-level logs actions.

## Couldn't verify until merge
- Live: API Gateway access logs actually flowing. On merge I'll invoke the silk API and confirm an access-log entry lands in `/aws/apigateway/…-silk-reeling`, and confirm `retention_in_days = 365` on the groups. The one likely first-deploy snag (per Tasks 5/6 pattern) is the exact resource-policy principal for HTTP API log delivery — I'll fix-forward if the logs don't appear.