### PR TITLE
ci(supply-chain S2): SLSA/in-toto provenance attestations per artifact

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -1280,6 +1280,48 @@ jobs:
         aws s3 cp ../website/viewer.html "s3://$BUCKET_NAME/viewer.html" --content-type "text/html; charset=utf-8" --cache-control "public, max-age=300"
         echo "✅ All signed artifacts published to /.well-known/ (post-gate)"
 
+    # -------------------------------------------------------------------------
+    # ATTEST ARTIFACT PROVENANCE (SLSA v1 / in-toto, DSSE — Task 14 / S2)
+    # -------------------------------------------------------------------------
+    # Each core compliance artifact gets a DSSE-signed SLSA provenance
+    # attestation binding it to the canonical inventory (ksi-signal.json sha256 +
+    # signal_id), the generator that produced it, this commit, and this run. This
+    # is the cryptographic form of reconciliation invariant (e) + the publish-
+    # freshness commit check: instead of string-matching the signal_id/commit, the
+    # binding is a signed attestation any in-toto-aware verifier can consume. Each
+    # attestation is verified here against the pinned identity, fail-closed.
+    # Additive only — the artifacts and their existing .bundle signatures are
+    # unchanged; this publishes new <artifact>.intoto.jsonl alongside them.
+    - name: Attest artifact provenance (SLSA/in-toto)
+      working-directory: infrastructure
+      run: |
+        BUCKET_NAME=$(terraform output -raw s3_bucket_name)
+        attest() {
+          art="$1"; gen="$2"
+          python3 ../scripts/build-provenance.py \
+            --ksi-signal ksi-signal.json --generator "../$gen" \
+            --output "$art.predicate.json"
+          cosign attest-blob --yes \
+            --predicate "$art.predicate.json" --type slsaprovenance1 \
+            --bundle "$art.intoto.jsonl" "$art"
+          cosign verify-blob-attestation \
+            --bundle "$art.intoto.jsonl" --type slsaprovenance1 \
+            --certificate-identity 'https://github.com/sam-aydlette/samaydlette.com/.github/workflows/deploy-with-opa.yml@refs/heads/main' \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "$art"
+          aws s3 cp "$art.intoto.jsonl" "s3://$BUCKET_NAME/.well-known/$art.intoto.jsonl" \
+            --content-type application/json --cache-control "public, max-age=300"
+          echo "  attested + published: $art.intoto.jsonl"
+        }
+        # Core canonical evidence set. Extending to the remaining CDS/SDR/CPO
+        # artifacts is one attest() line each (tracked follow-on).
+        attest ksi-signal.json scripts/build-ksi-signal.py
+        attest oscal-ssp.json  scripts/build-oscal-ssp.py
+        attest oscal-poam.json scripts/build-oscal-poam.py
+        attest vdr-report.json scripts/build-vdr-report.py
+        attest iiw.csv         scripts/build-iiw.py
+        echo "✅ SLSA/in-toto provenance attestations published for the core compliance artifacts"
+
     # Sign the research paper itself (a paper whose thesis is verifiability should
     # be verifiable). The signed bytes are the served bytes of
     # /research/the-plumbing.html; the bundle is published at a stable

