### PR TITLE
Publish Silk Reeling Cognito config as a static S3 JSON (reliable client_id delivery)

### DIFF
--- a/infrastructure/silk-reeling.tf
+++ b/infrastructure/silk-reeling.tf
@@ -400,3 +400,25 @@ resource "aws_lambda_permission" "silk_reeling_apigw" {
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.silk_reeling[0].execution_arn}/*/*"
 }
+
+# Publish the (public) Cognito config for the SPA as a static JSON on S3/CloudFront.
+# The SPA fetches this at /.well-known/silk-reeling-auth.json instead of relying on
+# the CMK-encrypted Lambda env (which this import-rebuilt-state pipeline doesn't
+# reliably populate) or a build-time CLI lookup (which can race). The values come
+# straight from the live Cognito resources, so they are always correct; all three
+# are public — they appear in the Hosted-UI authorize URL on every login. Served
+# from the website bucket (everything except /silk-reeling/* routes to S3), so it
+# is reachable without involving the app Lambda at all.
+resource "aws_s3_object" "silk_reeling_auth_config" {
+  count         = local.silk_create
+  bucket        = data.aws_s3_bucket.website.id
+  key           = ".well-known/silk-reeling-auth.json"
+  content_type  = "application/json"
+  cache_control = "no-cache"
+  content = jsonencode({
+    cognitoEnabled = true
+    domain         = "${aws_cognito_user_pool_domain.silk_reeling[0].domain}.auth.${var.aws_region}.amazoncognito.com"
+    clientId       = aws_cognito_user_pool_client.silk_reeling[0].id
+    redirectUri    = "https://${var.domain_name}/silk-reeling/"
+  })
+}


### PR DESCRIPTION
## Changed
Adds an `aws_s3_object` (`infrastructure/silk-reeling.tf`) that writes the Silk Reeling Cognito config to `.well-known/silk-reeling-auth.json` on the website bucket:

```hcl
content = jsonencode({
  cognitoEnabled = true
  domain         = "<from aws_cognito_user_pool_domain ref>"
  clientId       = "<from aws_cognito_user_pool_client ref>"
  redirectUri    = "https://<domain>/silk-reeling/"
})
```

## Why
The SPA needs the Cognito client_id, but the two prior delivery paths were unreliable in this no-remote-state pipeline:
- The CMK-encrypted Lambda env didn't get the `SRM_COGNITO_*` vars populated on the live function (so the Lambda `/auth-config` endpoint returned `cognitoEnabled:false`).
- The build-time CLI lookup baked an empty value into the SPA bundle.

Both left the SPA with no client_id, so Hosted-UI login failed. This sources the three values straight from the **live Cognito resource references** (always correct — the plan resolves them), as a plain file served from S3/CloudFront (everything except `/silk-reeling/*` routes to S3). No encrypted env, no CLI race. All three values are public (they appear in the authorize URL), so nothing sensitive is published.

The object re-PUTs idempotently each deploy (no import handling needed) and carries `Cache-Control: no-cache` so changes propagate.

## Verified
- `terraform validate` passes.
- The referenced resources (`aws_cognito_user_pool_client/domain.silk_reeling`, `data.aws_s3_bucket.website`, `local.silk_create`) all exist; the deploy role already has `s3:PutObject` on the website bucket (it publishes the other `/.well-known/` artifacts).

## Pairs with
silk-reeling-mirror#4 (SPA fetches this file). Merge this first so the file exists when the SPA ships; until both deploy the SPA falls back to its build-time env.

CodeGuard: a single S3 object of public config values; no secrets, no new IAM, no executable surface. No findings.