### PR TITLE
ci(supply-chain S3): consumable inline-DSSE attestations + non-cosign consumer

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -1301,17 +1301,26 @@ jobs:
           python3 ../scripts/build-provenance.py \
             --ksi-signal ksi-signal.json --generator "../$gen" \
             --output "$art.predicate.json"
-          cosign attest-blob --yes \
+          # --new-bundle-format emits a Sigstore bundle with the DSSE envelope
+          # INLINE (S3), so the in-toto Statement is decodable by any DSSE/in-toto
+          # tool, not only by cosign.
+          cosign attest-blob --yes --new-bundle-format \
             --predicate "$art.predicate.json" --type slsaprovenance1 \
             --bundle "$art.intoto.jsonl" "$art"
-          cosign verify-blob-attestation \
+          # 1) cosign verifies the signature + identity (trust).
+          cosign verify-blob-attestation --new-bundle-format \
             --bundle "$art.intoto.jsonl" --type slsaprovenance1 \
             --certificate-identity 'https://github.com/sam-aydlette/samaydlette.com/.github/workflows/deploy-with-opa.yml@refs/heads/main' \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             "$art"
+          # 2) a dependency-free, non-cosign consumer reads the predicate and
+          #    checks the bindings (subject==artifact, inventory sha256, generator,
+          #    commit) - the reciprocity claim, exercised in CI, fail-closed.
+          python3 ../scripts/verify-attestation.py \
+            --bundle "$art.intoto.jsonl" --artifact "$art" --ksi-signal ksi-signal.json
           aws s3 cp "$art.intoto.jsonl" "s3://$BUCKET_NAME/.well-known/$art.intoto.jsonl" \
             --content-type application/json --cache-control "public, max-age=300"
-          echo "  attested + published: $art.intoto.jsonl"
+          echo "  attested (inline-DSSE) + consumed + published: $art.intoto.jsonl"
         }
         # Core canonical evidence set. Extending to the remaining CDS/SDR/CPO
         # artifacts is one attest() line each (tracked follow-on).
@@ -1369,6 +1378,10 @@ jobs:
         check security-decision-record.json .well-known/security-decision-record.json
         check certification-package-overview.json .well-known/certification-package-overview.json
         check iiw.csv .well-known/iiw.csv
+        # SLSA/in-toto provenance attestations (S2/S3): served bytes match the build.
+        for a in ksi-signal.json oscal-ssp.json oscal-poam.json vdr-report.json iiw.csv; do
+          check "$a.intoto.jsonl" ".well-known/$a.intoto.jsonl"
+        done
         if [ "$fail" -ne 0 ]; then
           echo "Post-publish round-trip FAILED — served artifacts do not match the build."; exit 1
         fi

