### PR TITLE
Task 3 (PR-1): provision Cognito + API Gateway throttling (no cutover yet)

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -727,6 +727,16 @@ jobs:
         fi
         aws lambda get-policy --function-name samaydlette-com-silk-reeling --query 'Policy' --output text 2>/dev/null | grep -q AllowApiGatewayInvoke && \
           import_silk 'aws_lambda_permission.silk_reeling_apigw[0]' 'samaydlette-com-silk-reeling/AllowApiGatewayInvoke'
+        # Cognito (Task 3) — ephemeral state; adopt the pool/client/domain if present.
+        SILK_POOL_ID=$(aws cognito-idp list-user-pools --max-results 60 --query "UserPools[?Name=='samaydlette-com-silk-reeling-users'].Id | [0]" --output text 2>/dev/null || true)
+        if [ -n "$SILK_POOL_ID" ] && [ "$SILK_POOL_ID" != "None" ]; then
+          import_silk 'aws_cognito_user_pool.silk_reeling[0]' "$SILK_POOL_ID"
+          SILK_CLIENT_ID=$(aws cognito-idp list-user-pool-clients --user-pool-id "$SILK_POOL_ID" --query "UserPoolClients[?ClientName=='samaydlette-com-silk-reeling-spa'].ClientId | [0]" --output text 2>/dev/null || true)
+          [ -n "$SILK_CLIENT_ID" ] && [ "$SILK_CLIENT_ID" != "None" ] && \
+            import_silk 'aws_cognito_user_pool_client.silk_reeling[0]' "${SILK_POOL_ID}/${SILK_CLIENT_ID}"
+        fi
+        aws cognito-idp describe-user-pool-domain --domain samaydlette-com-silk-reeling --query 'DomainDescription.UserPoolId' --output text 2>/dev/null | grep -q . && \
+          import_silk 'aws_cognito_user_pool_domain.silk_reeling[0]' 'samaydlette-com-silk-reeling'
         echo "Silk Reeling import step complete"
 
     - name: Generate fresh Terraform plan

--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -339,6 +339,44 @@ resource "aws_iam_role_policy" "compliance_dlq" {
   policy = data.aws_iam_policy_document.compliance_dlq.json
 }
 
