### PR TITLE
Fix Silk Reeling auth-config publish (output + cp; unblocks deploys)

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -834,7 +834,9 @@ jobs:
         cd infrastructure
         
         BUCKET_NAME=$(terraform output -raw s3_bucket_name 2>/dev/null || echo "")
-        
+        # Public Cognito config for the SPA, published below after the sync.
+        AUTH_CFG=$(terraform output -raw silk_reeling_auth_config_json 2>/dev/null || echo "")
+
         if [ -z "$BUCKET_NAME" ]; then
           echo "❌ Could not get S3 bucket name from Terraform outputs"
           echo "Available outputs:"
@@ -863,6 +865,17 @@ jobs:
           --delete
         
         echo "✅ Website content synced successfully"
+
+        # Publish the public Cognito config for the SPA AFTER the sync's --delete
+        # (so it isn't removed). The SPA fetches /.well-known/silk-reeling-auth.json
+        # to resolve the live client_id at runtime. Written via cp (the deploy role
+        # has PutObject; an aws_s3_object resource fails on GetObjectTagging).
+        if [ -n "$AUTH_CFG" ]; then
+          printf '%s' "$AUTH_CFG" > /tmp/silk-reeling-auth.json
+          aws s3 cp /tmp/silk-reeling-auth.json "s3://$BUCKET_NAME/.well-known/silk-reeling-auth.json" \
+            --content-type application/json --cache-control no-cache
+          echo "✅ Published /.well-known/silk-reeling-auth.json"
+        fi
 
     # -------------------------------------------------------------------------
     # BUILD AND PUBLISH THE DEPLOY-TIME KSI SIGNAL

--- a/infrastructure/silk-reeling.tf
+++ b/infrastructure/silk-reeling.tf
@@ -401,24 +401,22 @@ resource "aws_lambda_permission" "silk_reeling_apigw" {
   source_arn    = "${aws_apigatewayv2_api.silk_reeling[0].execution_arn}/*/*"
 }
 
-# Publish the (public) Cognito config for the SPA as a static JSON on S3/CloudFront.
-# The SPA fetches this at /.well-known/silk-reeling-auth.json instead of relying on
-# the CMK-encrypted Lambda env (which this import-rebuilt-state pipeline doesn't
-# reliably populate) or a build-time CLI lookup (which can race). The values come
-# straight from the live Cognito resources, so they are always correct; all three
-# are public — they appear in the Hosted-UI authorize URL on every login. Served
-# from the website bucket (everything except /silk-reeling/* routes to S3), so it
-# is reachable without involving the app Lambda at all.
-resource "aws_s3_object" "silk_reeling_auth_config" {
-  count         = local.silk_create
-  bucket        = data.aws_s3_bucket.website.id
-  key           = ".well-known/silk-reeling-auth.json"
-  content_type  = "application/json"
-  cache_control = "no-cache"
-  content = jsonencode({
+# Expose the (public) Cognito config for the SPA as a Terraform output. The CI
+# publish step writes it to .well-known/silk-reeling-auth.json via `aws s3 cp`
+# (the same path the other published artifacts use), so the SPA can fetch it from
+# S3/CloudFront without relying on the CMK-encrypted Lambda env (which this
+# import-rebuilt-state pipeline doesn't reliably populate) or a build-time CLI
+# lookup (which can race). The values come straight from the live Cognito
+# resources, so they are always correct; all three are public — they appear in
+# the Hosted-UI authorize URL on every login. (An aws_s3_object resource can't be
+# used here: the deploy role can PutObject but not GetObjectTagging, which the
+# provider calls on read, so it would fail every apply.)
+output "silk_reeling_auth_config_json" {
+  description = "Public Cognito config JSON for the Silk Reeling SPA; published to .well-known/ by the CI."
+  value = var.create_silk_reeling ? jsonencode({
     cognitoEnabled = true
-    domain         = "${aws_cognito_user_pool_domain.silk_reeling[0].domain}.auth.${var.aws_region}.amazoncognito.com"
-    clientId       = aws_cognito_user_pool_client.silk_reeling[0].id
+    domain         = "${one(aws_cognito_user_pool_domain.silk_reeling[*].domain)}.auth.${var.aws_region}.amazoncognito.com"
+    clientId       = one(aws_cognito_user_pool_client.silk_reeling[*].id)
     redirectUri    = "https://${var.domain_name}/silk-reeling/"
-  })
+  }) : ""
 }


### PR DESCRIPTION
## Why
The `aws_s3_object` for `/.well-known/silk-reeling-auth.json` (just merged) **fails every `terraform apply`** and is currently blocking all deploys:

```
Error: listing tags for S3 Object (.../silk-reeling-auth.json): GetObjectTagging 403 AccessDenied
  github-actions-deploy-oidc is not authorized to perform: s3:GetObjectTagging
```

The PutObject succeeds, but the provider always calls `GetObjectTagging` on read, and the deploy role only has `PutObject` on the bucket.

## Changed
- Replace the `aws_s3_object` with a Terraform **output** (`silk_reeling_auth_config_json`) carrying the same public Cognito config, sourced from the live Cognito resource references.
- Publish it in the existing "Sync Website Content" step via `aws s3 cp` (uses the `PutObject` perm the role already has), **after** the sync's `--delete` so it isn't removed.

No IAM change, no new permission, same served file. This both unblocks deploys and delivers the SPA config the reliable way.

## Verified
- `terraform validate` passes; workflow YAML parses.
- Uses `one(resource[*].attr)` so the output is safe whether or not the Silk Reeling app is enabled.
- The deploy role already publishes the other `/.well-known/` artifacts via `aws s3 cp`, so the permission path is proven.

## After merge
One deploy, then I verify `/.well-known/silk-reeling-auth.json` serves the live client_id and sign-in round-trips. (SPA side — fetching that path — already merged.)