### PR TITLE
vdr: governed PAIN classifier config, wired inert (PR-A)

### DIFF
--- a/infrastructure/schemas/vdr-pain-config.json
+++ b/infrastructure/schemas/vdr-pain-config.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "./vdr-pain-config.schema.json",
+  "version": "1.0",
+  "description": "Governed calibration for the deterministic CVSS-Environmental VDR PAIN classifier. These are the ONLY tunable knobs in the method: the word thresholds, the EPSS likely-exploitable threshold, the impact/requirement weights, and the tag-to-requirement maps. The FedRAMP VDR-TFR-PVR remediation-day matrix is deliberately NOT here — it is fixed by FedRAMP and lives verbatim in code (scripts/build-vdr-report.py). Only the classifier is ours to tune; the deadlines are not.",
+  "method_reference": "A Deterministic, CVSS-Environmental Method for FedRAMP Rev5 VDR/VER Vulnerability Prioritization (informational memo, June 2026); CVSS v3.1 Environmental metric group (Modified Impact Sub-Score, CR/IR/AR).",
+  "fedramp_corpus_pin": "2a75592",
+  "pain_word_thresholds": {
+    "minimal_to_narrow": 0.25,
+    "narrow_to_disruptive": 0.55,
+    "disruptive_to_debilitating": 0.80
+  },
+  "epss_threshold": 0.70,
+  "isc_cap": 0.915,
+  "cvss_impact_weights": {
+    "none": 0.0,
+    "low": 0.22,
+    "high": 0.56
+  },
+  "requirement_weights": {
+    "low": 0.5,
+    "medium": 1.0,
+    "high": 1.5
+  },
+  "data_sensitivity_to_requirement": {
+    "public": "low",
+    "internal": "medium",
+    "pii": "high",
+    "cui": "high"
+  },
+  "mission_criticality_to_requirement": {
+    "low": "low",
+    "moderate": "medium",
+    "high": "high"
+  },
+  "multi_agency_default": 0
+}

--- a/infrastructure/schemas/vdr-pain-config.schema.json
+++ b/infrastructure/schemas/vdr-pain-config.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://samaydlette.com/.well-known/vdr-pain-config.schema.json",
+  "title": "VDR PAIN classifier configuration",
+  "description": "Governed calibration for the deterministic CVSS-Environmental PAIN classifier. Constrains the only tunable knobs of the method; the FedRAMP remediation-day matrix is out of scope here (fixed by FedRAMP, in code).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "pain_word_thresholds",
+    "epss_threshold",
+    "isc_cap",
+    "cvss_impact_weights",
+    "requirement_weights",
+    "data_sensitivity_to_requirement",
+    "mission_criticality_to_requirement",
+    "multi_agency_default"
+  ],
+  "properties": {
+    "$schema": {"type": "string"},
+    "version": {"type": "string"},
+    "description": {"type": "string"},
+    "method_reference": {"type": "string"},
+    "fedramp_corpus_pin": {"type": "string"},
+    "pain_word_thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["minimal_to_narrow", "narrow_to_disruptive", "disruptive_to_debilitating"],
+      "description": "The three cut points on the normalized impact scalar S in [0,1]; must be strictly ascending (validated in code).",
+      "properties": {
+        "minimal_to_narrow": {"type": "number", "minimum": 0, "maximum": 1},
+        "narrow_to_disruptive": {"type": "number", "minimum": 0, "maximum": 1},
+        "disruptive_to_debilitating": {"type": "number", "minimum": 0, "maximum": 1}
+      }
+    },
+    "epss_threshold": {"type": "number", "minimum": 0, "maximum": 1},
+    "isc_cap": {"type": "number", "exclusiveMinimum": 0, "maximum": 1},
+    "cvss_impact_weights": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["none", "low", "high"],
+      "properties": {
+        "none": {"type": "number", "minimum": 0},
+        "low": {"type": "number", "minimum": 0},
+        "high": {"type": "number", "minimum": 0}
+      }
+    },
+    "requirement_weights": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["low", "medium", "high"],
+      "properties": {
+        "low": {"type": "number", "exclusiveMinimum": 0},
+        "medium": {"type": "number", "exclusiveMinimum": 0},
+        "high": {"type": "number", "exclusiveMinimum": 0}
+      }
+    },
+    "data_sensitivity_to_requirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["public", "internal", "pii", "cui"],
+      "description": "Maps the data_sensitivity tag to a requirement level (drives CR).",
+      "properties": {
+        "public": {"enum": ["low", "medium", "high"]},
+        "internal": {"enum": ["low", "medium", "high"]},
+        "pii": {"enum": ["low", "medium", "high"]},
+        "cui": {"enum": ["low", "medium", "high"]}
+      }
+    },
+    "mission_criticality_to_requirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["low", "moderate", "high"],
+      "description": "Maps the mission_criticality tag to a requirement level (drives IR and AR).",
+      "properties": {
+        "low": {"enum": ["low", "medium", "high"]},
+        "moderate": {"enum": ["low", "medium", "high"]},
+        "high": {"enum": ["low", "medium", "high"]}
+      }
+    },
+    "multi_agency_default": {
+      "description": "The scope term m default. Hardwired 0 for this system (single operator, no agency data).",
+      "enum": [0, 1]
+    }
+  }
+}

