### PR TITLE
Pin the Cognito client id (re-land the stability fix that missed #161)

### DIFF
--- a/infrastructure/cognito.tf
+++ b/infrastructure/cognito.tf
@@ -81,4 +81,15 @@ resource "aws_cognito_user_pool_client" "silk_reeling" {
     id_token      = "minutes"
     refresh_token = "days"
   }
+
+  # The AWS provider does not read generate_secret back on import. This pipeline
+  # keeps no remote state and re-imports the client every run, so the imported
+  # state shows generate_secret as unset while the config says false — and because
+  # generate_secret FORCES REPLACEMENT, terraform destroys and recreates the client
+  # on every deploy, changing its id each time (which broke the SPA's baked-in
+  # client_id). The client is a public PKCE client with no secret and this never
+  # changes, so ignore it post-import to keep the client id stable across deploys.
+  lifecycle {
+    ignore_changes = [generate_secret]
+  }
 }


### PR DESCRIPTION
## Changed
Re-lands the `lifecycle { ignore_changes = [generate_secret] }` pin on `aws_cognito_user_pool_client.silk_reeling`. It was committed to #161 *after* that PR had already been merged, so only the env-var half landed — `origin/main` currently has no pin, and the client still gets recreated on every deploy.

## Why
Deploy log (run 28257190256): the client **imports fine** but the plan carries `+ generate_secret = false # forces replacement`, so `apply` destroys and recreates it every run (id changes each time). The provider doesn't read `generate_secret` back on import, and this pipeline rebuilds state by import every run, so the null→false diff on that force-new attribute churns the client. Ignoring it post-import keeps the id stable (public PKCE client, no secret, attribute never changes).

## Verified
- `terraform validate` passes.
- Confirmed `origin/main` lacks the pin (0 occurrences of `ignore_changes`) while the #161 env-vars and #160 concurrency are present.

## Residual / needs human
Merge to stop the churn. Sign-in already works via the runtime `/auth-config` path (app #2 + #161 env, both merged); this just stops the client id from needlessly changing every deploy. After merge I'll confirm `terraform plan` no longer replaces the client and the live id holds steady across two deploys.

CodeGuard: Terraform lifecycle rule only — no code, secrets, or IAM. No findings.