### PR TITLE
bootstrap: add a reusable read-only IAM group

### DIFF
--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -505,3 +505,43 @@ resource "aws_iam_user_group_membership" "operator" {
   user   = var.operator_user_name
   groups = [aws_iam_group.operators.name]
 }
+
+# =============================================================================
+# READ-ONLY ACCESS
+# =============================================================================
+# A reusable group granting full read visibility but no write, no execute, and
+# no ability to read secret VALUES or decrypt CMK-encrypted data. Add any IAM
+# user to this group to grant read-only access; no user identities are declared
+# here. Permissions live on the group, not on users (AC-2(1)/AC-6; clears Prowler
+# iam_policy_attached_only_to_group_or_roles), as with operators.
+# =============================================================================
+resource "aws_iam_group" "read_only" {
+  name = "read-only"
+}
+
+# AWS-managed ReadOnlyAccess: every Get/List/Describe across services; no write,
+# no invoke/execute. This is the "see all the info, change nothing" baseline.
+resource "aws_iam_group_policy_attachment" "read_only" {
+  group      = aws_iam_group.read_only.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+# Carve-outs from ReadOnlyAccess (a Deny always overrides the managed Allow):
+# read-only members may see that the secret and KMS keys exist, but cannot read
+# the Anthropic API key's value or decrypt any CMK-encrypted data (Lambda env,
+# encrypted log content, signed-blob plaintext, etc.).
+resource "aws_iam_group_policy" "read_only_deny_sensitive" {
+  # checkov:skip=CKV_AWS_355:A Deny on Resource:* is the intended blast radius —
+  # it must cover every secret/key in the account, not a scoped subset.
+  name  = "deny-secret-values-and-decrypt"
+  group = aws_iam_group.read_only.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid      = "DenySecretValuesAndDecrypt"
+      Effect   = "Deny"
+      Action   = ["secretsmanager:GetSecretValue", "kms:Decrypt"]
+      Resource = "*"
+    }]
+  })
+}


### PR DESCRIPTION
## Changed
Adds a generic, reusable **`read-only`** IAM group in the foundational IAM layer (`infrastructure/bootstrap/main.tf`):
- AWS-managed **`ReadOnlyAccess`** attached → full `Get/List/Describe`, no write/execute.
- Inline **`Deny`** on `secretsmanager:GetSecretValue` + `kms:Decrypt` → members can see secrets/keys exist but can't read secret values or decrypt CMK-encrypted data.
- Permissions on the **group**, not on users (AC-2(1)/AC-6; keeps Prowler `iam_policy_attached_only_to_group_or_roles` green), same as `operators`.

**No user identities are declared.** To grant someone read-only access, add their IAM user to this group out-of-band — the group is the reusable permission bundle; specific users (and their passwords/MFA) stay out of the repo.

## Verified
`terraform validate` passes in `bootstrap/`. Group-scoped only; no policy attached directly to a user.

## Applied via the bootstrap layer (manual, not the per-deploy CI)
After merge: `cd infrastructure/bootstrap && terraform apply`. Then add a user to the group as needed (`aws iam add-user-to-group --group-name read-only --user-name <name>`), set their console password out-of-band, and they enroll their own MFA.

CodeGuard: an IAM group + a Deny carve-out; no secrets, no broadened privilege (ReadOnlyAccess is read-only and the Deny tightens it). No findings.