### PR TITLE
fix(bootstrap): re-land the enforcing CSP into source (code/live drift)

### DIFF
--- a/infrastructure/bootstrap/cloudfront.tf
+++ b/infrastructure/bootstrap/cloudfront.tf
@@ -58,13 +58,13 @@ resource "aws_cloudfront_origin_access_control" "website" {
   signing_protocol                  = "sigv4"
 }
 
-# Baseline security headers, delivered at the edge to the static site. These five
-# are safe site-wide: they add headers, they do not block any resource, so no page
-# can break. A Content-Security-Policy is intentionally NOT set here yet — it needs
-# a frame-src allowance for the activities.html podcast embeds and a report-only
-# rollout first (see the project notes), so it is staged separately. Attached to
-# the default (static-site) behavior only; the /silk-reeling/* application path is
-# left off this policy.
+# Security headers delivered at the edge to the static site: HSTS, X-Frame-Options,
+# X-Content-Type-Options, Referrer-Policy, X-XSS-Protection, and an enforcing
+# Content-Security-Policy. The CSP was rolled out report-only first and verified
+# clean (headless, no violations across the dynamic pages) before enforcing; its
+# frame-src allows the YouTube and libsyn (activities.html podcast) embeds.
+# Attached to the default (static-site) behavior only; the /silk-reeling/*
+# application path is left off this policy.
 resource "aws_cloudfront_response_headers_policy" "website" {
   name    = "${replace(var.domain_name, ".", "-")}-security-headers"
   comment = "Baseline security headers for ${var.domain_name}"
@@ -86,6 +86,23 @@ resource "aws_cloudfront_response_headers_policy" "website" {
     referrer_policy {
       referrer_policy = "strict-origin-when-cross-origin"
       override        = true
+    }
+    content_security_policy {
+      content_security_policy = join("; ", [
+        "default-src 'self'",
+        "script-src 'self'",
+        "style-src 'self' 'unsafe-inline'",
+        "img-src 'self' data:",
+        "font-src 'self'",
+        "media-src 'self' https://ochelli.com",
+        "frame-src https://www.youtube.com https://www.youtube-nocookie.com https://html5-player.libsyn.com",
+        "connect-src 'self'",
+        "frame-ancestors 'none'",
+        "base-uri 'self'",
+        "form-action 'self'",
+        "object-src 'none'",
+      ])
+      override = true
     }
     xss_protection {
       mode_block = true


### PR DESCRIPTION
## Problem
The strict **Content-Security-Policy** is enforced on the live CloudFront distribution, but it is **absent from `origin/main`**. PR #181 merged only its first commit (`b752b9a`, headers-only); the CSP commit pushed afterward never landed. So `bootstrap/cloudfront.tf` says "headers only" while production enforces the CSP — and the bootstrap stack is applied out-of-band, *not* covered by the reconciliation gate.

**Risk:** a bootstrap apply from `origin/main` would diff the CSP **off** the live distribution — a silent security regression. (Same partial-merge class as #156/#161.)

## Change
Restore the `content_security_policy` block (and the accurate comment) to `bootstrap/cloudfront.tf` so the source matches the deployed policy exactly: `default-src 'self'`, `script-src 'self'`, `style-src 'self' 'unsafe-inline'`, `font-src 'self'`, `frame-src` YouTube + libsyn, `object-src 'none'`, `frame-ancestors 'none'`, etc. Attached to the default (static-site) behavior; `/silk-reeling/*` left off.

## Verified (code == live)
- Diff vs `origin/main` is **only** the CSP block + comment (24 insertions / 7 deletions, `cloudfront.tf` only).
- `terraform plan` against the live bootstrap state: `aws_cloudfront_response_headers_policy.website` and `aws_cloudfront_distribution.website` show **No changes** — the committed CSP equals the deployed one. (The single `compliance_kms` plan line is the separate, pre-existing `main.tf` Sid staleness, not part of this PR.)
- No functional change to live; this only reconciles source with what's already deployed.

## Next
- Reconcile the local bootstrap working tree to `origin/main` (pick up the `compliance_kms` Sid).
- Then Task 16 Phase A (remote-backend provisioning) on a clean bootstrap.