--- a/scripts/build-vdr-report.py
+++ b/scripts/build-vdr-report.py
@@ -40,6 +40,7 @@
 # =============================================================================
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -47,6 +48,69 @@ import sys
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+
+# =============================================================================
+# GOVERNED PAIN CLASSIFIER CONFIG (see infrastructure/schemas/vdr-pain-config.json)
+# =============================================================================
+# The deterministic CVSS-Environmental PAIN method has exactly two classes of
+# tunable knob — the word thresholds and the EPSS likely-exploitable threshold —
+# plus the impact/requirement weight tables and the tag-to-requirement maps.
+# The memo (s14) requires these to live in GOVERNED CONFIGURATION, not as in-band
+# ad-hoc constants, so they are loaded from a versioned, schema-backed JSON file
+# and never silently defaulted. The FedRAMP VDR-TFR-PVR remediation-day matrix is
+# deliberately NOT a knob here: it stays verbatim in CLASS_C_SLA_DAYS below.
+#
+# Wired but inert in this change: the config is loaded, validated fail-closed,
+# and recorded in the report's methodology block, but assign_pain still uses the
+# severity-proxy stub. The CVSS-Environmental derivation that consumes these
+# knobs lands in a follow-on change.
+DEFAULT_PAIN_CONFIG = (Path(__file__).resolve().parent.parent
+                       / "infrastructure" / "schemas" / "vdr-pain-config.json")
+
+
+def _validate_pain_config(cfg, where):
+    """Fail-closed structural validation of the governed PAIN config. A malformed
+    or incomplete config is an error, never a silent fallback to built-in
+    defaults — that is what keeps the governed knobs from being bypassed."""
+    required = ["version", "pain_word_thresholds", "epss_threshold", "isc_cap",
+                "cvss_impact_weights", "requirement_weights",
+                "data_sensitivity_to_requirement", "mission_criticality_to_requirement",
+                "multi_agency_default"]
+    missing = [k for k in required if k not in cfg]
+    if missing:
+        raise SystemExit(f"::error::PAIN config {where} missing required keys: {missing}")
+    t = cfg["pain_word_thresholds"]
+    th = [t.get("minimal_to_narrow"), t.get("narrow_to_disruptive"),
+          t.get("disruptive_to_debilitating")]
+    if any(not isinstance(x, (int, float)) for x in th):
+        raise SystemExit(f"::error::PAIN config {where}: word thresholds must be numbers")
+    if not (0 <= th[0] < th[1] < th[2] <= 1):
+        raise SystemExit(f"::error::PAIN config {where}: word thresholds must be strictly "
+                         f"ascending in [0,1], got {th}")
+    if not (0 <= cfg["epss_threshold"] <= 1):
+        raise SystemExit(f"::error::PAIN config {where}: epss_threshold must be in [0,1]")
+    if not (0 < cfg["isc_cap"] <= 1):
+        raise SystemExit(f"::error::PAIN config {where}: isc_cap must be in (0,1]")
+    if cfg["multi_agency_default"] not in (0, 1):
+        raise SystemExit(f"::error::PAIN config {where}: multi_agency_default must be 0 or 1")
+
+
+def load_pain_config(path=None):
+    """Load + validate the governed PAIN classifier config. Returns
+    (config_dict, sha256_hex). Fails closed on a missing/malformed file so the
+    governed calibration is always present and auditable (memo s14)."""
+    cfg_path = Path(path) if path else DEFAULT_PAIN_CONFIG
+    if not cfg_path.exists():
+        raise SystemExit(f"::error::PAIN config not found at {cfg_path}; the governed "
+                         f"classifier config is required (fail-closed).")
+    raw = cfg_path.read_bytes()
+    try:
+        cfg = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"::error::PAIN config at {cfg_path} is not valid JSON: {exc}")
+    _validate_pain_config(cfg, cfg_path)
+    return cfg, hashlib.sha256(raw).hexdigest()
 
 
 # =============================================================================
