### PR TITLE
vdr: governed resource-level tagging standard (PR-0 of deterministic PAIN)

### DIFF
--- a/docs/policies/resource-tagging-standard.md
+++ b/docs/policies/resource-tagging-standard.md
@@ -1,0 +1,98 @@
+# Resource Tagging Standard
+
+Every information resource in this system carries a small, governed set of
+classification tags at the asset level. The tags are operator-facing and
+intentionally few; the machine-readable risk inputs the pipeline needs — the
+CVSS Environmental requirements (CR/IR/AR), the VER internet-reachability axis
+(IRV), and the multi-agency scope flag (m) — are **derived** from these tags
+rather than tagged directly. This keeps the inputs auditable (a tag carries a
+clear chain of thought) and keeps a single source of truth.
+
+This standard is the asset-metadata layer the deterministic VDR PAIN classifier
+reads (see `scripts/build-vdr-report.py` and the governed
+`infrastructure/schemas/vdr-pain-config.json`). It is **not** itself a FedRAMP
+requirement; it is a method for assigning the asset half of the PAIN score
+systematically. The remediation-deadline numbers it ultimately selects are
+fixed by FedRAMP (VDR-TFR-PVR); nothing here calibrates them.
+
+## The six axes
+
+| Tag | Axis | Allowed values | Derives |
+|-----|------|----------------|---------|
+| `data_sensitivity`    | privacy / confidentiality       | `public`, `internal`, `pii`, `cui` | **CR** + reconciles with the FIPS-199 confidentiality category |
+| `mission_criticality` | integrity + availability        | `low`, `moderate`, `high`          | **IR** and **AR** |
+| `internet_reachable`  | reachability                    | `true`, `false`                    | **IRV** (VER-EVA-EIR) |
+| `agency_scope`        | blast radius                    | `single`, `multi`                  | **m** (the scope term in PAIN) |
+| `owner`               | accountability                  | governed role label                | operational; routing of remediation |
+| `archetype`           | role lens (optional, auditable) | see catalog below                  | the chain-of-thought label only; never scored directly |
+
+### Allowed-value notes
+
+- **`data_sensitivity`.** This system holds **no PII and no CUI** — every value
+  in use today is `public` (public web content, software packages, public DNS,
+  the private site bucket, low-sensitivity operational logs) or `internal`
+  (credentials, IAM authorization material, the audit trail, the identity
+  provider — the moderate-confidentiality assets). The `pii` and `cui` values
+  exist so the standard generalizes to a real estate; using them here would be
+  dishonest. `data_sensitivity` is **derived** from the component's FIPS-199
+  confidentiality category in the canonical inventory (`not-applicable/low →
+  public`, `moderate → internal`, `high → cui`), so the two cannot drift.
+- **`mission_criticality`** is the high-water mark of the integrity and
+  availability requirements. Deriving **both** IR and AR from one knob is
+  deliberately conservative: it never *under*-states availability. This system's
+  high-water mark is `moderate` (driven by integrity — defacement is the worst
+  realistic outcome); availability is genuinely low everywhere (a personal site
+  tolerates downtime within its declared RTO), so no asset is `high`.
+- **`agency_scope`** is **hardwired `single`** for every resource. This is a
+  single-operator proof of concept with **no federal data and no agency
+  sponsor**, so the multi-agency blast-radius term `m` is always 0. The `multi`
+  value and the scope machinery exist in the method for a real multi-tenant
+  estate; this system has no subject for them. This is an honest-gap stance, not
+  a limitation to be engineered around.
+- **`owner`** is a governed **role** label (e.g. `platform-operator`), never a
+  personal identifier. One operator owns everything today; the role label keeps
+  the record accurate and public-safe if that ever changes.
+
+## Archetype catalog (role lens)
+
+The archetype is the auditable label for *why* a resource carries the
+criticality it does. It is classified by role/usage, not by intrinsic kind — the
+control-plane lens first (anything that holds credentials, actuates config, or
+secures the estate is classified by that function), then by the data it holds.
+Only the archetypes this estate actually contains are listed; the full memo
+catalog is deliberately not imported.
+
+| Archetype | Lens | Members here |
+|-----------|------|--------------|
+| `public-edge`         | data    | CloudFront, the public API Gateway, public HTML, public DNS, ACM |
+| `app-tier`            | data    | the Silk Reeling app Lambda, its software dependencies |
+| `identity-secrets`    | control | Cognito user pool, Secrets Manager, KMS keys, IAM roles/policies |
+| `security-tooling`    | control | the internal compliance Lambda, audit/log stores |
+| `internal-tooling`    | data    | private object storage, the EventBridge schedule, read-only external services |
+| `platform-foundation` | control | DNS, TLS certificates (reachability/foundation, metadata only) |
+
+## Source of truth and enforcement
+
+The **live AWS resource tag is authoritative.** The canonical inventory
+(`scripts/build-ksi-signal.py`) projects each resource's classification onto its
+component (`attributes.classification`), so every derived risk input traces back
+to the tag. A future build-time gate (PR-D) applies these keys as real AWS
+resource tags on every taggable resource, fails the build if any required key is
+missing, and reconciles the live tags against this projected classification so a
+tag cannot drift from reality — the same fail-closed pattern the reconciliation
+gate already uses for live-resource completeness.
+
+### Fail-safe
+
+Missing or unknown classification **must not** lower risk. An untagged or
+unknown-type resource resolves to the conservative default
+(`data_sensitivity: cui`, `mission_criticality: high`, `internet_reachable:
+true`, `agency_scope: single`) so it scores loudly and surfaces itself for
+classification rather than hiding. Silence never makes a resource look safer
+than it is.
+
+## Review cadence
+
+Annually with the security review, and after any Transformative change that adds
+a resource type or changes a resource's reachability, data sensitivity, or
+criticality.