--- a/scripts/verify-attestation.py
+++ b/scripts/verify-attestation.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+verify-attestation.py - a dependency-free, NON-cosign consumer of the SLSA/in-toto
+provenance attestations this pipeline publishes (Task 15 / S3).
+
+It reads a Sigstore *new-bundle-format* attestation (the inline-DSSE form produced
+by `cosign attest-blob --new-bundle-format`), decodes the DSSE envelope to the
+in-toto Statement, and checks the CLAIMS:
+  - the Statement subject's sha256 equals the artifact's bytes (the binding),
+  - the predicate is SLSA provenance v1,
+  - the predicate binds the canonical inventory (ksi-signal.json sha256 + signal_id),
+    the generator, and a commit.
+
+This is the point of the whole supply-chain track: the evidence is consumable by
+ANY in-toto-aware tool, not only by our own viewer. It deliberately does NOT
+re-verify the Sigstore signature - that is cosign's job (verify-blob-attestation,
+run alongside this) - it demonstrates that a downstream party can read and act on
+the predicate. Honest scope: claims-consumption, not signature trust.
+
+Exit non-zero (fail closed) on any missing/mismatched binding.
+"""
+import argparse
+import base64
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+SLSA_V1 = "https://slsa.dev/provenance/v1"
+
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def extract_statement(bundle):
+    """Pull the in-toto Statement out of a Sigstore new-format bundle's DSSE
+    envelope. Accepts a few key spellings across bundle versions."""
+    env = None
+    for k in ("dsseEnvelope", "dsse_envelope"):
+        if isinstance(bundle, dict) and k in bundle:
+            env = bundle[k]
+            break
+    if env is None:
+        raise ValueError("no dsseEnvelope in bundle (is this the new bundle format?)")
+    payload_b64 = env.get("payload")
+    if not payload_b64:
+        raise ValueError("dsseEnvelope has no payload")
+    return json.loads(base64.b64decode(payload_b64))
+
+
+def check(bundle_path, artifact_path, ksi_signal_path=None):
+    bundle = json.loads(Path(bundle_path).read_text())
+    stmt = extract_statement(bundle)
+    errors = []
+
+    if stmt.get("_type") not in ("https://in-toto.io/Statement/v1", "https://in-toto.io/Statement/v0.1"):
+        errors.append(f"unexpected statement _type: {stmt.get('_type')!r}")
+    if stmt.get("predicateType") != SLSA_V1:
+        errors.append(f"predicateType is {stmt.get('predicateType')!r}, expected {SLSA_V1}")
+
+    # subject binding: the statement's subject sha256 must equal the artifact bytes
+    art_digest = sha256_file(artifact_path)
+    subj_digests = [s.get("digest", {}).get("sha256") for s in stmt.get("subject", [])]
+    if art_digest not in subj_digests:
+        errors.append(f"subject digest {subj_digests} does not match artifact sha256 {art_digest}")
+
+    # predicate bindings
+    pred = stmt.get("predicate", {})
+    deps = pred.get("buildDefinition", {}).get("resolvedDependencies", [])
+    by_role = {d.get("annotations", {}).get("role"): d for d in deps}
+    inv = by_role.get("canonical-inventory")
+    gen = by_role.get("generator")
+    commit_dep = next((d for d in deps if "gitCommit" in d.get("digest", {})), None)
+
+    if not inv or not inv.get("digest", {}).get("sha256"):
+        errors.append("no canonical-inventory dependency with a sha256")
+    if not gen or not gen.get("digest", {}).get("sha256"):
+        errors.append("no generator dependency with a sha256")
+    if not commit_dep:
+        errors.append("no source dependency with a gitCommit")
+
+    # optional cross-check: the inventory digest in the predicate equals the
+    # actual ksi-signal.json bytes (a tampered inventory would not match)
+    if ksi_signal_path and inv:
+        want = sha256_file(ksi_signal_path)
+        got = inv.get("digest", {}).get("sha256")
+        if want != got:
+            errors.append(f"inventory digest {got} != actual ksi-signal.json sha256 {want}")
+
+    return stmt, errors
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--bundle", required=True, help="Path to the *.intoto.jsonl new-format attestation")
+    ap.add_argument("--artifact", required=True, help="Path to the artifact the attestation should bind to")
+    ap.add_argument("--ksi-signal", default=None, help="Optional ksi-signal.json to cross-check the inventory digest")
+    args = ap.parse_args()
+
+    try:
+        stmt, errors = check(args.bundle, args.artifact, args.ksi_signal)
+    except Exception as e:  # noqa: BLE001 - any decode failure is a hard fail
+        print(f"FAIL {args.bundle}: {e}", file=sys.stderr)
+        return 2
+
+    if errors:
+        print(f"FAIL {args.bundle}:", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    subj = stmt["subject"][0]
+    print(f"ok  {Path(args.artifact).name}: in-toto SLSA-v1 statement consumed, subject "
+          f"sha256={subj['digest']['sha256'][:16]}… bound to the artifact and the inventory")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_verify_attestation.py
+++ b/tests/test_verify_attestation.py
@@ -1,0 +1,91 @@
+"""Tests for scripts/verify-attestation.py (Task 15 / S3).
+
+Builds a synthetic Sigstore new-bundle-format attestation (inline DSSE envelope
+wrapping an in-toto SLSA v1 Statement) and checks that the dependency-free
+consumer accepts a correct one and fails closed on tampering.
+"""
+import base64
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "verify_attestation", REPO / "scripts" / "verify-attestation.py"
+)
+va = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(va)
+
+
+def _sha(b):
+    return hashlib.sha256(b).hexdigest()
+
+
+def _bundle(subject_sha, inv_sha, signal_id="sig-1", commit="c0ffee"):
+    stmt = {
+        "_type": "https://in-toto.io/Statement/v1",
+        "predicateType": va.SLSA_V1,
+        "subject": [{"name": "oscal-ssp.json", "digest": {"sha256": subject_sha}}],
+        "predicate": {
+            "buildDefinition": {
+                "buildType": "https://samaydlette.com/buildtypes/compliance-artifact/v1",
+                "resolvedDependencies": [
+                    {"uri": "git+x@refs/heads/main", "digest": {"gitCommit": commit}},
+                    {"uri": "ksi-signal.json", "digest": {"sha256": inv_sha},
+                     "annotations": {"role": "canonical-inventory", "signal_id": signal_id}},
+                    {"uri": "scripts/build-oscal-ssp.py", "digest": {"sha256": "abcd"},
+                     "annotations": {"role": "generator"}},
+                ],
+            },
+            "runDetails": {"builder": {"id": "https://github.com/.../deploy-with-opa.yml@refs/heads/main"}},
+        },
+    }
+    payload = base64.b64encode(json.dumps(stmt).encode()).decode()
+    return {"dsseEnvelope": {"payloadType": "application/vnd.in-toto+json", "payload": payload, "signatures": [{"sig": "x"}]}}
+
+
+def _write(tmp_path, name, data: bytes):
+    p = tmp_path / name
+    p.write_bytes(data)
+    return p
+
+
+def test_accepts_correct_attestation(tmp_path):
+    art = _write(tmp_path, "oscal-ssp.json", b'{"system":"x"}')
+    inv = _write(tmp_path, "ksi-signal.json", b'{"signal_id":"sig-1"}')
+    bundle = _write(tmp_path, "a.intoto.jsonl",
+                    json.dumps(_bundle(_sha(art.read_bytes()), _sha(inv.read_bytes()))).encode())
+    stmt, errors = va.check(str(bundle), str(art), str(inv))
+    assert errors == []
+    assert stmt["predicateType"] == va.SLSA_V1
+
+
+def test_fails_on_subject_mismatch(tmp_path):
+    art = _write(tmp_path, "oscal-ssp.json", b'{"system":"x"}')
+    inv = _write(tmp_path, "ksi-signal.json", b'{"signal_id":"sig-1"}')
+    # subject digest is for DIFFERENT bytes -> binding must fail
+    bundle = _write(tmp_path, "a.intoto.jsonl",
+                    json.dumps(_bundle(_sha(b"other-bytes"), _sha(inv.read_bytes()))).encode())
+    _, errors = va.check(str(bundle), str(art), str(inv))
+    assert any("subject digest" in e for e in errors)
+
+
+def test_fails_on_tampered_inventory_digest(tmp_path):
+    art = _write(tmp_path, "oscal-ssp.json", b'{"system":"x"}')
+    inv = _write(tmp_path, "ksi-signal.json", b'{"signal_id":"sig-1"}')
+    # predicate claims an inventory digest that is not the real ksi-signal bytes
+    bundle = _write(tmp_path, "a.intoto.jsonl",
+                    json.dumps(_bundle(_sha(art.read_bytes()), "deadbeef")).encode())
+    _, errors = va.check(str(bundle), str(art), str(inv))
+    assert any("inventory digest" in e for e in errors)
+
+
+def test_rejects_non_dsse_bundle(tmp_path):
+    art = _write(tmp_path, "oscal-ssp.json", b"x")
+    bundle = _write(tmp_path, "legacy.json", json.dumps({"cert": "...", "rekorBundle": {}}).encode())
+    try:
+        va.check(str(bundle), str(art))
+        assert False, "should have raised on a legacy (non-DSSE) bundle"
+    except ValueError as e:
+        assert "dsseEnvelope" in str(e)


### PR DESCRIPTION
Foundational step of **Task 15 / S3** — the reciprocity capstone at the format level. Depends on S2 (merged). Additive.

## Why
Verifying a live S2 attestation surfaced the gap: the published `.intoto.jsonl` was a cosign **legacy bundle** (a `dsse 0.0.1` Rekor entry, **no inline envelope**) — `cosign verify-blob-attestation` returns `Verified OK`, but the in-toto **predicate isn't readable** by non-cosign tooling. That defeats "any in-toto-aware verifier can consume it."

## Changed
- **Inline DSSE:** `cosign attest-blob --new-bundle-format` → each `*.intoto.jsonl` is a Sigstore bundle with the **DSSE envelope inline**, so the in-toto SLSA-v1 Statement (subject + predicate bindings) is decodable by any DSSE/in-toto tool. `verify-blob-attestation` switched to `--new-bundle-format` too.
- **`scripts/verify-attestation.py`** — a **dependency-free, non-cosign consumer** that decodes the DSSE payload and checks the *claims*: subject sha256 == the artifact, plus the inventory sha256 / generator / commit bindings. Runs in CI per artifact, **fail-closed**. This is the reciprocity argument made concrete: a downstream party reads and acts on the evidence without our viewer and without cosign. It deliberately does **not** re-verify the signature (cosign's job, run alongside) — honest scope.
- **Round-trip invariant (f)** now also covers the `*.intoto.jsonl` (served == built).
- **`tests/test_verify_attestation.py`** — accepts a correct attestation; fails closed on subject mismatch, tampered inventory digest, and non-DSSE legacy bundles.

## Verified
- `pytest` (consumer + both provenance suites) → **10 passed**; YAML parses; consumer CLI reads a synthetic new-format bundle and checks bindings.
- `--new-bundle-format` is supported by both `attest-blob` and `verify-blob-attestation` (CI cosign-installer v3.10.1). The real new-format bundle only exists in CI (keyless OIDC), so the **merge deploy is the integration test**; it fails closed if the format or bindings are wrong. On green I'll decode a **live** attestation with `verify-attestation.py` (non-cosign) to prove consumability.
- CodeGuard (python/devops): pure-stdlib consumer (no eval/exec, safe JSON/base64), keyless OIDC, pinned-identity fail-closed verification, no secrets. No findings.

## Residual / S3b (tracked, follow-on)
- Present the in-toto/DSSE path as the "verify it yourself" instructions in `viewer.html` and the paper's §Cryptographic-protection (narrative-matches-config).
- Decide whether to retire the bespoke `cosign sign-blob` `.bundle` (dual-publish → cutover) or keep it for raw-bytes integrity.
- Out-of-boundary residual (no eBPF/Falco) + SR/SI-7 control mapping live in cross-cutting task #44.