### PR TITLE
Task 3 (PR-2 infra): API Gateway Cognito JWT authorizer + remove Basic Auth (POAM-021/022/023)

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -82,13 +82,9 @@ skip-check:
   # source. Rotated manually via put-secret-value; revisit annually. Low.
   - CKV2_AWS_57
 
-  # POAM-022 — API Gateway HTTP API route specifies no authorizer (IA-2, AC-3).
-  # Access control is enforced at the application layer (in-app HTTP Basic Auth),
-  # which gates every request; a Gateway authorizer (JWT/IAM) is incompatible with
-  # Basic Auth (both use the Authorization header), and the app must receive that
-  # header unchanged. The API fronts a Lambda whose middleware rejects any request
-  # without valid credentials. Risk-accepted.
-  - CKV_AWS_309
+  # POAM-022 CLOSED (Task 3) — the /api/* routes now carry a Cognito JWT authorizer
+  # at the gateway; CKV_AWS_309 passes. (The $default SPA route is intentionally
+  # unauthenticated so the login page can load.)
 
   # POAM-024 CLOSED (Task 7) — the HTTP API stage now emits access logs to a
   # CMK-encrypted CloudWatch log group (with the required delivery resource

--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -609,8 +609,16 @@ jobs:
         rm -rf _silk_src _pkg silk-reeling.zip
         git clone --depth 1 --branch "$SILK_REELING_REF" \
           "https://x-access-token:${SILK_REELING_REPO_TOKEN}@github.com/sam-aydlette/silk-reeling-mirror.git" _silk_src
+        # Resolve the Cognito config (provisioned in Task 3 PR-1) so the SPA's
+        # Hosted-UI login flow is wired at build time.
+        SILK_POOL_ID=$(aws cognito-idp list-user-pools --max-results 60 --query "UserPools[?Name=='samaydlette-com-silk-reeling-users'].Id | [0]" --output text 2>/dev/null || true)
+        SILK_CLIENT_ID=$(aws cognito-idp list-user-pool-clients --user-pool-id "$SILK_POOL_ID" --query "UserPoolClients[?ClientName=='samaydlette-com-silk-reeling-spa'].ClientId | [0]" --output text 2>/dev/null || true)
         ( cd _silk_src/frontend && npm ci && \
-          VITE_API_BASE=/silk-reeling npm run build -- --base=/silk-reeling/ )
+          VITE_API_BASE=/silk-reeling \
+          VITE_COGNITO_DOMAIN="samaydlette-com-silk-reeling.auth.us-east-2.amazoncognito.com" \
+          VITE_COGNITO_CLIENT_ID="$SILK_CLIENT_ID" \
+          VITE_COGNITO_REDIRECT_URI="https://samaydlette.com/silk-reeling/" \
+          npm run build -- --base=/silk-reeling/ )
         mkdir -p _pkg
         # Target the Lambda runtime (python3.13 / manylinux x86_64) explicitly so
         # numpy/pydantic-core C-extension wheels match the runtime ABI regardless
@@ -700,8 +708,6 @@ jobs:
           import_silk 'aws_cloudwatch_log_group.silk_reeling[0]' '/aws/lambda/samaydlette-com-silk-reeling'
         aws logs describe-log-groups --log-group-name-prefix /aws/apigateway/samaydlette-com-silk-reeling --query 'logGroups[0].logGroupName' --output text 2>/dev/null | grep -q silk-reeling && \
           import_silk 'aws_cloudwatch_log_group.silk_apigw[0]' '/aws/apigateway/samaydlette-com-silk-reeling'
-        aws secretsmanager describe-secret --secret-id samaydlette-com-silk-reeling-basic-auth >/dev/null 2>&1 && \
-          import_silk 'aws_secretsmanager_secret.silk_basic_auth[0]' 'samaydlette-com-silk-reeling-basic-auth'
         aws secretsmanager describe-secret --secret-id samaydlette-com-silk-reeling-anthropic-api-key >/dev/null 2>&1 && \
           import_silk 'aws_secretsmanager_secret.silk_anthropic[0]' 'samaydlette-com-silk-reeling-anthropic-api-key'
         aws lambda get-function --function-name samaydlette-com-silk-reeling >/dev/null 2>&1 && \