--- a/scripts/build-ksi-signal.py
+++ b/scripts/build-ksi-signal.py
@@ -457,6 +457,125 @@ def apply_mas_defaults(component):
 
 
 # =============================================================================
+# RESOURCE-LEVEL CLASSIFICATION TAGS (see docs/policies/resource-tagging-standard.md)
+# =============================================================================
+# The governed asset-tagging standard. Every component carries six tags from
+# which the VDR PAIN classifier derives the CVSS Environmental requirements
+# (CR/IR/AR), the internet-reachability axis (IRV), and the multi-agency scope
+# flag (m). The tag is the single source of truth; the risk inputs are derived,
+# not separately tagged.
+#
+# data_sensitivity is kept consistent with the MAS FIPS-199 confidentiality
+# category above (low -> public, moderate -> internal) so the two cannot drift.
+# This system holds no PII/CUI, so no resource uses those values. agency_scope
+# is hardwired "single" (single operator, no agency data — m is always 0).
+# owner is a governed ROLE label, never a personal identifier (public repo).
+OPERATOR_ROLE = "platform-operator"
+
+# data_sensitivity and mission_criticality are DERIVED from the component's
+# FIPS-199 categorization (security_category, set by apply_mas_defaults) so they
+# can never drift from it. data_sensitivity tracks confidentiality;
+# mission_criticality is the high-water mark of integrity and availability.
+_CONF_TO_SENSITIVITY = {"not-applicable": "public", "low": "public",
+                        "moderate": "internal", "high": "cui"}
+_CAT_ORDINAL = {"not-applicable": 0, "low": 0, "moderate": 1, "high": 2}
+_ORDINAL_TO_CRITICALITY = {0: "low", 1: "moderate", 2: "high"}
+
+# Per-component-TYPE baseline for the two axes that are NOT derivable from the
+# FIPS-199 categorization: internet reachability and the role-lens archetype.
+# internet_reachable here is the type default; the per-resource overrides below
+# correct the cases that differ (notably the two Lambdas, which share the
+# "function" type but differ on reachability).
+CLASSIFICATION_DEFAULTS = {
+    #                       internet_reachable  archetype
+    "object_store":        (False,              "internal-tooling"),
+    "cdn_distribution":    (True,               "public-edge"),
+    "function":            (False,              "app-tier"),
+    "npm_package":         (False,              "app-tier"),
+    "pypi_package":        (False,              "app-tier"),
+    "html_artifact":       (True,               "public-edge"),
+    "dns_zone":            (True,               "platform-foundation"),
+    "tls_certificate":     (False,              "platform-foundation"),
+    "event_schedule":      (False,              "internal-tooling"),
+    "iam_role":            (False,              "identity-secrets"),
+    "iam_policy":          (False,              "identity-secrets"),
+    "audit_log_trail":     (False,              "security-tooling"),
+    "log_group":           (False,              "security-tooling"),
+    "external_service":    (False,              "internal-tooling"),
+    "api_gateway":         (True,               "public-edge"),
+    "secrets_manager":     (False,              "identity-secrets"),
+    "kms_key":             (False,              "identity-secrets"),
+    "identity_provider":   (True,               "identity-secrets"),
+}
+
+# Per-RESOURCE overrides keyed by (component type, Terraform resource name).
+# Keying on type as well as name matters: many resources share a tf_name (the
+# Silk Reeling Lambda, API, Cognito pool, authorizer are all "silk_reeling"), so
+# a name-only key would bleed one resource's override onto its siblings. These
+# adjust only the non-derived axes (reachability, archetype) for asset-level
+# exceptions a type default cannot express; they mirror exactly what real
+# per-resource AWS tags will carry (PR-D). data_sensitivity / mission_criticality
+# are never overridden here — they derive from the categorization, by design.
+CLASSIFICATION_OVERRIDES = {
+    # The public Silk Reeling app Lambda is reachable through its API Gateway;
+    # the internal compliance Lambda (opa_compliance) is EventBridge-only and
+    # stays not-reachable. Both are stated explicitly so neither relies on the
+    # "function" type default by accident.
+    ("function", "silk_reeling"):  {"internet_reachable": True},
+    ("function", "opa_compliance"): {"internet_reachable": False, "archetype": "security-tooling"},
+    # The log bucket is security-tooling by role, unlike the site bucket which
+    # serves public content under the object_store default.
+    ("object_store", "logs"): {"archetype": "security-tooling"},
+}
+
+# Conservative fail-safe for an untagged/unknown-type resource: assume the worst
+# so it scores loudly and surfaces for classification (never lowers risk).
+CLASSIFICATION_FAILSAFE = {
+    "data_sensitivity": "cui",
+    "mission_criticality": "high",
+    "internet_reachable": True,
+    "archetype": "unclassified",
+}
+
+
+def apply_classification_defaults(component):
+    """Stamp the governed classification tags onto component.attributes.
+
+    data_sensitivity and mission_criticality are derived from the component's
+    FIPS-199 security_category (set by apply_mas_defaults) so they cannot drift.
+    internet_reachable and archetype come from the per-type baseline, then any
+    per-resource override keyed by attributes.tf_name. An unknown type resolves
+    to the conservative fail-safe. agency_scope and owner are system-wide
+    constants today. Lives under attributes (free-form by schema) — no schema
+    change needed.
+    """
+    component.setdefault("attributes", {})
+    base = CLASSIFICATION_DEFAULTS.get(component["type"])
+    if base is None:
+        classification = dict(CLASSIFICATION_FAILSAFE)
+    else:
+        cat = component.get("security_category") or {}
+        conf = cat.get("confidentiality", "not-applicable")
+        integ = _CAT_ORDINAL.get(cat.get("integrity", "not-applicable"), 0)
+        avail = _CAT_ORDINAL.get(cat.get("availability", "not-applicable"), 0)
+        internet_reachable, archetype = base
+        classification = {
+            "data_sensitivity": _CONF_TO_SENSITIVITY.get(conf, "cui"),
+            "mission_criticality": _ORDINAL_TO_CRITICALITY[max(integ, avail)],
+            "internet_reachable": internet_reachable,
+            "archetype": archetype,
+        }
+        override = CLASSIFICATION_OVERRIDES.get(
+            (component["type"], component["attributes"].get("tf_name")))
+        if override:
+            classification.update(override)
+    # Hardwired for this system: single operator, no agency data (m == 0).
+    classification["agency_scope"] = "single"
+    classification["owner"] = OPERATOR_ROLE
+    component["attributes"]["classification"] = classification
+
+
+# =============================================================================
 # HELPERS
 # =============================================================================
 
