### PR TITLE
artifacts: relabel this system's FedRAMP standing to Certified (CR26)

### DIFF
--- a/scripts/build-ksi-signal.py
+++ b/scripts/build-ksi-signal.py
@@ -1189,7 +1189,7 @@ def main():
             "authorization_status": "self-attested-proof-of-concept",
             "fedramp_certified": False,
             "remarks": (
-                "This system is not FedRAMP-authorized. The artifacts published "
+                "This system is not FedRAMP-certified. The artifacts published "
                 "at /.well-known/ are self-attested by the operator and "
                 "demonstrate an architectural pattern aligned with FedRAMP "
                 "NTC-0009 (machine-readable authorization data, text-based "

--- a/scripts/build-oscal-poam.py
+++ b/scripts/build-oscal-poam.py
@@ -369,7 +369,7 @@ def build_metadata(now_iso, system_uuid, ksi_signal):
         ],
         "remarks": (
             "This Plan of Action and Milestones is a self-attested proof-of-concept artifact. "
-            "The system it describes is NOT FedRAMP-authorized. No 3PAO assessment has been "
+            "The system it describes is NOT FedRAMP-certified. No 3PAO assessment has been "
             "conducted; no agency Authorization to Operate is in place. The POA&M is published "
             "to demonstrate an architectural pattern (canonical-inventory-derived OSCAL artifacts) "
             "aligned with FedRAMP NTC-0009. Treat all entries as the operator's self-attestation. "

--- a/scripts/build-oscal-ssp.py
+++ b/scripts/build-oscal-ssp.py
@@ -768,13 +768,13 @@ def now_iso():
 
 def build_metadata(signal):
     return {
-        "title": "samaydlette.com — System Security Plan (Self-Attested PoC, NOT FedRAMP-Authorized)",
+        "title": "samaydlette.com — System Security Plan (Self-Attested PoC, NOT FedRAMP-Certified)",
         "last-modified": now_iso(),
         "version": SSP_VERSION,
         "oscal-version": OSCAL_VERSION,
         "remarks": (
             "This System Security Plan is a self-attested proof-of-concept artifact. "
-            "The system it describes is NOT FedRAMP-authorized. No 3PAO assessment has "
+            "The system it describes is NOT FedRAMP-certified. No 3PAO assessment has "
             "been conducted; no agency Authorization to Operate is in place. The SSP "
             "is published to demonstrate an architectural pattern (canonical-inventory-"
             "derived OSCAL artifacts) aligned with FedRAMP NTC-0009. Treat all "

--- a/scripts/build-oscal-ssp.py
+++ b/scripts/build-oscal-ssp.py
@@ -369,7 +369,7 @@ FAMILY_DEFAULTS = {
         "origination": "inherited",
         "statement": (
             "Inherited from AWS. AWS handles all hardware and platform "
-            "maintenance under their FedRAMP authorization. The system "
+            "maintenance under their FedRAMP certification. The system "
             "has no on-premises hardware and no operator-side "
             "maintenance actions; the Lambda runtime is AWS-managed."
         ),
@@ -383,7 +383,7 @@ FAMILY_DEFAULTS = {
             "AWS-managed storage services (S3 with server-side "
             "encryption; CloudWatch Logs). Storage media handling, "
             "sanitization, and disposal are AWS-managed under their "
-            "FedRAMP authorization."
+            "FedRAMP certification."
         ),
     },
     # Physical and Environmental — inherited
@@ -392,7 +392,7 @@ FAMILY_DEFAULTS = {
         "origination": "inherited",
         "statement": (
             "Inherited from AWS. AWS data centers operate under their "
-            "FedRAMP-authorized physical and environmental security "
+            "FedRAMP-certified physical and environmental security "
             "program. The system has no operator-managed physical "
             "facilities."
         ),
@@ -464,7 +464,7 @@ FAMILY_DEFAULTS = {
             "Lambda, Route 53, ACM) and OSS dependencies (npm, "
             "Terraform providers, GitHub Actions). Acquisition controls "
             "for the AWS services are inherited under AWS's FedRAMP "
-            "authorization; OSS dependencies are subject to the supply-"
+            "certification; OSS dependencies are subject to the supply-"
             "chain controls in docs/supply-chain.md. Enhancements that "
             "presume vendor-management agreements with custom contracts "
             "are tracked as separate not-applicable entries; a sole-"
@@ -507,7 +507,7 @@ POLICY_AND_PROCEDURES_DEFAULT = {
 }
 
 # Controls that are conventionally inherited from the underlying CSP (AWS,
-# in this implementation) under their own FedRAMP authorization. These are
+# in this implementation) under their own FedRAMP certification. These are
 # emitted as implemented-requirement entries with status=implemented and
 # origination=inherited regardless of whether an in-scope KSI references
 # them — a real Rev 5 SSP must address the full Moderate baseline, and the 20x
@@ -642,7 +642,7 @@ INHERITED_FROM_AWS = {
     "sr-12": "Component Disposal",
 
     # Maintenance — Moderate adds maintenance-tools enhancements; AWS handles
-    # all maintenance tooling and personnel under its FedRAMP authorization.
+    # all maintenance tooling and personnel under its FedRAMP certification.
     "ma-3": "Maintenance Tools",
     "ma-3.1": "Inspect Tools",
     "ma-3.2": "Inspect Media",
@@ -908,7 +908,7 @@ def build_system_characteristics(signal):
             "validation report on every deploy; runtime Lambda re-validates "
             "the live AWS configuration on a schedule. Sole-operator "
             "deployment; no end users, no federal customer data, no FedRAMP "
-            "authorization in scope."
+            "certification in scope."
         ),
         "security-sensitivity-level": _sens,
         "system-information": {
@@ -1287,7 +1287,7 @@ def build_control_implementation(signal, catalog):
             origination = "inherited"
             statement = (
                 f"{inherited_title} ({control_id.upper()}) is inherited "
-                f"from AWS under the AWS FedRAMP authorization. The "
+                f"from AWS under the AWS FedRAMP certification. The "
                 f"system has no operator-side responsibility for this "
                 f"control; AWS's published customer-responsibility "
                 f"matrix carries the full implementation. This entry is "
@@ -1347,12 +1347,12 @@ def build_control_implementation(signal, catalog):
         if origination == "inherited":
             props.append({
                 "name": "leveraged-authorization",
-                "value": "AWS FedRAMP Authorization (commercial regions)",
+                "value": "AWS FedRAMP Certification, Class C (commercial regions)",
             })
             links.append({
                 "href": "https://aws.amazon.com/compliance/fedramp/",
                 "rel": "reference",
-                "text": "AWS FedRAMP authorization",
+                "text": "AWS FedRAMP certification",
             })
 
         ir = {
@@ -1394,13 +1394,13 @@ def build_control_implementation(signal, catalog):
             "implementation status and origination resolved per-control via "
             "explicit overrides or family-level fall-throughs, or "
             "(b) part of the FedRAMP Rev 5 Moderate baseline that AWS carries "
-            "wholly under its FedRAMP authorization (PE, MP, parts of MA), "
+            "wholly under its FedRAMP certification (PE, MP, parts of MA), "
             "and is therefore emitted here as inherited so the SSP addresses "
             "the baseline in full. Evidence references point at the live "
             "KSI signal at /.well-known/ksi-signal.json (deploy-time, signed "
             "via Sigstore), the runtime signal at "
             "/.well-known/ksi-signal-runtime.json, the AWS FedRAMP "
-            "authorization page, and the documentation set in docs/."
+            "certification page, and the documentation set in docs/."
         ),
         "implemented-requirements": implemented_reqs,
     }

--- a/scripts/build-scuba-bundle.py
+++ b/scripts/build-scuba-bundle.py
@@ -44,7 +44,7 @@ def classify(status, origination):
 
 
 WHO = {
-    "fully-inherited": "AWS (leveraged FedRAMP authorization)",
+    "fully-inherited": "AWS (leveraged FedRAMP certification)",
     "partially-inherited": "the provider and AWS (shared; no separate customer action)",
     "implemented": "the provider (cloud service offering and operator policies)",
     "not-applicable": "not applicable to this offering",


### PR DESCRIPTION
## Changed
Aligns the generated artifacts to the CR26 relabel: a FedRAMP standing is a **Certification** (Class A–D), not an **Authorization** (Low/Moderate/High).

**This system's own standing** → `NOT FedRAMP-Certified` (SSP title + remarks, POA&M remarks, KSI disclosure, the "no FedRAMP certification in scope" system description).

**AWS's leveraged standing** → `FedRAMP certification`. AWS US East/West commercial regions are **FedRAMP Certified at Class C**, and this system inherits PE/MP/MA (and other CSP-side families) from that package. Updated the SSP inheritance narratives, the `leveraged-authorization` prop **value** (now "AWS FedRAMP Certification, Class C (commercial regions)"), the AWS reference link text, and the SCuBA bundle's inheritance label.

**Deliberately left unchanged** (these are not the FedRAMP-standing label):
- The **agency decision** — *Authorization to Operate (ATO)*, *Authorizing Official* role, "no agency authorization in scope."
- The OSCAL/NIST structural terms — `leveraged-authorization` prop **name**, the **authorization boundary** diagram/concept, the CA family name *"Assessment, Authorization, and Monitoring"*, CM-7.5 *authorized-software* control language.
- *"AWS authorization package AGENCYAMAZONEW"* — the formal security-package term plus the real FedRAMP package identifier.
- External-service (Anthropic) *"non-FedRAMP-authorized"* notes — an external service with no FedRAMP standing of either name.

## Verified
- All four generators compile; reconcile/SSP-params/disposition tests pass. No test asserts the old title; the reconciliation gate doesn't check the SSP title (metadata-only).
- Every remaining "authoriz" string in the generators was classified and is an intentional keep (agency/ATO, OSCAL structural, NIST control names, or external-service).
- CodeGuard: terminology-only narrative change to generators — no credentials, IAM, crypto, or input handling; no security surface.

## Residual / needs human
On merge, the deploy regenerates `/.well-known/` so the live SSP title returns `…NOT FedRAMP-Certified` and the AWS inheritance reads "certification." I'll confirm the live round-trip after deploy, then sync the (still-unpublished) article's verify-section quote to match.

## Couldn't verify
The published artifacts change only after this deploys; verified post-merge.