@@ -724,6 +730,13 @@ jobs:
             import_silk 'aws_apigatewayv2_route.silk_reeling[0]' "$SILK_API_ID/$SILK_ROUTE_ID"
           aws apigatewayv2 get-stage --api-id "$SILK_API_ID" --stage-name '$default' >/dev/null 2>&1 && \
             import_silk 'aws_apigatewayv2_stage.silk_reeling[0]' "$SILK_API_ID/\$default"
+          # Cognito JWT authorizer + the /api route (Task 3).
+          SILK_AUTH_ID=$(aws apigatewayv2 get-authorizers --api-id "$SILK_API_ID" --query "Items[?Name=='samaydlette-com-silk-reeling-cognito'].AuthorizerId | [0]" --output text 2>/dev/null || true)
+          [ -n "$SILK_AUTH_ID" ] && [ "$SILK_AUTH_ID" != "None" ] && \
+            import_silk 'aws_apigatewayv2_authorizer.silk_reeling[0]' "$SILK_API_ID/$SILK_AUTH_ID"
+          SILK_API_ROUTE_ID=$(aws apigatewayv2 get-routes --api-id "$SILK_API_ID" --query "Items[?RouteKey=='ANY /api/{proxy+}'].RouteId | [0]" --output text 2>/dev/null || true)
+          [ -n "$SILK_API_ROUTE_ID" ] && [ "$SILK_API_ROUTE_ID" != "None" ] && \
+            import_silk 'aws_apigatewayv2_route.silk_reeling_api[0]' "$SILK_API_ID/$SILK_API_ROUTE_ID"
         fi
         aws lambda get-policy --function-name samaydlette-com-silk-reeling --query 'Policy' --output text 2>/dev/null | grep -q AllowApiGatewayInvoke && \
           import_silk 'aws_lambda_permission.silk_reeling_apigw[0]' 'samaydlette-com-silk-reeling/AllowApiGatewayInvoke'
@@ -748,25 +761,18 @@ jobs:
       run: terraform apply -auto-approve tfplan
 
     # -------------------------------------------------------------------------
-    # SEED SILK REELING SECRETS (out-of-band) — set the basic-auth credential and
-    # the Anthropic key into Secrets Manager from GitHub secrets, so plaintext
-    # never lands in Terraform state. Skips quietly if a secret isn't configured.
+    # SEED SILK REELING SECRETS (out-of-band) — set the Anthropic key into Secrets
+    # Manager from a GitHub secret, so plaintext never lands in Terraform state.
+    # (The basic-auth credential was removed in Task 3 — auth is now Cognito.)
     # -------------------------------------------------------------------------
     - name: Seed Silk Reeling secrets
       working-directory: infrastructure
       env:
-        SILK_REELING_BASIC_AUTH: ${{ secrets.SILK_REELING_BASIC_AUTH }}
         SILK_REELING_ANTHROPIC_KEY: ${{ secrets.SILK_REELING_ANTHROPIC_KEY }}
       run: |
         set -euo pipefail
         ARNS=$(terraform output -json silk_reeling_secret_arns)
-        BASIC_ARN=$(echo "$ARNS" | jq -r '.basic_auth // empty')
         ANTH_ARN=$(echo "$ARNS" | jq -r '.anthropic_key // empty')
-        if [ -n "${SILK_REELING_BASIC_AUTH:-}" ] && [ -n "$BASIC_ARN" ]; then
-          aws secretsmanager put-secret-value --secret-id "$BASIC_ARN" \
-            --secret-string "$SILK_REELING_BASIC_AUTH" >/dev/null
-          echo "seeded basic-auth credential"
-        fi
         if [ -n "${SILK_REELING_ANTHROPIC_KEY:-}" ] && [ -n "$ANTH_ARN" ]; then
           aws secretsmanager put-secret-value --secret-id "$ANTH_ARN" \
             --secret-string "$SILK_REELING_ANTHROPIC_KEY" >/dev/null

--- a/docs/poam.md
+++ b/docs/poam.md
@@ -26,7 +26,7 @@ Status values: **Open** · **In progress** · **Closed** · **Risk-accepted**.
 
 ## Configuration Findings (POAM-003 through POAM-018)
 
