### PR TITLE
fix(reconcile): exclude Terraform state bucket from the live completeness sweep

### DIFF
--- a/scripts/reconcile.py
+++ b/scripts/reconcile.py
@@ -91,6 +91,14 @@ def inventory_component_ids(signal):
 SYSTEM_PREFIX = "samaydlette"
 
 
+def is_state_backend_bucket(name):
+    """The Terraform remote-state bucket (<prefix>-tfstate) is management-plane
+    infrastructure (bootstrap-provisioned, holds this stack's own state), not a
+    per-deploy system resource, so it is excluded from the live completeness
+    sweep. Matches the state-backend naming convention, nothing else."""
+    return (name or "").endswith("-tfstate")
+
+
 def enumerate_live_arns(region_primary="us-east-2", region_edge="us-east-1"):
     """Enumerate live in-boundary resource ARNs via the AWS CLI (boto3 is not a
     build dependency), scoped to SYSTEM_PREFIX. Returns a set of ARNs. Raises on
@@ -130,9 +138,15 @@ def enumerate_live_arns(region_primary="us-east-2", region_edge="us-east-1"):
         meta = (cli(["kms", "describe-key", "--key-id", kid, "--region", region_primary]) or {}).get("KeyMetadata", {})
         if meta.get("KeyManager") == "CUSTOMER" and meta.get("Arn"):
             arns.add(meta["Arn"])
-    # S3 (global) — the system bucket(s)
+    # S3 (global) — the system bucket(s). The Terraform remote-state bucket
+    # (<prefix>-tfstate) is excluded: it is management-plane infrastructure that
+    # stores this stack's OWN state, like the bootstrap identity plane, and is
+    # provisioned and verified by the bootstrap stack rather than the per-deploy
+    # inventory. Excluding it keeps the state backend from reading as an
+    # un-inventoried system resource; any other system-named bucket (actual
+    # system storage) is still swept, so deny-by-default holds.
     for b in (cli(["s3api", "list-buckets"]) or {}).get("Buckets", []):
-        if in_boundary(b["Name"]):
+        if in_boundary(b["Name"]) and not is_state_backend_bucket(b["Name"]):
             arns.add(f"arn:aws:s3:::{b['Name']}")
     # CloudWatch log groups (primary region)
     for lg in (cli(["logs", "describe-log-groups", "--region", region_primary]) or {}).get("logGroups", []):

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -213,5 +213,14 @@ def test_committed_clean_fixture_passes_via_main(monkeypatch):
     assert rc.main() == 0
 
 
+def test_state_backend_bucket_excluded_from_live_sweep():
+    # The Terraform state bucket is management-plane (bootstrap-managed) and must
+    # be excluded from the (a) live completeness sweep; real system buckets are not.
+    assert rc.is_state_backend_bucket("samaydlette-com-tfstate") is True
+    assert rc.is_state_backend_bucket("samaydlette-com-logs") is False
+    assert rc.is_state_backend_bucket("samaydlette.com") is False
+    assert rc.is_state_backend_bucket("") is False
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Problem (blocking ALL deploys)
Provisioning the remote-state bucket (Task 16 Phase A) broke the reconciliation gate. Its invariant **(a)** does a deny-by-default live sweep — `s3api list-buckets`, keep any whose name contains the system prefix, and fail if any isn't in the inventory. `samaydlette-com-tfstate` is now live but isn't a per-deploy component:
```
RECONCILIATION FAILED — 1 violation(s):
  ✗ (a) live resource not in inventory: arn:aws:s3:::samaydlette-com-tfstate
```
This fails **every** deploy now, not just the Phase C-1 run.

## Fix
The state bucket is **management-plane** infrastructure — it stores this stack's *own* Terraform state, the same category as the bootstrap identity plane (which the sweep already doesn't cover: it sweeps Lambda/API-GW/Secrets/KMS/S3/Logs, not IAM/DynamoDB). It's provisioned and verified by the **bootstrap stack**, not the per-deploy inventory. So exclude buckets matching the state-backend naming convention (`<prefix>-tfstate`) from the sweep. **Every other system-named bucket is still swept** — deny-by-default holds for actual system storage.

## Verified
- `is_state_backend_bucket("samaydlette-com-tfstate") == True`; `…-logs`, `samaydlette.com`, `""` → `False`.
- `pytest tests/test_reconcile.py` passes (incl. the new exclusion test).

## Honest note
I should have anticipated this when creating the bucket — the live sweep + boundary interaction is exactly what the gate is for. The state backend is in-boundary but bootstrap-verified; a follow-up can add it to the SSP/boundary narrative alongside the existing CI/CD-identity-plane note.