@@ -960,7 +1024,14 @@ def main():
     parser.add_argument("--output", default="vdr-report.json", help="Output report path")
     parser.add_argument("--md-output", default="vdr-report.md", help="Human-readable VDR rendering path (VER-TFR-MHR); empty to skip")
     parser.add_argument("--ksi-signal", default="ksi-signal.json", help="Canonical inventory; its signal_id binds this VDR to one inventory (reconciliation invariant e)")
+    parser.add_argument("--pain-config", default=None, help="Governed PAIN classifier config (default: infrastructure/schemas/vdr-pain-config.json). Loaded and validated fail-closed; recorded in the report methodology block.")
     args = parser.parse_args()
+
+    # Load the governed classifier calibration. Fails closed if absent/malformed
+    # so the knobs are always present and auditable (memo s14). Wired but inert
+    # in this change: recorded in the methodology block; assign_pain still uses
+    # the severity-proxy stub until the CVSS-Environmental derivation lands.
+    pain_config, pain_config_sha256 = load_pain_config(args.pain_config)
 
     ksi_signal_id = None
     _sig_path = Path(args.ksi_signal)
@@ -1001,6 +1072,15 @@ def main():
     report, blocking = build_report(findings, suppressions, kev_cves, ledger)
     report["ksi_signal_id"] = ksi_signal_id
     report["false_positives"] = false_positives
+    # Provenance for the PAIN derivation: which classifier produced these N-levels
+    # and which governed config calibrated it. pain_classifier is "severity-proxy"
+    # until the CVSS-Environmental derivation replaces the stub.
+    report["methodology"] = {
+        "pain_classifier": "severity-proxy",
+        "pain_config_version": pain_config["version"],
+        "pain_config_sha256": pain_config_sha256,
+        "reference": pain_config.get("method_reference", ""),
+    }
 
     output_path = Path(args.output)
     output_path.write_text(json.dumps(report, indent=2, sort_keys=False))

--- a/tests/test_pain_config.py
+++ b/tests/test_pain_config.py
@@ -1,0 +1,91 @@
+"""PR-A: governed PAIN classifier configuration.
+
+Pins the committed config's values and the loader's fail-closed validation. The
+config holds the only tunable knobs of the CVSS-Environmental method; the
+FedRAMP remediation-day matrix is NOT here (it stays verbatim in code).
+"""
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+CONFIG = REPO / "infrastructure" / "schemas" / "vdr-pain-config.json"
+
+
+def _vdr():
+    spec = importlib.util.spec_from_file_location("vdr", REPO / "scripts" / "build-vdr-report.py")
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+vdr = _vdr()
+
+
+def test_committed_config_loads_and_validates():
+    cfg, sha = vdr.load_pain_config(str(CONFIG))
+    assert len(sha) == 64
+    assert cfg["version"]
+    t = cfg["pain_word_thresholds"]
+    assert (t["minimal_to_narrow"], t["narrow_to_disruptive"], t["disruptive_to_debilitating"]) == (0.25, 0.55, 0.80)
+    assert cfg["epss_threshold"] == 0.70
+    assert cfg["isc_cap"] == 0.915
+    assert cfg["cvss_impact_weights"] == {"none": 0.0, "low": 0.22, "high": 0.56}
+    assert cfg["requirement_weights"] == {"low": 0.5, "medium": 1.0, "high": 1.5}
+
+
+def test_multi_agency_default_is_hardwired_zero():
+    """Single operator, no agency data: the scope term m is always 0."""
+    cfg, _ = vdr.load_pain_config(str(CONFIG))
+    assert cfg["multi_agency_default"] == 0
+
+
+def test_tag_to_requirement_maps_cover_every_tag_value():
+    cfg, _ = vdr.load_pain_config(str(CONFIG))
+    assert set(cfg["data_sensitivity_to_requirement"]) == {"public", "internal", "pii", "cui"}
+    assert set(cfg["mission_criticality_to_requirement"]) == {"low", "moderate", "high"}
+    levels = set(cfg["requirement_weights"])
+    for v in cfg["data_sensitivity_to_requirement"].values():
+        assert v in levels
+    for v in cfg["mission_criticality_to_requirement"].values():
+        assert v in levels
+
+
+def test_loader_fails_closed_on_missing_file(tmp_path):
+    with pytest.raises(SystemExit):
+        vdr.load_pain_config(str(tmp_path / "does-not-exist.json"))
+
+
+def test_loader_fails_closed_on_non_ascending_thresholds(tmp_path):
+    cfg = json.loads(CONFIG.read_text())
+    cfg["pain_word_thresholds"]["narrow_to_disruptive"] = 0.20  # below minimal_to_narrow
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps(cfg))
+    with pytest.raises(SystemExit):
+        vdr.load_pain_config(str(bad))
+
+
+def test_loader_fails_closed_on_bad_multi_agency_value(tmp_path):
+    cfg = json.loads(CONFIG.read_text())
+    cfg["multi_agency_default"] = 2
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps(cfg))
+    with pytest.raises(SystemExit):
+        vdr.load_pain_config(str(bad))
+
+
+def test_loader_fails_closed_on_missing_required_key(tmp_path):
+    cfg = json.loads(CONFIG.read_text())
+    del cfg["epss_threshold"]
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps(cfg))
+    with pytest.raises(SystemExit):
+        vdr.load_pain_config(str(bad))
+
+
+def test_committed_config_matches_its_schema():
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads((CONFIG.parent / "vdr-pain-config.schema.json").read_text())
+    jsonschema.validate(json.loads(CONFIG.read_text()), schema)