-Configuration Findings are findings about how software and infrastructure are configured, surfaced by IaC and configuration scanners (Checkov, tfsec) rather than by vulnerability scanners. They are tracked as POA&M items but live on a separate tab in the FedRAMP Excel template because the lifecycle is different from vulnerability findings. Each entry below is either a Checkov-reported configuration weakness or an explicit architectural decision; all are risk-accepted with documented rationale **except: POAM-011/POAM-018 (closed under Task 6); POAM-005/POAM-017/POAM-024 (closed under Task 7); POAM-006/POAM-013 (closed under Task 8b); and POAM-012/POAM-015 (reclassified as false positives under Task 8b — see the False Positives register)** (closure notes below the table).
+Configuration Findings are findings about how software and infrastructure are configured, surfaced by IaC and configuration scanners (Checkov, tfsec) rather than by vulnerability scanners. They are tracked as POA&M items but live on a separate tab in the FedRAMP Excel template because the lifecycle is different from vulnerability findings. Each entry below is either a Checkov-reported configuration weakness or an explicit architectural decision; all are risk-accepted with documented rationale **except: POAM-011/POAM-018 (closed under Task 6); POAM-005/POAM-017/POAM-024 (closed under Task 7); POAM-006/POAM-013 (closed under Task 8b); POAM-012/POAM-015 (reclassified as false positives under Task 8b — see the False Positives register); and POAM-021/POAM-022/POAM-023 (closed under Task 3 — Cognito)** (closure notes below the table).
 
 The source of truth for the rationale is the inline `#checkov:skip=ID:reason` annotation in `infrastructure/main.tf` (or, for POAM-016, the architectural decision record in [`docs/recovery-plan.md`](recovery-plan.md)). All entries have been evaluated per VDR-EVA-* (PAIN N1-N5, internet-reachability, likely-exploitability) and carry the corresponding `VDR-RPT-AVI` fields in the published `/.well-known/vdr-report.json`. None is in CISA KEV.
 
@@ -43,9 +43,9 @@ The source of truth for the rationale is the inline `#checkov:skip=ID:reason` an
 | POAM-018 | SC-28 | CloudWatch log group not customer-key encrypted | Checkov | CKV_AWS_158 | aws-cloudwatch-log-group | N1 | Low | — | No | Closed (Task 6) |
 | POAM-019 | SC-12, SC-28 | Secrets Manager automatic rotation not enabled | Checkov | CKV2_AWS_57 | aws-secretsmanager::silk-reeling | N2 | Moderate | Low | Yes | Risk-accepted |
 | POAM-020 | SA-9, CA-3 | Interconnection with Anthropic API (non-FedRAMP-authorized external service) | Architectural decision | silk-reeling-deploy.md | interconnection::anthropic-api | N2 | Moderate | Low | Yes | Risk-accepted |
