### PR TITLE
ci: serialize deploys to stop concurrent applies thrashing the Cognito client

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -40,6 +40,24 @@ on:
         - prod
 
 # =============================================================================
+# CONCURRENCY — serialize deploys so overlapping runs never race terraform apply
+# =============================================================================
+# This repo keeps NO remote Terraform state; each run rebuilds state by importing
+# live resources before apply. Two deploys running at once therefore apply
+# against the same AWS account from independent states and thrash ephemeral-state
+# resources — most visibly the Cognito app client, whose server-generated id is
+# baked into the SPA at build time: concurrent applies recreate the client, its
+# id changes, and the deployed SPA is left pointing at a dead client_id (the
+# Hosted-UI "an error was encountered with the requested page" failure).
+# Serialize the deploy path to one run at a time, keyed by ref. Never cancel a
+# run mid-apply — a partial terraform apply is worse than a queue — so the
+# in-flight run finishes and the newest queued run goes next.
+# =============================================================================
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+# =============================================================================
 # GLOBAL SETTINGS
 # =============================================================================
 # Tool versions and AWS region used everywhere


### PR DESCRIPTION
## Changed
Adds a workflow-level `concurrency` group to `deploy-with-opa.yml` so deploys to `main` run **one at a time**:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: false
```

## Why (production incident)
The Silk Reeling app sign-in started returning the Cognito Hosted-UI error *"An error was encountered with the requested page."* Diagnosis:

- The deployed SPA bakes the Cognito **client_id** in at build time (`VITE_COGNITO_CLIENT_ID`, resolved by name from the live pool).
- This repo keeps **no remote Terraform state** — each run rebuilds state by importing live resources before `apply`.
- A burst of merges to `main` launched **overlapping deploy runs with no concurrency control**. Concurrent `terraform apply`s against the same account from independent states **recreated the Cognito app client repeatedly** — its id was observed changing several times in ten minutes (several times), and two deploys were confirmed in-flight at once.
- The SPA, built once per run, is left pointing at a client_id that no longer exists → the Hosted-UI error.

Serializing the deploy path stops the race. `cancel-in-progress: false` ensures a run is never interrupted mid-`apply` (a partial apply is worse than queueing); the newest queued run goes next.

## Verified
- YAML parses; `concurrency` block resolves as expected.
- Root cause confirmed live via the AWS CLI (client id thrash + two concurrent in-progress runs + no existing concurrency key in the workflow).

## Residual / needs human
- **Recovery:** after this merges, let any in-flight deploy finish, then one clean (now-serialized) deploy will rebuild the SPA against the stable client id and restore sign-in. I'll verify the SPA's baked client_id matches the live client afterward.
- **Latent fragility (follow-up, app-repo):** the SPA resolves the client_id at *build* time, before `apply`. Even serialized, a single run that recreates the client (e.g. an import miss) would leave the SPA one generation behind. The durable fix is runtime client-id resolution (SPA fetches a small config served by the Lambda) so the build no longer hard-codes a server-generated id — tracked separately in `silk-reeling-mirror`.

CodeGuard: not applicable — CI workflow concurrency config; no code, credentials, or IaC resource changes.