### PR TITLE
ci: bound the recurring OIDC/STS credential hang (timeouts + retry)

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -99,6 +99,9 @@ jobs:
   compliance-check:
     name: OPA Compliance Check
     runs-on: ubuntu-latest
+    # Cap the job so a stuck step (notably the intermittent OIDC/STS credential
+    # hang) fails in minutes instead of GitHub's 6-hour default.
+    timeout-minutes: 25
     outputs:
       compliant: ${{ steps.compliance.outputs.compliant }}
 
@@ -139,11 +142,17 @@ jobs:
     # Connect to AWS using stored credentials
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+      # The OIDC AssumeRoleWithWebIdentity call to regional STS intermittently
+      # times out from GitHub runners. retry-max-attempts rides through a brief
+      # blip; timeout-minutes caps a real outage at a quick, re-runnable failure
+      # instead of hanging on GitHub's 6-hour default.
+      timeout-minutes: 6
       with:
         # GitHub OIDC role assumption — no long-lived access key (POAM-001).
         # Role ARN is a repo variable so the account ID stays out of the YAML.
         role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
         aws-region: ${{ env.AWS_REGION }}
+        retry-max-attempts: 5
 
     # -------------------------------------------------------------------------
     # CREATE CONFIGURATION FILE
@@ -275,6 +284,9 @@ jobs:
   deploy:
     name: Deploy Infrastructure
     runs-on: ubuntu-latest
+    # Cap the job so a stuck step (notably the intermittent OIDC/STS credential
+    # hang) fails in minutes instead of GitHub's 6-hour default.
+    timeout-minutes: 30
     permissions:
       contents: read
       issues: write
@@ -326,11 +338,15 @@ jobs:
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+      # See the compliance-check job: cap the intermittent OIDC/STS hang and
+      # retry the assume-role call to ride through a brief blip.
+      timeout-minutes: 6
       with:
         # GitHub OIDC role assumption — no long-lived access key (POAM-001).
         # Role ARN is a repo variable so the account ID stays out of the YAML.
         role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
         aws-region: ${{ env.AWS_REGION }}
+        retry-max-attempts: 5
 
     # -------------------------------------------------------------------------
     # RE-RENDER tfvars FROM SECRETS (not persisted as an artifact)


### PR DESCRIPTION
## Changed
The "Configure AWS credentials" step has stalled deploys several times. Root cause: the OIDC `AssumeRoleWithWebIdentity` call to **regional STS (us-east-2) intermittently times out** from GitHub runners (`connect ETIMEDOUT`), and the workflow had **no step or job timeout and no extra retries** — so a transient blip hangs on GitHub's **6-hour** default instead of failing fast.

- `timeout-minutes: 6` on **both** `configure-aws-credentials` steps → a real outage fails in minutes (quick, re-runnable) instead of hanging for hours.
- `retry-max-attempts: 5` (a supported input on the pinned v4.0.2, verified against its `action.yml`) → the action rides through a brief blip within that window.
- Job-level `timeout-minutes` (compliance-check 25, deploy 30) as a backstop so no job runs for hours.

This doesn't eliminate the underlying GitHub-runner→STS network flakiness (not ours to fix), but it converts a multi-hour stall into a fast, obvious, re-runnable failure — and most blips will now be absorbed by the retries.

## Verified
- `yaml.safe_load` parses; 4 `timeout-minutes` + 2 `retry-max-attempts` present.
- `retry-max-attempts` / `disable-retry` confirmed as real inputs of the pinned action SHA (v4.0.2 `action.yml`).
- Diagnosed from a live run that hung ~28 min on this exact step, pre-apply (run 28258055231).

## Residual / needs human
None. Future hangs fail in ≤6 min and re-run cleanly. A deeper fix (self-hosted runner / VPC STS endpoint) is overkill for this PoC.

CodeGuard: CI timeout/retry config only — no code, secrets, IAM, or IaC resources. No findings.