### PR DESCRIPTION
Second of the sequence adopting the *mechanism* of a deterministic, CVSS-Environmental method for VDR/VER PAIN. Quality/defensibility, **not** a change to compliance posture. This PR adds the governed calibration and wires it in **without changing any score**.

Stacks logically after #193 (the tagging standard) but is independent of it — no file overlap, can merge in either order.

## Changed
- `infrastructure/schemas/vdr-pain-config.json` (+ a JSON schema) holds the only tunable knobs of the method: the three word thresholds, the EPSS likely-exploitable threshold, the CVSS impact and requirement weight tables, and the maps from the asset-classification tags to a requirement level.
- The FedRAMP **VDR-TFR-PVR remediation-day matrix is deliberately not a knob here** — it stays verbatim in code (`CLASS_C_SLA_DAYS`). Only the classifier is ours to tune; the deadlines are fixed by FedRAMP.
- `multi_agency_default` is hardwired `0` (single operator, no agency data → the scope term is always zero).
- `build-vdr-report.py` gains a fail-closed `load_pain_config` (a missing or malformed config is an error, never a silent fallback) and a `--pain-config` flag, and records the config in a new report `methodology` block: the classifier in use, the config version, and its sha256.
- The classifier is honestly marked `severity-proxy` — **the scoring path is unchanged**; the CVSS-Environmental derivation that consumes these knobs lands in PR-B.

## Verified
- Full suite: **99 passed** (only the 3 pre-existing `test_inject_figures` failures remain — they fail identically on pristine `main` in a fresh worktree; unrelated).
- New `tests/test_pain_config.py` (8 tests): pins the committed values (θ = 0.25/0.55/0.80, EPSS 0.70, ISC cap 0.915, impact/requirement weights), the hardwired `multi_agency_default = 0`, full tag-map coverage, the config-vs-schema validation, and the loader failing closed on missing file / non-ascending thresholds / bad scope value / missing key.
- End-to-end build smoke: the VDR builder loads the config, emits the `methodology` block (version `1.0`, sha recorded, classifier `severity-proxy`), and the PAIN histogram + blocking behavior are unchanged.
- Confirmed no strict VDR-report schema exists and the additive `methodology` key is ignored by the trend builder (`summary.by_pain`) and the vuln gate (`findings` / `cve_findings`).

## Residual / needs human
- None. The knobs are inert until PR-B wires them into the score.

## Couldn't verify
- The post-deploy publish round-trip (regenerated `vdr-report.json` carrying `methodology` served under `/.well-known/`) runs in CI on merge; the full build needs live scan inputs, so it is not exercised locally beyond the empty-input smoke.

CodeGuard: ran against the diff (Python input-validation, hardcoded-credentials, logging) — no findings. The loader validates fail-closed; no secrets in the config or schema; the config path is operator-controlled CI input, not untrusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)