### PR TITLE
content: drop inline provenance paragraph from the Shift Left on Reciprocity paper

### DIFF
--- a/website/research/the-plumbing.html
+++ b/website/research/the-plumbing.html
@@ -52,8 +52,6 @@
                 <div class="article-summary">
                     <strong>Evidence reciprocity is an architecture decision. Authorization reciprocity is a government decision. Stop waiting for the second.</strong>
                 </div>
-                <p class="article-provenance">Version 1.1, dated 2026-06-12. This paper is published with a Sigstore bundle at <code>/.well-known/the-plumbing.html.bundle</code>; verify the served bytes with <code>cosign verify-blob --bundle the-plumbing.html.bundle --certificate-identity 'https://github.com/sam-aydlette/samaydlette.com/.github/workflows/deploy-with-opa.yml@refs/heads/main' --certificate-oidc-issuer https://token.actions.githubusercontent.com the-plumbing.html</code>. The signature attests to who published these bytes and that the event is logged, not that the claims are true.</p>
-
                 <h3 id="authors-note">Author's Note</h3>
                 <p>This paper documents an implementation that runs on the infrastructure of this website. Every assertion the paper makes about the artifacts it describes is verifiable: anyone can <code>curl</code> the published documents from <code>/.well-known/</code>, run <code>cosign verify-blob</code> against the Sigstore bundle, browse the artifacts in the <a href="/viewer.html">live trust dashboard</a>, and check that what the paper claims matches what is actually being served. The implementation is open-source at <a href="https://github.com/sam-aydlette/samaydlette.com">github.com/sam-aydlette/samaydlette.com</a>.</p>
                 <p>The system is small. One CSP, one operator, no end users, no federal customer data. The patterns it demonstrates are not.</p>


### PR DESCRIPTION
## Changed
Removes the standalone `<p class="article-provenance">` paragraph that sat directly before the **Author's Note** in `website/research/the-plumbing.html` (the "verify the served bytes with `cosign verify-blob` …" block).

The Author's Note still explains how to verify the published bytes against the Sigstore bundle, and the article version/date remain in the `.article-version` meta, so no unique information is lost.

## Verified
- HTML still parses; the summary now flows directly into the Author's Note.
- The removed block carried no `data-figure` marker, so build-time figure injection is unaffected.
- Reconcile gate is unaffected (it inspects the dashboard `viewer.html`, not this article); the page's Sigstore bundle re-signs from the served bytes on deploy.

## Residual / needs human
None. Single-paragraph content removal.