### PR TITLE
infra: cut per-deploy stack over to remote S3 state (Task 16, Phase C-1)

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -234,7 +234,7 @@ jobs:
     # -------------------------------------------------------------------------
     - name: Terraform Init
       working-directory: infrastructure
-      run: terraform init
+      run: terraform init -input=false
 
     - name: Terraform Validate
       working-directory: infrastructure
@@ -420,7 +420,7 @@ jobs:
 
     - name: Terraform Init
       working-directory: infrastructure
-      run: terraform init
+      run: terraform init -input=false
     
     # -------------------------------------------------------------------------
     # BUILD THE INFRASTRUCTURE  

--- a/infrastructure/backend.tf
+++ b/infrastructure/backend.tf
@@ -1,0 +1,24 @@
+# =============================================================================
+# Remote Terraform backend (Task 16, Phase C cutover)
+# =============================================================================
+# The per-deploy stack now persists state in S3 (bucket + lock provisioned in
+# infrastructure/bootstrap/tf-state-backend.tf, Phase A) instead of rebuilding
+# it by `terraform import` on every run.
+#
+# Migration is automatic: the first deploy after this merges runs against an
+# empty remote state, so the existing (idempotent, state-show-guarded) import
+# steps populate it once; from the next deploy on those imports find every
+# resource already in state and skip, removing ~8.5 min/run. The reconciliation
+# gate (reconcile.py --live) still verifies live AWS == inventory, so persisted
+# state does not weaken drift detection.
+#
+# Phase C-2 (a follow-up) removes the now-redundant import steps entirely.
+terraform {
+  backend "s3" {
+    bucket         = "samaydlette-com-tfstate"
+    key            = "infrastructure/terraform.tfstate"
+    region         = "us-east-2"
+    dynamodb_table = "samaydlette-com-tflock"
+    encrypt        = true
+  }
+}


### PR DESCRIPTION
**Task 16 / Phase C-1** — the cutover that buys back the ~8.5 min/deploy. Depends on Phase A (#187, applied + verified live).

## Changed
- **`infrastructure/backend.tf`** (new): a `backend "s3"` block pointing at the Phase-A bucket (`samaydlette-com-tfstate`), key `infrastructure/terraform.tfstate`, lock table `samaydlette-com-tflock`, region `us-east-2`, `encrypt = true`.
- **`deploy-with-opa.yml`**: `-input=false` on both `terraform init` calls (defensive — a fresh backend init can never hang on a prompt).

## How the migration works (automatic, no separate step)
- **First deploy after merge:** runs against an *empty* remote state, so the existing import steps populate it once. This run is normal speed (~14 min).
- **Every deploy after:** every resource is already in the persisted state, so each import skips via a fast `terraform state show` check → **~8.5 min removed**.

## Why it's safe
- The import steps are all **idempotent** — each is guarded by `if ! terraform state show …`, inline `|| terraform import`, or `|| echo skipped` — so they no-op against populated state (and a partial first run resumes correctly).
- The **OPA gate is unaffected**: it evaluates `planned_values` (the full resource set), not `resource_changes`, so it sees every resource regardless of create-vs-no-change.
- The **reconciliation gate** (`reconcile.py --live`) still enumerates live AWS and fails closed on drift, independent of how state is built — so persisted state keeps the same correctness guarantee.
- The deploy role already has scoped state access (Phase A IAM); state versioning + the DynamoDB lock guard against corruption/contention.

## Verified
- `terraform validate` → "the configuration is valid"; workflow YAML parses; both inits carry `-input=false`.
- The real test is the **first deploy on merge** (it performs the one-time migration). I'll watch it: it should be normal-speed and green, then the *next* deploy should be ~8 min faster.

## Residual / next
- **Phase C-2** (follow-up PR): delete the two import steps entirely now that state persists (removes the residual state-show overhead + the import code).
- **Phase D** (later): bump Terraform ≥1.10 and switch to native S3 lockfile (`use_lockfile`) to drop DynamoDB.