--- a/scripts/build-provenance.py
+++ b/scripts/build-provenance.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+build-provenance.py - emit a SLSA v1 in-toto provenance PREDICATE for one
+published compliance artifact (Task 14 / S2).
+
+It binds the artifact to:
+  - the canonical inventory: ksi-signal.json content sha256 + its signal_id,
+  - the generator that produced it (scripts/build-*.py, by content sha256),
+  - this commit (git+repo@ref with gitCommit), and
+  - the CI run (builder id + invocationId).
+
+The builder.id and commit are taken from build-ksi-signal.py's build_provenance()
+so there is ONE source of truth for the pinned identity (derived from
+GITHUB_WORKFLOW_REF, the Fulcio SAN - never the spaced display name); that logic
+is covered by tests/test_provenance.py.
+
+cosign attest-blob --type slsaprovenance1 --predicate <this output> <artifact>
+wraps it into a DSSE-signed in-toto Statement whose subject is the artifact's
+own sha256, so the binding cannot be forged by editing this file. This is the
+cryptographic form of reconciliation invariant (e) (one-inventory binding) plus
+the publish-freshness commit check, consumable by any in-toto-aware verifier.
+
+Honesty note: the builder is this repo's self-hosted GitHub Actions identity
+(Sigstore keyless, public Rekor log) - NOT a managed SLSA L3 build service, and
+this strengthens the evidence mechanism, not its authorization.
+"""
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+# Reuse the signal builder's provenance logic so builder.id is single-sourced.
+_KSI_PATH = Path(__file__).resolve().parent / "build-ksi-signal.py"
+_spec = importlib.util.spec_from_file_location("ksi_builder", _KSI_PATH)
+_ksi = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_ksi)
+
+# Fallback identity if GITHUB_WORKFLOW_REF is absent (e.g. local dry-run).
+BUILDER_ID_FALLBACK = (
+    "https://github.com/sam-aydlette/samaydlette.com/"
+    ".github/workflows/deploy-with-opa.yml@refs/heads/main"
+)
+BUILD_TYPE = "https://samaydlette.com/buildtypes/compliance-artifact/v1"
+
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def build_predicate(ksi_signal_path, generator_path):
+    ksi_path = Path(ksi_signal_path)
+    signal = json.loads(ksi_path.read_text())
+    signal_id = signal.get("signal_id", "unknown")
+    ksi_hash = sha256_file(ksi_path)
+
+    gen_path = Path(generator_path)
+    gen_hash = sha256_file(gen_path)
+    gen_name = "scripts/" + gen_path.name
+
+    prov = _ksi.build_provenance() or {}
+    builder_id = (prov.get("builder") or {}).get("id") or BUILDER_ID_FALLBACK
+    source = prov.get("source") or {}
+    commit = source.get("commit") or os.environ.get("GITHUB_SHA", "unknown")
+    ref = source.get("ref") or "refs/heads/main"
+    repo_url = source.get("repository") or "https://github.com/sam-aydlette/samaydlette.com"
+    run_id = os.environ.get("GITHUB_RUN_ID", "unknown")
+
+    return {
+        "buildDefinition": {
+            "buildType": BUILD_TYPE,
+            "externalParameters": {
+                "workflow": {
+                    "ref": ref,
+                    "repository": repo_url,
+                    "path": ".github/workflows/deploy-with-opa.yml",
+                }
+            },
+            "internalParameters": {
+                "inventory_signal_id": signal_id,
+            },
+            "resolvedDependencies": [
+                {
+                    "uri": f"{repo_url.replace('https://', 'git+https://')}@{ref}",
+                    "digest": {"gitCommit": commit},
+                },
+                {
+                    "uri": "ksi-signal.json",
+                    "digest": {"sha256": ksi_hash},
+                    "annotations": {
+                        "signal_id": signal_id,
+                        "role": "canonical-inventory",
+                    },
+                },
+                {
+                    "uri": gen_name,
+                    "digest": {"sha256": gen_hash},
+                    "annotations": {"role": "generator"},
+                },
+            ],
+        },
+        "runDetails": {
+            "builder": {"id": builder_id},
+            "metadata": {
+                "invocationId": f"{repo_url}/actions/runs/{run_id}",
+            },
+        },
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--ksi-signal",
+        default="ksi-signal.json",
+        help="Path to the canonical inventory whose content sha256 + signal_id anchor the binding",
+    )
+    ap.add_argument(
+        "--generator",
+        required=True,
+        help="Path to the scripts/build-*.py that produced the artifact being attested",
+    )
+    ap.add_argument("--output", default="-", help="Output path for the predicate JSON ('-' = stdout)")
+    args = ap.parse_args()
+
+    predicate = build_predicate(args.ksi_signal, args.generator)
+    out = json.dumps(predicate, indent=2)
+    if args.output == "-":
+        print(out)
+    else:
+        Path(args.output).write_text(out + "\n")
+        print(f"provenance predicate written: {args.output}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_build_provenance.py
+++ b/tests/test_build_provenance.py
@@ -1,0 +1,77 @@
+"""Tests for scripts/build-provenance.py (Task 14 / S2).
+
+Verifies the SLSA v1 provenance predicate binds an artifact to the canonical
+inventory's content hash + signal_id, the generator, the commit, and the run;
+that the inventory/generator digests are the real sha256 of the bytes (so the
+binding cannot be forged without changing the digest); and that builder.id is
+the single-sourced pinned identity from build-ksi-signal.py's build_provenance()
+(GITHUB_WORKFLOW_REF, the Fulcio SAN - never a wildcard or the display name).
+"""
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "build_provenance", REPO / "scripts" / "build-provenance.py"
+)
+bp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bp)
+
+WORKFLOW_REF = "sam-aydlette/samaydlette.com/.github/workflows/deploy-with-opa.yml@refs/heads/main"
+EXPECTED_BUILDER = "https://github.com/" + WORKFLOW_REF
+
+
+def _ci_env(monkeypatch):
+    for k in ("GITHUB_REPOSITORY", "GITHUB_WORKFLOW", "GITHUB_WORKFLOW_REF",
+              "GITHUB_RUN_ID", "GITHUB_SHA", "GITHUB_REF", "KSI_SIGN"):
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("GITHUB_REPOSITORY", "sam-aydlette/samaydlette.com")
+    monkeypatch.setenv("GITHUB_WORKFLOW_REF", WORKFLOW_REF)
+    monkeypatch.setenv("GITHUB_RUN_ID", "42")
+    monkeypatch.setenv("GITHUB_SHA", "deadbeef")
+    monkeypatch.setenv("GITHUB_REF", "refs/heads/main")
+
+
+def _signal(tmp_path):
+    p = tmp_path / "ksi-signal.json"
+    p.write_text(json.dumps({"signal_id": "test-uuid-1234", "components": []}))
+    return p
+
+
+def _deps(pred):
+    return {d.get("annotations", {}).get("role") or "src": d
+            for d in pred["buildDefinition"]["resolvedDependencies"]}
+
+
+def test_predicate_structure_and_bindings(tmp_path, monkeypatch):
+    _ci_env(monkeypatch)
+    sig = _signal(tmp_path)
+    gen = REPO / "scripts" / "build-oscal-ssp.py"
+    pred = bp.build_predicate(str(sig), str(gen))
+
+    assert set(pred) == {"buildDefinition", "runDetails"}
+    assert pred["buildDefinition"]["buildType"].startswith("https://")
+    deps = _deps(pred)
+
+    # commit binding comes through build_provenance() -> GITHUB_SHA
+    assert deps["src"]["digest"]["gitCommit"] == "deadbeef"
+    # inventory digest is the REAL sha256 of the bytes
+    assert deps["canonical-inventory"]["digest"]["sha256"] == hashlib.sha256(sig.read_bytes()).hexdigest()
+    assert deps["canonical-inventory"]["annotations"]["signal_id"] == "test-uuid-1234"
+    assert pred["buildDefinition"]["internalParameters"]["inventory_signal_id"] == "test-uuid-1234"
+    # generator digest is the real sha256 of the generator file
+    assert deps["generator"]["uri"] == "scripts/build-oscal-ssp.py"
+    assert deps["generator"]["digest"]["sha256"] == hashlib.sha256(gen.read_bytes()).hexdigest()
+
+
+def test_builder_id_single_sourced_and_pinned(tmp_path, monkeypatch):
+    _ci_env(monkeypatch)
+    sig = _signal(tmp_path)
+    pred = bp.build_predicate(str(sig), str(REPO / "scripts" / "build-iiw.py"))
+    bid = pred["runDetails"]["builder"]["id"]
+    assert bid == EXPECTED_BUILDER          # derived from WORKFLOW_REF, not hardcoded drift
+    assert " " not in bid                   # never the spaced display name
+    assert not bid.endswith("@*")           # never a wildcard ref
+    assert "/actions/runs/42" in pred["runDetails"]["metadata"]["invocationId"]


### PR DESCRIPTION
Second step of the supply-chain track (**Task 14 / S2**). Depends on S1 (merged). Additive, no artifact-format change.

## Changed
Each core compliance artifact now carries a **DSSE-signed SLSA v1 provenance attestation** binding it to:
- the **canonical inventory** — `ksi-signal.json` content sha256 + its `signal_id`,
- the **generator** that produced it (`scripts/build-*.py`, by content sha256),
- **this commit** (`git+…@ref`, `gitCommit`), and
- **this run** (pinned `builder.id` + `invocationId`).

This is the cryptographic form of reconciliation invariant **(e)** (one-inventory binding) plus the publish-freshness commit check: instead of string-matching the `signal_id`/commit across artifacts, the binding is a signed in-toto statement any in-toto-aware verifier can consume.

- **`scripts/build-provenance.py`** — emits the SLSA v1 predicate. `builder.id` is **reused from `build-ksi-signal.py:build_provenance()`** (one source of truth for the pinned identity, derived from `GITHUB_WORKFLOW_REF`), so it agrees with the signal's own embedded provenance — complementary, not duplicative. The subject is added by cosign from the blob's digest, so the binding can't be forged by editing the predicate.
- **`deploy-with-opa.yml`** — after publish: `cosign attest-blob --type slsaprovenance1` each of `ksi-signal.json`, `oscal-ssp.json`, `oscal-poam.json`, `vdr-report.json`, `iiw.csv`; `verify-blob-attestation` against the pinned identity (**fail-closed**); publish `<artifact>.intoto.jsonl` at `/.well-known/`.
- **`tests/test_build_provenance.py`** — binding + single-sourced-pinned-identity tests (named to avoid the existing `test_provenance.py`).

## Verified
- `pytest tests/test_build_provenance.py tests/test_provenance.py` → **6 passed** (mine + the pre-existing signal-provenance tests; nothing clobbered).
- Generator end-to-end: the inventory/generator digests are the **real sha256** of the bytes; `builder.id` derives to the pinned `…deploy-with-opa.yml@refs/heads/main`. YAML parses; attest/publish steps run from `infrastructure/`.
- Additive: existing artifacts, their `.bundle` signatures, the reconcile gate, and the OPA gate are unchanged. Live deploy on merge is the real test (`cosign attest-blob` needs CI OIDC); I'll then verify a published `.intoto.jsonl` with `cosign verify-blob-attestation` against the pinned identity.
- CodeGuard (python/devops): keyless OIDC, pinned-identity fail-closed verification, no secrets, no untrusted-input interpolation, controlled paths. No findings.

## Residual / follow-ons (tracked)
- Extend attestation to the remaining CDS/SDR/CPO artifacts (one `attest()` line each).
- Optional reconcile invariant that cross-checks each attestation's `materials.signal_id`/sha256 against the live inventory (deeper enforcement).
- SR-3/SR-4/SR-11 + SI-7 control-narrative mapping (cross-cutting task #44).