### PR TITLE
Task 7 (PR A fix): vended-log-delivery perms for API Gateway access logging

### DIFF
--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -185,12 +185,17 @@ data "aws_iam_policy_document" "compliance_logs" {
     ]
   }
   statement {
-    # API Gateway access logging needs an account log-resource-policy granting the
-    # logs delivery service. These actions are account-level and do not support
-    # resource scoping.
-    sid       = "ManageApiGwLogResourcePolicy"
-    effect    = "Allow"
-    actions   = ["logs:PutResourcePolicy", "logs:DeleteResourcePolicy", "logs:DescribeResourcePolicies"]
+    # HTTP API (and CloudFront) access logging deliver through the CloudWatch Logs
+    # vended-logs path, so the deploy role needs the log-resource-policy + the
+    # log-delivery actions. All are account-level and do not support resource
+    # scoping.
+    sid    = "ManageVendedLogDelivery"
+    effect = "Allow"
+    actions = [
+      "logs:PutResourcePolicy", "logs:DeleteResourcePolicy", "logs:DescribeResourcePolicies",
+      "logs:CreateLogDelivery", "logs:GetLogDelivery", "logs:UpdateLogDelivery",
+      "logs:DeleteLogDelivery", "logs:ListLogDeliveries",
+    ]
     resources = ["*"]
   }
 }


### PR DESCRIPTION
SCN-Type: Routine Recurring

Fixes the failed apply on #122's deploy.

## Changed
Enabling access logging on the HTTP API stage failed with `logs:CreateLogDelivery` AccessDenied — HTTP API access logging delivers through the CloudWatch Logs **vended-logs** path, so the caller (deploy role) needs the log-delivery actions (`CreateLogDelivery`/`GetLogDelivery`/`UpdateLogDelivery`/`DeleteLogDelivery`/`ListLogDeliveries`) on top of the resource-policy actions. These are account-level (no resource scoping; covered by the existing `CKV_AWS_356` exception). Applied live to the deploy role and recorded in bootstrap. (These same perms cover the CloudFront standard-logging delivery in the upcoming C-3 step.)

## Verified
- Live grant applied; the re-run of the merge deploy **succeeded**.
- The silk stage now reports `AccessLogSettings.DestinationArn` = the apigw log group; `terraform validate` passes.

## Note
Main is already green (the live grant unblocked the re-run); this PR records the grant in IaC so live and bootstrap stay in sync.