### PR TITLE
fix: keep silk-reeling CMK description at its deployed value (unblock apply)

### DIFF
--- a/infrastructure/silk-reeling.tf
+++ b/infrastructure/silk-reeling.tf
@@ -48,8 +48,14 @@ data "aws_caller_identity" "current" {}
 # Customer-managed KMS key for the app's secrets (rotation enabled).
 # -----------------------------------------------------------------------------
 resource "aws_kms_key" "silk_reeling" {
-  count                   = local.silk_create
-  description             = "CMK for ${local.silk_name} secrets (Anthropic key)"
+  count = local.silk_create
+  # Description is left at its original value: a KMS key description is immutable
+  # metadata that can only be changed via kms:UpdateKeyDescription, which the
+  # deploy role intentionally does not hold (least privilege — not worth a new
+  # grant for a cosmetic relabel). Post-Task-3 the key now protects only the
+  # Anthropic key; the "basic-auth" label is historical and carries no compliance
+  # claim. The CMK still encrypts all app secrets at rest (SC-28).
+  description             = "CMK for ${local.silk_name} secrets (basic-auth, Anthropic key)"
   deletion_window_in_days = 30
   enable_key_rotation     = true
 


### PR DESCRIPTION
## Changed
The Task 3 follow-on (#138) relabeled the Silk Reeling CMK description to drop the now-stale "basic-auth" wording. A KMS key description is mutable only via `kms:UpdateKeyDescription`, which the deploy role intentionally does not hold, so Terraform Apply failed on that single cosmetic update. This restores the description to its original (and currently deployed) value so no update is attempted.

Rationale: the description is historical metadata with no compliance claim, and broadening the deploy role's IAM for a non-functional relabel would violate least privilege. The CMK still encrypts all app secrets at rest (SC-28) — unchanged.

## Verified
- `terraform validate` passes; `terraform fmt` clean.
- The restored string matches the live key description, so the next apply makes no KMS call on this resource.

## Residual / needs human
None. One-line revert; no new resources, permissions, or manual steps.

## Couldn't verify (until merged + deployed)
The full apply going green and the live `/.well-known/` artifacts (the new `identity_provider` component and the SC-12 rotation validation from #138) — I'll confirm those once this merges and the pipeline runs clean.