### PR TITLE
infra: skip redundant import steps (Task 16, Phase C-2 — the real speedup)

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -69,6 +69,11 @@ env:
   # syncs, signs, and serves the paper. Set "false" to hold it back during a
   # revision (the draft stays in the repo either way).
   PUBLISH_PLUMBING_PAPER: "true"
+  # The per-deploy stack now persists state in S3 (Task 16), so resources no
+  # longer need re-importing every run. The import steps are skipped by default
+  # and kept only as a disaster-recovery path: set REBUILD_STATE=true to
+  # re-adopt every live resource into a fresh/empty state.
+  REBUILD_STATE: "false"
   TERRAFORM_VERSION: 1.5.0
   OPA_VERSION: 0.57.0
   # Published SHA-256 of opa_linux_amd64_static for OPA_VERSION above.
@@ -426,6 +431,7 @@ jobs:
     # BUILD THE INFRASTRUCTURE  
     # -------------------------------------------------------------------------
     - name: Import Existing Resources (if needed)
+      if: ${{ env.REBUILD_STATE == 'true' }}
       working-directory: infrastructure
       run: |
         echo "Checking for existing AWS resources to import..."
@@ -727,6 +733,7 @@ jobs:
     # into state before plan/apply (mirrors "Import Existing Resources" above).
     # -------------------------------------------------------------------------
     - name: Import Silk Reeling resources (if needed)
+      if: ${{ env.REBUILD_STATE == 'true' }}
       working-directory: infrastructure
       run: |
         set +e   # handle each guard/import explicitly; a missing resource is fine


### PR DESCRIPTION
**Task 16 / Phase C-2** — this is the change that actually buys back the ~8 minutes. Depends on Phase C-1 (#189, merged) + the gate fix (#190, merged).

## Why
Phase C-1 persisted state but kept the import steps, and the payoff deploy (`d2cc839`) showed only ~2.5 min saved. Measured step durations:
| step | C-1 run |
|---|---|
| Import Existing Resources | **173s** |
| Import Silk Reeling resources | **171s** |
| Reconciliation gate | 8s ✓ |

The imports still cost ~6 min because each guarded import runs `terraform state show`, which now reads the **~31 MB remote state from S3** ~18 times. They're no longer needed — every resource is already in the persisted state.

## Changed
- Both import steps gated with `if: ${{ env.REBUILD_STATE == 'true' }}` (default **false**), so a normal deploy goes **init → plan → apply**, reading state once.
- `REBUILD_STATE` kept as a **disaster-recovery path**: set it `true` to re-adopt every live resource into a fresh/empty state — preserving the "reconstructable from live" property the ephemeral design had (just no longer paid every run).

## Why it's safe
- The persisted state already contains every resource (the Phase C-1 migration populated 26 resources); `terraform plan` reads it directly.
- The **OPA gate** (`planned_values`) and **reconcile `--live`** gate are unchanged.
- DR is preserved (flag flip re-runs the full import logic).

## Verified
- YAML parses; both import steps carry the `if:` guard.
- The real proof is the **next deploy on merge**: the two ~3-min import steps should drop out entirely, taking the deploy from ~11.5 min toward ~5–6 min, gate still green. I'll measure it.

## Next / residual
- Phase D (later): bump Terraform ≥1.10 + native S3 lockfile (drop DynamoDB).
- Boundary-doc note folding the state backend in next to the CI/CD-identity-plane note (#44).