+# Task 3 (POAM-021/022/023): manage the Silk Reeling Cognito user pool, client,
+# and Hosted UI domain.
+data "aws_iam_policy_document" "cognito_management" {
+  # checkov:skip=CKV_AWS_356:cognito-idp:CreateUserPool/CreateUserPoolDomain/DescribeUserPoolDomain are account-level (a new pool/global domain has no pre-existing ARN); the pool/client management actions are scoped to userpool/*. Documented exception.
+  statement {
+    sid    = "ManageUserPool"
+    effect = "Allow"
+    actions = [
+      "cognito-idp:DescribeUserPool", "cognito-idp:UpdateUserPool", "cognito-idp:DeleteUserPool",
+      "cognito-idp:SetUserPoolMfaConfig", "cognito-idp:GetUserPoolMfaConfig",
+      "cognito-idp:CreateUserPoolClient", "cognito-idp:DescribeUserPoolClient",
+      "cognito-idp:UpdateUserPoolClient", "cognito-idp:DeleteUserPoolClient",
+      "cognito-idp:ListUserPoolClients",
+      "cognito-idp:CreateUserPoolDomain", "cognito-idp:DeleteUserPoolDomain",
+      "cognito-idp:TagResource", "cognito-idp:UntagResource", "cognito-idp:ListTagsForResource",
+    ]
+    resources = ["arn:aws:cognito-idp:${var.aws_region}:${data.aws_caller_identity.current.account_id}:userpool/*"]
+  }
+  statement {
+    # Account-level (no pre-existing resource ARN) or global-domain actions.
+    sid    = "CreateAndDescribeGlobal"
+    effect = "Allow"
+    actions = [
+      "cognito-idp:CreateUserPool",
+      "cognito-idp:DescribeUserPoolDomain",
+      "cognito-idp:ListUserPools",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "cognito_management" {
+  # checkov:skip=CKV_AWS_356:CreateUserPool + DescribeUserPoolDomain are account/global-level and cannot be resource-scoped; pool/client actions are scoped to userpool/*. Documented exception.
+  name   = "cognito-management"
+  role   = aws_iam_role.deploy.id
+  policy = data.aws_iam_policy_document.cognito_management.json
+}
+
 resource "aws_iam_role_policy" "log_bucket_management" {
   name   = "log-bucket-management"
   role   = aws_iam_role.deploy.id

--- a/infrastructure/cognito.tf
+++ b/infrastructure/cognito.tf
@@ -1,0 +1,84 @@
+# =============================================================================
+# COGNITO — authentication for the Silk Reeling app (POAM-021/022/023)
+# =============================================================================
+# Replaces the shared HTTP Basic Auth credential with a real identity provider:
+# per-user accounts, required TOTP MFA, and a Hosted UI login. The API Gateway
+# JWT authorizer (silk-reeling.tf) validates the Cognito token at the boundary;
+# the app also validates it (so the app stays standalone-deployable). Gated on
+# create_silk_reeling, like the rest of the app.
+# =============================================================================
+
+resource "aws_cognito_user_pool" "silk_reeling" {
+  count = local.silk_create
+  name  = "${local.silk_name}-users"
+
+  # Operator-managed accounts only — no open self-registration.
+  admin_create_user_config {
+    allow_admin_create_user_only = true
+  }
+
+  # Required multi-factor auth via authenticator-app TOTP (free; no SMS cost).
+  mfa_configuration = "ON"
+  software_token_mfa_configuration {
+    enabled = true
+  }
+
+  password_policy {
+    minimum_length                   = 14
+    require_lowercase                = true
+    require_uppercase                = true
+    require_numbers                  = true
+    require_symbols                  = true
+    temporary_password_validity_days = 7
+  }
+
+  username_attributes      = ["email"]
+  auto_verified_attributes = ["email"]
+
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "verified_email"
+      priority = 1
+    }
+  }
+
+  tags = merge(local.silk_tags, { Name = "${var.domain_name}-silk-reeling-users" })
+}
+
+# Hosted UI login page (Cognito-prefix domain; free). Must be globally unique.
+resource "aws_cognito_user_pool_domain" "silk_reeling" {
+  count        = local.silk_create
+  domain       = local.silk_name
+  user_pool_id = aws_cognito_user_pool.silk_reeling[0].id
+}
+
+# Public SPA client (no secret) using the OAuth2 authorization-code + PKCE flow.
+resource "aws_cognito_user_pool_client" "silk_reeling" {
+  count        = local.silk_create
+  name         = "${local.silk_name}-spa"
+  user_pool_id = aws_cognito_user_pool.silk_reeling[0].id
+
+  generate_secret = false
+
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_flows                  = ["code"]
+  allowed_oauth_scopes                 = ["openid", "email", "profile"]
+  supported_identity_providers         = ["COGNITO"]
+
+  callback_urls = ["https://${var.domain_name}/silk-reeling/"]
+  logout_urls   = ["https://${var.domain_name}/silk-reeling/"]
+
+  explicit_auth_flows = ["ALLOW_USER_SRP_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+
+  prevent_user_existence_errors = "ENABLED"
+  enable_token_revocation       = true
+
+  access_token_validity  = 60
+  id_token_validity      = 60
+  refresh_token_validity = 30
+  token_validity_units {
+    access_token  = "minutes"
+    id_token      = "minutes"
+    refresh_token = "days"
+  }
+}

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -81,6 +81,28 @@ output "dnssec_ksk_details" {
   } : null
 }
 
+# Cognito identity provider for the Silk Reeling app (Task 3). Feeds the SPA
+# build (VITE_COGNITO_*) and the Lambda's app-layer JWT validation.
+output "cognito_user_pool_id" {
+  description = "Silk Reeling Cognito user pool id"
+  value       = var.create_silk_reeling ? aws_cognito_user_pool.silk_reeling[0].id : "Not created"
+}
+
+output "cognito_client_id" {
+  description = "Silk Reeling Cognito app client id (public SPA client)"
+  value       = var.create_silk_reeling ? aws_cognito_user_pool_client.silk_reeling[0].id : "Not created"
+}
+
+output "cognito_hosted_ui_domain" {
+  description = "Cognito Hosted UI domain prefix (login page)"
+  value       = var.create_silk_reeling ? "${aws_cognito_user_pool_domain.silk_reeling[0].domain}.auth.${var.aws_region}.amazoncognito.com" : "Not created"
+}
+
+output "cognito_issuer" {
+  description = "Cognito JWT issuer URL (for the API Gateway authorizer + app-layer validation)"
+  value       = var.create_silk_reeling ? "https://cognito-idp.${var.aws_region}.amazonaws.com/${aws_cognito_user_pool.silk_reeling[0].id}" : "Not created"
+}
+
 # The SSL certificate that secures my website
 output "ssl_certificate_arn" {
   description = "ARN of the existing SSL certificate"

--- a/infrastructure/silk-reeling.tf
+++ b/infrastructure/silk-reeling.tf
@@ -325,6 +325,13 @@ resource "aws_apigatewayv2_stage" "silk_reeling" {
   name        = "$default"
   auto_deploy = true
 
+  # Rate limiting / brute-force protection (POAM-023, AC-7/SC-5). Sized for a
+  # single-operator app; bounds request floods at the managed edge (no WAF).
+  default_route_settings {
+    throttling_rate_limit  = 20
+    throttling_burst_limit = 10
+  }
+
   # Access logging (POAM-024): one JSON line per request to the CMK-encrypted
   # access-log group. depends_on the resource policy so the delivery service is
   # authorized before the stage starts emitting.


### PR DESCRIPTION
SCN-Type: Adaptive

First of two Task 3 PRs. **Non-breaking**: stands up Cognito + throttling; the app stays on Basic Auth until PR-2 wires JWT validation + the gateway authorizer (verify-before-cutover).

## Changed
- **`cognito.tf`** — `aws_cognito_user_pool` (operator-managed accounts only, **required TOTP MFA**, 14-char password policy), a **public PKCE app client** (OAuth code flow; callback/logout = `https://samaydlette.com/silk-reeling/`), and a **Hosted UI domain**. Free tier; no SMS.
- **API Gateway throttling** on the stage (`default_route_settings`: rate 20 / burst 10) → POAM-023.
- **Outputs**: pool id / client id / Hosted UI domain / issuer — feed the SPA build (`VITE_COGNITO_*`) and the Lambda's app-layer JWT validation in PR-2.
- **Deploy role**: `cognito-management` (pool/client/domain scoped to `userpool/*`; account-level create/list on `*` with a documented `CKV_AWS_356` exception) — applied live + in bootstrap. Cognito added to the workflow import step.

## Verified
- `terraform fmt`/`validate` (infra + bootstrap); `validate-locally.sh` 12/12; Cognito isn't reconcile-enumerated, so the new pool doesn't affect inventory drift.

## Couldn't verify until merge
- Live: the pool/client/domain creating cleanly + Hosted UI reachable. On merge I'll create a test user and confirm the Hosted UI issues a JWT (with MFA enrollment) before building PR-2. Likely first-deploy snag: a `cognito-idp` perm I scoped too tightly — fix-forward.

## Next (PR-2)
Cross-repo cutover: app JWT middleware + `/api/*` routes + Hosted-UI login flow (in `silk-reeling-mirror`), plus the API Gateway JWT authorizer + Basic-Auth removal here. Closes POAM-021/022/023.