@@ -636,6 +755,7 @@ def build_cloud_components(tf_state, tf_outputs):
             component["native_id"] = native_id
         apply_mas_defaults(component)
         apply_iiw_defaults(component)
+        apply_classification_defaults(component)
         components_by_id[cid] = component
 
     # Second pass: fold attribute resources into their parent.
@@ -742,6 +862,7 @@ def build_live_log_groups(existing_components, region="us-east-2"):
         }
         apply_mas_defaults(component)
         apply_iiw_defaults(component)
+        apply_classification_defaults(component)
         new.append(component)
         have.add(native_id)
     return new
@@ -789,6 +910,7 @@ def build_npm_components(lock_path):
         }
         apply_mas_defaults(component)
         apply_iiw_defaults(component)
+        apply_classification_defaults(component)
         components.append(component)
     return components
 
@@ -875,6 +997,7 @@ def build_sbom_components(sbom_path, existing_components=None):
         }
         apply_mas_defaults(component)
         apply_iiw_defaults(component)
+        apply_classification_defaults(component)
         components.append(component)
     return components
 
@@ -969,6 +1092,7 @@ def build_external_components():
         }
         apply_mas_defaults(component)
         apply_iiw_defaults(component)
+        apply_classification_defaults(component)
         components.append(component)
     return components
 
