### PR TITLE
bootstrap: align compliance-kms Sid with live (state reconcile)

### DIFF
--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -215,6 +215,7 @@ resource "aws_iam_role_policy" "compliance_logs" {
 data "aws_iam_policy_document" "compliance_kms" {
   # checkov:skip=CKV_AWS_356:KMS alias-based scoping requires Resource "*"; the kms:ResourceAliases condition restricts the grant to two specific app-key aliases. No write to key policy, no admin. Documented exception.
   statement {
+    sid    = "EncryptAndGrantAppCmkForLambdaEnv"
     effect = "Allow"
     actions = [
       "kms:Encrypt",


### PR DESCRIPTION
## Context
Reconciled `bootstrap/`'s local Terraform state, which had drifted from live (it tracked 13 resources while the config declared ~21 — the operators group, password policy, and deploy-role inline policies were applied via live CLI in earlier tasks and never imported into bootstrap state).

## What was done
- **Imported** the 18 missing live resources into bootstrap state (non-destructive — `terraform import` only records existing resources; no live change). State now tracks all of them.
- **This commit:** the only resulting config diff was cosmetic — the live `compliance-kms-encrypt` policy carried a `Sid` (`EncryptAndGrantAppCmkForLambdaEnv`) and the `.tf` data source omitted it. Adding the `sid` makes the config match live exactly. Same permissions; purely a parity/documentation fix.

## Verified
`terraform plan` in `bootstrap/` → **"No changes. Your infrastructure matches the configuration."**

Note: bootstrap keeps **local** state (no remote backend), so this reconciliation lives on the machine that ran the imports. A future improvement would be a remote backend so the reconciled state is shared, but that's out of scope here.

CodeGuard: a one-line `sid` addition to an existing policy document; no permission change, no secrets. No findings.