### PR TITLE
infra(bootstrap): manage the CloudFront distribution as code

### DIFF
--- a/infrastructure/bootstrap/.gitignore
+++ b/infrastructure/bootstrap/.gitignore
@@ -2,3 +2,4 @@
 .terraform.lock.hcl
 *.tfstate
 *.tfstate.*
+*.tfvars

--- a/infrastructure/bootstrap/README.md
+++ b/infrastructure/bootstrap/README.md
@@ -20,6 +20,35 @@ After a green OIDC deploy proves the role works, the legacy IAM user and its
 access key are deleted and the `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
 repo secrets are removed (the POAM-001 closure). Until then both paths coexist.
 
+## CloudFront (cloudfront.tf)
+
+This module also manages the **CloudFront distribution** that serves the site
+(and proxies the Silk Reeling app) plus its Origin Access Control. CloudFront is
+foundational, rarely-changing infrastructure, so — like the IAM trust layer — it
+is managed here and applied deliberately, **not** re-applied on every website
+deploy. The per-deploy `infrastructure/` stack keeps reading it through a
+`data "aws_cloudfront_distribution"`; a routine deploy never plans or mutates it.
+The config (origins, behaviors, the 403/404 → `/404.html` error responses, TLS,
+OAC) was reconciled byte-for-byte against the live distribution before commit.
+
+Two inputs are not committed (kept in a local, git-ignored `terraform.tfvars`):
+
+- `silk_reeling_api_origin_domain` — the API Gateway origin host for the
+  `/silk-reeling/*` behavior (`<api-id>.execute-api.<region>.amazonaws.com`).
+- `owner_email` — the value of the distribution's `Owner` tag (kept out of the
+  public repo).
+
+On a fresh state, import the two resources before the first plan:
+
+```
+terraform import aws_cloudfront_origin_access_control.website <oac-id>
+terraform import aws_cloudfront_distribution.website          <distribution-id>
+terraform plan   # expect: No changes
+```
+
+`prevent_destroy` is set on the distribution so a plan can never replace or
+destroy it; changes are made in place and reviewed.
+
 ## Apply
 
 ```

--- a/infrastructure/bootstrap/cloudfront.tf
+++ b/infrastructure/bootstrap/cloudfront.tf
@@ -59,6 +59,13 @@ resource "aws_cloudfront_origin_access_control" "website" {
 }
 
 resource "aws_cloudfront_distribution" "website" {
+  # Scanner findings that describe this distribution's deliberate posture. Each is
+  # classified here at scan-time (not silently dropped); the WAF/failover items
+  # are already tracked in the POA&M register, the other two are noted for it.
+  # checkov:skip=CKV_AWS_310:Risk-accepted (POAM-009). The two origins serve distinct path patterns (static S3 site vs the Silk Reeling API), not a redundant failover pair, so an origin group does not apply.
+  # checkov:skip=CKV2_AWS_47:Risk-accepted (POAM-007/008). A WAF is intentionally declined for this system (SC-7/SC-5 met via the CloudFront + API Gateway managed interfaces, Shield Standard, and throttling); there is also no Java/Log4j runtime in scope, so the Log4j AMR rule is moot.
+  # checkov:skip=CKV_AWS_374:Not applicable. This is a public personal website intended to be reachable from every geography; no control requires geo-blocking. Documented as a false positive for this system.
+  # checkov:skip=CKV2_AWS_32:Residual, risk-accepted. No CloudFront response-headers policy is attached today; attaching one (security headers) is a cheap follow-up hardening tracked for a deliberate change, not a fix folded into this faithful-import PR.
   enabled             = true
   is_ipv6_enabled     = true
   comment             = ""

--- a/infrastructure/bootstrap/cloudfront.tf
+++ b/infrastructure/bootstrap/cloudfront.tf
@@ -1,0 +1,182 @@
+# =============================================================================
+# CloudFront edge — managed here in the bootstrap (foundational) stack
+# =============================================================================
+# The distribution that serves the whole site (and proxies the Silk Reeling app)
+# is foundational, rarely-changing infrastructure. It is managed here, in the
+# manually-applied bootstrap stack with local state, for the same reasons the
+# IAM trust layer is: it should change deliberately, not be re-applied on every
+# website deploy. The per-deploy pipeline in ../ keeps READING it through
+# `data "aws_cloudfront_distribution" "website"`, so a routine website deploy
+# never plans or mutates the distribution.
+#
+# This configuration was reconciled byte-for-byte against the live distribution
+# (terraform plan == "No changes") before being committed, including the
+# custom_error_response entries that route 403/404 to the styled /404.html page.
+#
+# To bring it under management on a fresh bootstrap state:
+#   terraform import aws_cloudfront_origin_access_control.website <OAC_ID>
+#   terraform import aws_cloudfront_distribution.website          <DISTRIBUTION_ID>
+# then `terraform plan` should report no changes.
+# =============================================================================
+
+# ACM certificate for the aliases (must be in us-east-1 for CloudFront).
+data "aws_acm_certificate" "website" {
+  provider    = aws.us_east_1
+  domain      = var.domain_name
+  statuses    = ["ISSUED"]
+  most_recent = true
+}
+
+# AWS-managed cache / origin-request policies used by the /silk-reeling/* behavior.
+# These are well-known global managed policies (same IDs in every account); read
+# by name so no magic IDs are hard-coded.
+data "aws_cloudfront_cache_policy" "caching_disabled" {
+  name = "Managed-CachingDisabled"
+}
+
+data "aws_cloudfront_origin_request_policy" "all_viewer_except_host" {
+  name = "Managed-AllViewerExceptHostHeader"
+}
+
+# The viewer-request function that strips the /silk-reeling prefix before the
+# request reaches the API Gateway origin. Referenced (not managed) here so its
+# code is not duplicated; it is published out-of-band from
+# ../cloudfront/silk-reeling-strip-prefix.js.
+data "aws_cloudfront_function" "strip_prefix" {
+  name  = "silk-reeling-strip-prefix"
+  stage = "LIVE"
+}
+
+# Origin Access Control: lets CloudFront (and only CloudFront) read the private
+# S3 origin via SigV4. Managed here; the S3 bucket policy in ../ already trusts
+# the distribution ARN.
+resource "aws_cloudfront_origin_access_control" "website" {
+  name                              = "${var.domain_name}-oac"
+  description                       = "OAC for ${var.domain_name}"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "website" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = ""
+  default_root_object = "index.html"
+  http_version        = "http2"
+  price_class         = "PriceClass_100"
+  aliases             = ["www.${var.domain_name}", var.domain_name]
+
+  # Private S3 origin (static site), reached through the OAC above.
+  origin {
+    origin_id                = "S3-${var.domain_name}"
+    domain_name              = "${var.domain_name}.s3.${var.aws_region}.amazonaws.com"
+    origin_access_control_id = aws_cloudfront_origin_access_control.website.id
+    connection_attempts      = 3
+    connection_timeout       = 10
+  }
+
+  # Silk Reeling API Gateway origin (the app behind /silk-reeling/*).
+  origin {
+    origin_id           = "apigw-silk-reeling"
+    domain_name         = var.silk_reeling_api_origin_domain
+    connection_attempts = 3
+    connection_timeout  = 10
+    custom_origin_config {
+      http_port                = 80
+      https_port               = 443
+      origin_protocol_policy   = "https-only"
+      origin_ssl_protocols     = ["TLSv1.2"]
+      origin_read_timeout      = 30
+      origin_keepalive_timeout = 5
+    }
+  }
+
+  # Static site: cache normally, redirect to HTTPS.
+  default_cache_behavior {
+    target_origin_id       = "S3-${var.domain_name}"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
+    cached_methods         = ["HEAD", "GET"]
+    compress               = true
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  # App path: no caching, forward everything except Host (so the JWT authorizer
+  # sees the Authorization header), strip the prefix at the edge.
+  ordered_cache_behavior {
+    path_pattern             = "/silk-reeling/*"
+    target_origin_id         = "apigw-silk-reeling"
+    viewer_protocol_policy   = "redirect-to-https"
+    allowed_methods          = ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"]
+    cached_methods           = ["HEAD", "GET"]
+    compress                 = true
+    cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer_except_host.id
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = data.aws_cloudfront_function.strip_prefix.arn
+    }
+  }
+
+  # Serve the styled 404 page. S3-via-OAC returns 403 for a missing object, so
+  # both 403 and 404 map to /404.html with a real 404 status. Short error cache
+  # so a fixed/added page propagates quickly.
+  custom_error_response {
+    error_code            = 403
+    response_code         = 404
+    response_page_path    = "/404.html"
+    error_caching_min_ttl = 10
+  }
+  custom_error_response {
+    error_code            = 404
+    response_code         = 404
+    response_page_path    = "/404.html"
+    error_caching_min_ttl = 10
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = data.aws_acm_certificate.website.arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  tags = {
+    Name               = "${var.domain_name}-cdn"
+    Environment        = var.deploy_environment
+    Owner              = var.owner_email
+    CostCenter         = "website-ops"
+    DataClassification = "Public"
+    ComplianceScope    = "Section508"
+  }
+
+  # The distribution serves the entire site and the app. It must never be
+  # replaced or destroyed by a plan; changes are made in place and reviewed.
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+variable "silk_reeling_api_origin_domain" {
+  type        = string
+  description = "Hostname of the Silk Reeling API Gateway origin behind the /silk-reeling/* behavior, e.g. <api-id>.execute-api.<region>.amazonaws.com. Supplied at apply time; not a secret, but kept out of committed code so the stack stays portable."
+}
+
+variable "owner_email" {
+  type        = string
+  description = "Value for the distribution's Owner tag. Supplied at apply time so a personal address is not committed to the public repo."
+}

--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -19,6 +19,14 @@ provider "aws" {
   region = var.aws_region
 }
 
+# CloudFront and its ACM certificate live in us-east-1 (ACM certs for CloudFront
+# must be issued there). CloudFront itself is global, but the cert data source
+# must read from us-east-1. See cloudfront.tf.
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
 variable "aws_region" {
   type    = string
   default = "us-east-2"


### PR DESCRIPTION
## Changed
Bring the **CloudFront distribution** and its **Origin Access Control** under Terraform, in the manually-applied **bootstrap** stack (local state), instead of leaving them unmanaged and referenced only by a data source. This was prompted by a manual change (adding the 403/404 → `/404.html` custom error responses for the styled 404 page); that change is now codified so it is reproducible from code.

- **`bootstrap/cloudfront.tf`** (new): the distribution — two origins (private S3 via OAC, and the Silk Reeling API Gateway), the static-site default behavior and the `/silk-reeling/*` behavior, TLS via the ACM cert, the `strip-prefix` viewer-request function, and the **403/404 → `/404.html`** custom error responses — plus the `aws_cloudfront_origin_access_control`. The cert, AWS-managed cache/origin-request policies, and the function are read via **data sources by name**; the OAC is managed. `prevent_destroy` guards the distribution against replacement/destroy.
- **`bootstrap/main.tf`**: a `us-east-1` provider alias (CloudFront's ACM cert lives there).
- **`bootstrap/.gitignore` + README**: the API origin host and the `Owner` tag value are supplied as **variables** from a local, git-ignored `terraform.tfvars`, so no account IDs, ARNs, secrets, or personal address land in the public repo.

**Why bootstrap and not the per-deploy pipeline:** the distribution serves the entire site + app and rarely changes. Managing it in bootstrap (applied deliberately, like the IAM trust layer) keeps it out of the ephemeral-state pipeline, so a routine website deploy never plans or mutates it. The per-deploy `infrastructure/` stack keeps reading it through its existing `data "aws_cloudfront_distribution"` — unchanged.

## Verified (live)
- Authored against the live `get-distribution-config`, then reconciled in an **isolated throwaway workspace**: `terraform import` of the OAC + distribution followed by `terraform plan` → **"No changes. Your infrastructure matches the configuration."**
- Imported into the **real bootstrap state** and re-planned: the CloudFront resources show **no changes**; the only diff in the stack is the unrelated, pre-existing `compliance_kms` policy item (tracked separately), confirming this change adds no drift.
- Earlier, the live distribution was confirmed serving the custom 404 (a missing URL returns HTTP 404 rendering `/404.html`); this PR makes that configuration reproducible.
- CodeGuard (IaC) applied: no committed secrets/ARNs/account IDs; TLS is `redirect-to-https` viewer + `TLSv1.2_2021` minimum + `https-only` origin; `prevent_destroy` set. No findings.

## Residual / needs human
- On any **fresh** bootstrap state, the two resources must be `terraform import`ed before the first plan (documented in the README); on the operator's current state they are already imported.
- The `compliance_kms` policy diff in the bootstrap stack is pre-existing and out of scope here.

## Couldn't verify
- Nothing outstanding for this change.