-| POAM-021 | IA-2(2), AC-7 | App access via single-factor shared-credential HTTP Basic Auth (no MFA, no lockout) | Architectural decision | silk-reeling-deploy.md | silk-reeling::access-control | N2 | Moderate | Low | Yes | Risk-accepted |
-| POAM-022 | IA-2, AC-3 | API Gateway HTTP API route specifies no authorizer (app-layer Basic Auth is the access control) | Checkov | CKV_AWS_309 | aws-apigatewayv2::silk-reeling | N2 | Moderate | Low | Yes | Risk-accepted |
-| POAM-023 | AC-7, SC-5 | No brute-force / rate-limit protection on the Basic Auth endpoint (no lockout, no WAF) | Security review | security-review.md | silk-reeling::access-control | N2 | Moderate | Low | Yes | Risk-accepted |
+| POAM-021 | IA-2(2), AC-7 | App access via single-factor shared-credential HTTP Basic Auth (no MFA, no lockout) | Architectural decision | silk-reeling-deploy.md | silk-reeling::access-control | N2 | Moderate | Low | Yes | Closed (Task 3) |
+| POAM-022 | IA-2, AC-3 | API Gateway HTTP API route specifies no authorizer (app-layer Basic Auth is the access control) | Checkov | CKV_AWS_309 | aws-apigatewayv2::silk-reeling | N2 | Moderate | Low | Yes | Closed (Task 3) |
+| POAM-023 | AC-7, SC-5 | No brute-force / rate-limit protection on the Basic Auth endpoint (no lockout, no WAF) | Security review | security-review.md | silk-reeling::access-control | N2 | Moderate | Low | Yes | Closed (Task 3) |
 | POAM-024 | AU-2, AU-3 | API Gateway HTTP API access logging not enabled | Checkov | CKV_AWS_76 | aws-apigatewayv2::silk-reeling | N1 | Low | — | No | Closed (Task 7) |
 
 **POAM-011 and POAM-018 closed (Task 6, 2026-06-16) — encryption-consistency remediation.** Both were risk-accepted on the rationale that the contents were non-sensitive and AWS-default encryption sufficed. Rather than carry them as standing acceptances, the system was brought to a single at-rest standard: *every* Lambda environment block and *every* CloudWatch log group is now encrypted with a customer-managed CMK. Specifically — the compliance Lambda's environment and log group use a new `aws_kms_key.at_rest` CMK; the route53 query-log group (when enabled) uses the same CMK; and the silk-reeling Lambda's environment uses the existing `aws_kms_key.silk_reeling` CMK (its role already held `kms:Decrypt` on that key). With no Lambda env or log group left unencrypted, the global Checkov suppressions for `CKV_AWS_173` and `CKV_AWS_158` were **removed** from `.checkov.yaml` — the checks now pass on their own, so the remediation is enforced by the gate rather than asserted. The website S3 bucket remains on SSE-S3 (AES-256, AWS-managed keys) by deliberate decision: it holds only public static content and persists no user data, so a customer CMK there would add cost and key-management burden without protecting anything sensitive (the app's pose extraction is client-side; nothing is stored at rest).
@@ -165,6 +165,17 @@ hard-capped at 10 concurrency, making reservation infeasible anyway; *POAM-015*
 integrity is met via the Sigstore source-signing chain plus the OIDC/GitOps chain
 of custody. Per the "POA&M only for real gaps" policy, both move to the register
 rather than being carried as risk acceptances.
+
+**POAM-021, POAM-022, and POAM-023 closed (Task 3) — Cognito authentication.** The
+shared HTTP Basic Auth credential is replaced by Amazon Cognito: per-user accounts
+with **required TOTP MFA**, a strong password policy, and Cognito's built-in
+brute-force lockout (**POAM-021**). The Silk Reeling HTTP API's `/api/*` routes now
+carry a **Cognito JWT authorizer at the gateway** (**POAM-022**, `CKV_AWS_309`
+suppression removed); the `$default` route stays unauthenticated only so the SPA /
+Hosted-UI login page can load. The stage enforces **rate-limit throttling**
+(**POAM-023**). The app also validates the JWT at the app layer (so it stays
+standalone-deployable) and the basic-auth secret is removed (narrowing POAM-019 to
+the Anthropic key, whose rotation is handled by procedure — see its note).
 
 **Standard fields for all of POAM-003 through POAM-018:**
 

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -245,9 +245,8 @@ output "silk_reeling_api_endpoint" {
 #   aws secretsmanager put-secret-value --secret-id <arn> --secret-string 'user:pass'
 #   aws secretsmanager put-secret-value --secret-id <arn> --secret-string '<anthropic-key>'
 output "silk_reeling_secret_arns" {
-  description = "Secret ARNs to populate out-of-band (basic-auth + Anthropic key)"
+  description = "Secret ARNs to populate out-of-band (Anthropic key)"
   value = var.create_silk_reeling ? {
-    basic_auth    = aws_secretsmanager_secret.silk_basic_auth[0].arn
     anthropic_key = aws_secretsmanager_secret.silk_anthropic[0].arn
   } : {}
 }

--- a/infrastructure/silk-reeling.tf
+++ b/infrastructure/silk-reeling.tf
@@ -117,14 +117,8 @@ resource "aws_kms_alias" "silk_reeling" {
 # -----------------------------------------------------------------------------
 # Secrets (containers only; values set out-of-band — see header).
 # -----------------------------------------------------------------------------
-resource "aws_secretsmanager_secret" "silk_basic_auth" {
-  count       = local.silk_create
-  name        = "${local.silk_name}-basic-auth"
-  description = "Operator-set HTTP Basic Auth credential (user:pass) gating the app"
-  kms_key_id  = aws_kms_key.silk_reeling[0].arn
-
-  tags = merge(local.silk_tags, { Name = "${var.domain_name}-silk-reeling-basic-auth" })
-}
+# (The HTTP Basic Auth secret was removed in Task 3 — access control is now
+# Cognito, enforced by the API Gateway JWT authorizer + app-layer validation.)
 
 resource "aws_secretsmanager_secret" "silk_anthropic" {
   count       = local.silk_create
@@ -177,13 +171,11 @@ resource "aws_iam_role_policy" "silk_reeling" {
         Resource = "arn:aws:logs:${var.aws_region}:*:log-group:/aws/lambda/${local.silk_name}:*"
       },
       {
-        # Read ONLY the two app secrets.
-        Effect = "Allow"
-        Action = ["secretsmanager:GetSecretValue"]
-        Resource = [
-          aws_secretsmanager_secret.silk_basic_auth[0].arn,
-          aws_secretsmanager_secret.silk_anthropic[0].arn,
-        ]
+        # Read ONLY the Anthropic API-key secret (the basic-auth secret was
+        # removed in Task 3; auth is now Cognito).
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue"]
+        Resource = [aws_secretsmanager_secret.silk_anthropic[0].arn]
       },
       {
         # Decrypt those secrets with the app CMK only.
@@ -239,11 +231,15 @@ resource "aws_lambda_function" "silk_reeling" {
   environment {
     variables = {
       # Non-sensitive config only — secret ARNs, never values (POAM-011).
-      SRM_BASIC_AUTH_SECRET_ARN = aws_secretsmanager_secret.silk_basic_auth[0].arn
-      SRM_ANTHROPIC_SECRET_ARN  = aws_secretsmanager_secret.silk_anthropic[0].arn
-      SRM_ALLOWED_ORIGIN        = "https://${var.domain_name}"
+      SRM_ANTHROPIC_SECRET_ARN = aws_secretsmanager_secret.silk_anthropic[0].arn
+      SRM_ALLOWED_ORIGIN       = "https://${var.domain_name}"
+      # Cognito for app-layer JWT validation (Task 3). The API Gateway JWT
+      # authorizer is the boundary control; the app validates too so it stays
+      # standalone-deployable.
+      SRM_COGNITO_ISSUER    = "https://cognito-idp.${var.aws_region}.amazonaws.com/${aws_cognito_user_pool.silk_reeling[0].id}"
+      SRM_COGNITO_CLIENT_ID = aws_cognito_user_pool_client.silk_reeling[0].id
       # Built SPA bundled into the Lambda package at /var/task/spa (see the CI
-      # packaging step). The app serves it from "/" behind the Basic Auth gate.
+      # packaging step). The app serves it from "/"; /api/* is gated.
       SRM_SPA_DIR = "/var/task/spa"
     }
   }
@@ -281,11 +277,38 @@ resource "aws_apigatewayv2_integration" "silk_reeling" {
   payload_format_version = "2.0"
 }
 
+# Catch-all route → serves the SPA (and the OAuth callback at /). No authorizer,
+# so the login page can load.
 resource "aws_apigatewayv2_route" "silk_reeling" {
   count     = local.silk_create
   api_id    = aws_apigatewayv2_api.silk_reeling[0].id
   route_key = "$default"
   target    = "integrations/${aws_apigatewayv2_integration.silk_reeling[0].id}"
+}
+
+# Cognito JWT authorizer (POAM-022). For Cognito access tokens the authorizer
+# matches the configured audience against the token's client_id.
+resource "aws_apigatewayv2_authorizer" "silk_reeling" {
+  count            = local.silk_create
+  api_id           = aws_apigatewayv2_api.silk_reeling[0].id
+  authorizer_type  = "JWT"
+  identity_sources = ["$request.header.Authorization"]
+  name             = "${local.silk_name}-cognito"
+
+  jwt_configuration {
+    audience = [aws_cognito_user_pool_client.silk_reeling[0].id]
+    issuer   = "https://cognito-idp.${var.aws_region}.amazonaws.com/${aws_cognito_user_pool.silk_reeling[0].id}"
+  }
+}
+
+# The API routes (/api/*) require a valid Cognito JWT at the gateway (POAM-022).
+resource "aws_apigatewayv2_route" "silk_reeling_api" {
+  count              = local.silk_create
+  api_id             = aws_apigatewayv2_api.silk_reeling[0].id
+  route_key          = "ANY /api/{proxy+}"
+  target             = "integrations/${aws_apigatewayv2_integration.silk_reeling[0].id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.silk_reeling[0].id
 }
 
 # Access-log group for the HTTP API stage (POAM-024). CMK-encrypted + 1-year

--- a/scripts/build-vdr-report.py
+++ b/scripts/build-vdr-report.py
@@ -65,7 +65,6 @@ POAM_BY_CHECK_ID = {
     # CKV_AWS_338 (POAM-017) + CKV_AWS_158 (POAM-018) closed — suppressions removed
     # from .checkov.yaml (Task 7 retention; Task 6 CMK encryption).
     "CKV2_AWS_57": "POAM-019",  # Secrets Manager automatic rotation not enabled
-    "CKV_AWS_309": "POAM-022",  # API Gateway route specifies no authorizer
     # CKV_AWS_76 (POAM-024) closed under Task 7 — HTTP API access logging enabled.
 }
 
@@ -77,7 +76,6 @@ SUPPRESSION_EVALUATION = {
     "CKV_AWS_86":  {"pain": "N1", "irv": False, "lev": False},
     "CKV_AWS_117": {"pain": "N1", "irv": False, "lev": False},
     "CKV2_AWS_57": {"pain": "N1", "irv": False, "lev": False},
-    "CKV_AWS_309": {"pain": "N2", "irv": True,  "lev": False},
 }
 
 # Rationale per suppressed check, mirrored from .checkov.yaml comments and the
@@ -87,7 +85,6 @@ SUPPRESSION_RATIONALE = {
     "CKV_AWS_86":  "Single S3 origin. No secondary origin to fail over to; multi-origin would require multi-region storage.",
     "CKV_AWS_117": "Lambda has no internet egress, no sensitive data, no private endpoint targets. NAT Gateway adds cost without commensurate isolation benefit.",
     "CKV2_AWS_57": "The two Silk Reeling app secrets (a third-party Anthropic API key and an operator-set basic-auth credential) have no programmatic rotation source; rotated manually via put-secret-value. Mooted once the secrets are removed (Tasks 3-4).",
-    "CKV_AWS_309": "Access control is enforced at the application layer; the API fronts a Lambda whose middleware rejects any request without valid credentials. Remediated by the Cognito JWT authorizer (Task 3).",
 }
 
 # Read .checkov.yaml as YAML if PyYAML is available; fall back to a forgiving


### PR DESCRIPTION
SCN-Type: Adaptive

The `samaydlette.com` half of the Basic Auth → Cognito cutover.

## ⚠️ Merge order
**Merge the app PR first** — sam-aydlette/silk-reeling-mirror#1 (the app expecting Cognito tokens). This deploy pulls the app's `main` at build time; merging this first would make the gateway demand Cognito JWTs while the app still wanted Basic Auth.

## Changed
- **API Gateway JWT authorizer** (issuer = the Cognito pool, audience = the app client) now protects `ANY /api/{proxy+}` (**POAM-022**); the `$default` route stays unauthenticated so the SPA / Hosted-UI login can load. (Stage throttling landed in PR-1 → **POAM-023**.)
- **Silk Lambda env**: add `SRM_COGNITO_ISSUER` + `SRM_COGNITO_CLIENT_ID` (app-layer JWT validation → keeps the app standalone-deployable); remove `SRM_BASIC_AUTH_SECRET_ARN`.
- **Remove the basic-auth Secrets Manager secret** + its IAM read + the seed step; `silk_reeling_secret_arns` drops `basic_auth` (narrows POAM-019 to the Anthropic key).
- **SPA build**: pass `VITE_COGNITO_*` (resolved from the Cognito resources) into `npm run build`.
- **Workflow**: import the authorizer + `/api` route; drop the basic-auth import/seed.
- **POAM-021/022/023 closed** in `docs/poam.md`; `CKV_AWS_309` removed (authorizer makes it pass) + dropped from the VDR maps.

Closes **POAM-021** (Cognito + required MFA + built-in lockout), **POAM-022** (gateway JWT authorizer), **POAM-023** (throttling).

## Verified
- `terraform fmt`/`validate` (infra + bootstrap); `validate-locally.sh` 12/12 (VDR risk-accepted 5 → 4). Deploy role already holds the needed `apigateway`/`secretsmanager` perms (no new grants).

## Couldn't verify until merge (the cutover)
On merge (after the app PR) I'll verify end-to-end: an **unauthenticated `/silk-reeling/api/*` returns 401 at the gateway** (authorizer working before the Lambda), the SPA itself loads without a token, the Lambda env carries the Cognito vars, and the basic-auth secret is gone. The full Hosted-UI login (token → authenticated API call) needs your Cognito user + MFA enrollment — I'll walk through it. Expect possible fix-forward (authorizer audience/issuer exact-match, the `/api` route + prefix-strip interaction).

## Follow-on (small)
Add Cognito to the canonical inventory (`build-ksi-signal` component map) and reclassify POAM-019 (manual annual Anthropic-key rotation + a `LastChangedDate` check in the daily monitor).