@@ -992,6 +1116,7 @@ def build_html_components(website_root):
         }
         apply_mas_defaults(component)
         apply_iiw_defaults(component)
+        apply_classification_defaults(component)
         components.append(component)
     return components
 

--- a/tests/test_classification_tags.py
+++ b/tests/test_classification_tags.py
@@ -1,0 +1,100 @@
+"""PR-0: governed resource-level tagging standard.
+
+Pins the invariants of the asset-classification layer the VDR PAIN classifier
+derives CR/IR/AR, IRV, and m from. See docs/policies/resource-tagging-standard.md.
+"""
+import importlib.util
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("ksi", REPO / "scripts" / "build-ksi-signal.py")
+ksi = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ksi)
+
+
+def _state():
+    """TF state exercising the components whose classification matters most:
+    both Lambdas (same type, different reachability), both buckets, the edges."""
+    return {"values": {"root_module": {"resources": [
+        {"type": "aws_lambda_function", "name": "silk_reeling",
+         "values": {"function_name": "silk-reeling", "arn": "arn:aws:lambda:us-east-2:1:function:silk-reeling"}},
+        {"type": "aws_lambda_function", "name": "opa_compliance",
+         "values": {"function_name": "opa", "arn": "arn:aws:lambda:us-east-2:1:function:opa"}},
+        {"type": "aws_s3_bucket", "name": "logs", "values": {"bucket": "samaydlette-com-logs"}},
+        {"type": "aws_s3_bucket", "name": "website", "values": {"bucket": "samaydlette.com"}},
+        {"type": "aws_cloudfront_distribution", "name": "website",
+         "values": {"id": "E1", "arn": "arn:aws:cloudfront::1:distribution/E1"}},
+        {"type": "aws_apigatewayv2_api", "name": "silk_reeling",
+         "values": {"id": "api1", "arn": "arn:aws:apigateway:us-east-2::/apis/api1"}},
+        {"type": "aws_cognito_user_pool", "name": "silk_reeling",
+         "values": {"id": "pool1", "arn": "arn:aws:cognito-idp:us-east-2:1:userpool/pool1"}},
+    ]}}}
+
+
+def _by_tf_name():
+    comps = ksi.build_cloud_components(_state(), {})
+    return {(c["type"], c["attributes"].get("tf_name")): c["attributes"]["classification"] for c in comps}
+
+
+def test_every_component_carries_all_six_tags():
+    required = {"data_sensitivity", "mission_criticality", "internet_reachable",
+                "agency_scope", "owner", "archetype"}
+    for cls in _by_tf_name().values():
+        assert required <= set(cls), f"missing tags: {required - set(cls)}"
+
+
+def test_two_lambdas_get_distinct_reachability():
+    """The core defect the per-resource override fixes: the public app Lambda and
+    the internal compliance Lambda share the 'function' type but must not share
+    reachability — a type-only model sent both down one path."""
+    cls = _by_tf_name()
+    assert cls[("function", "silk_reeling")]["internet_reachable"] is True
+    assert cls[("function", "opa_compliance")]["internet_reachable"] is False
+    assert cls[("function", "opa_compliance")]["archetype"] == "security-tooling"
+
+
+def test_resource_override_does_not_bleed_onto_same_named_siblings():
+    """Many Silk Reeling resources share tf_name 'silk_reeling' (Lambda, API,
+    Cognito pool). The per-resource override is keyed by (type, tf_name), so the
+    Lambda's reachability override must not leak onto the Cognito pool or API."""
+    cls = _by_tf_name()
+    # The Cognito pool keeps its identity-secrets archetype, not the Lambda's app-tier.
+    assert cls[("identity_provider", "silk_reeling")]["archetype"] == "identity-secrets"
+    # The API Gateway keeps its public-edge archetype.
+    assert cls[("api_gateway", "silk_reeling")]["archetype"] == "public-edge"
+
+
+def test_data_sensitivity_does_not_drift_from_fips199_confidentiality():
+    """data_sensitivity must stay consistent with the MAS FIPS-199 confidentiality
+    category so the two cannot diverge: low/not-applicable -> public, moderate -> internal."""
+    comps = ksi.build_cloud_components(_state(), {})
+    allowed = {"low": {"public"}, "not-applicable": {"public"},
+               "moderate": {"internal"}, "high": {"pii", "cui"}}
+    for c in comps:
+        conf = c["security_category"]["confidentiality"]
+        ds = c["attributes"]["classification"]["data_sensitivity"]
+        assert ds in allowed[conf], f"{c['component_id']}: conf={conf} but data_sensitivity={ds}"
+
+
+def test_agency_scope_hardwired_single():
+    """Single operator, no agency data: m is always 0, so every resource is single-scope."""
+    for cls in _by_tf_name().values():
+        assert cls["agency_scope"] == "single"
+
+
+def test_owner_is_a_role_not_a_personal_identifier():
+    """The public repo must never carry a personal identifier; owner is a role label."""
+    for cls in _by_tf_name().values():
+        assert "@" not in cls["owner"]
+        assert cls["owner"] == ksi.OPERATOR_ROLE
+
+
+def test_failsafe_scores_unknown_type_loudly():
+    """An untagged/unknown-type resource must resolve to the conservative default
+    (never lower risk): cui / high / internet-reachable."""
+    comp = {"type": "totally_unknown_type", "attributes": {}}
+    ksi.apply_classification_defaults(comp)
+    cls = comp["attributes"]["classification"]
+    assert cls["data_sensitivity"] == "cui"
+    assert cls["mission_criticality"] == "high"
+    assert cls["internet_reachable"] is True


### PR DESCRIPTION
First of a sequenced set adopting the *mechanism* of a deterministic, CVSS-Environmental method for VDR/VER PAIN. Quality and defensibility improvement, **not** a change to compliance posture; selects no remediation deadlines (those stay fixed by FedRAMP).

## Changed
- Adds a single governed asset-tagging standard (`docs/policies/resource-tagging-standard.md`) and projects it onto every component in the canonical inventory under `attributes.classification`: `data_sensitivity`, `mission_criticality`, `internet_reachable`, `agency_scope`, `owner`, and an optional `archetype` role label.
- `data_sensitivity` and `mission_criticality` are **derived** from each component's existing FIPS-199 categorization (`security_category`) so the two cannot drift. Only the two axes a categorization can't express per-instance — reachability and archetype — are carried as per-type defaults with per-resource overrides keyed by `(type, tf_name)`.
- Why the compound key: several resources share a Terraform name (the application Lambda, its API, the user pool are all `silk_reeling`), so a name-only key would bleed one resource's override onto its siblings.
- Closes a real blind spot in the prior type-only model: the public application function and the internal compliance function share the `function` type but must not share reachability. They now classify distinctly at the source.
- `agency_scope` is hardwired `single` (single operator, no agency data — the scope term is always zero) and `owner` is a role label, never a personal identifier. Untagged / unknown-type resources resolve to a conservative fail-safe so they score loudly rather than hide.
- Lives in the free-form `attributes` block, so **no inventory schema change**.

## Verified
- Full local test suite: **98 passed** (the only failures are 3 pre-existing `test_inject_figures` cases that fail identically on pristine `main` in a fresh worktree — a missing built artifact, unrelated to this change).
- New `tests/test_classification_tags.py` (7 tests) pins the invariants: no-drift from FIPS-199 confidentiality, sibling-isolation of overrides, hardwired single scope, role-not-personal owner, and the conservative fail-safe.
- Type coverage checked against `main`'s live `MAS_DEFAULTS`: every component type is covered; **no** known component falls through to the `unclassified` fail-safe.
- A stamped component validates against `$defs/component` in `ksi-signal.schema.json` with `attributes.classification` present.
- Stamping inspection confirms the two functions classify distinctly (application function → reachable/`app-tier`; compliance function → not-reachable/`security-tooling`) and the user pool keeps `identity-secrets` rather than inheriting the Lambda's override.

## Residual / needs human
- None for this PR. The standard is consumed by later PRs (the CVSS-Environmental classifier) and enforced on live AWS resource tags by a planned build-time gate; this PR is inventory-side only.

## Couldn't verify
- The post-deploy publish round-trip (the regenerated signal carrying `attributes.classification` served under `/.well-known/`) runs in CI on merge; not exercised locally since the full signal build needs live Terraform outputs.

CodeGuard: ran against the diff (Python input-validation, logging, hardcoded-credentials rules) — no findings. No secrets or personal identifiers; unvalidated input resolves to the fail-safe; published classification carries only non-sensitive categorization metadata already implied by the existing `information_flow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)