### PR TITLE
fix(vdr): classifier crash on dict global_id (deploy-blocking)

### DIFF
--- a/scripts/build-vdr-report.py
+++ b/scripts/build-vdr-report.py
@@ -820,11 +820,17 @@ def build_classification_index(ksi_signal_path):
         if cid:
             keys.add(cid)
             keys.add(cid.split("::")[-1])
+        # native_id is a scalar (ARN/id); global_id is a dict of cross-CSP
+        # identifiers ({"purl": ...} / {"sha256": ...}). Index the scalar values,
+        # never the dict itself (which is unhashable and would crash the set add).
         for k in ("native_id", "global_id"):
-            if comp.get(k):
-                keys.add(comp[k])
+            v = comp.get(k)
+            if isinstance(v, str):
+                keys.add(v)
+            elif isinstance(v, dict):
+                keys.update(x for x in v.values() if isinstance(x, str))
         for k in ("tf_name", "name", "purl"):
-            if attrs.get(k):
+            if isinstance(attrs.get(k), str):
                 keys.add(attrs[k])
         if attrs.get("tf_name") and comp.get("resource_type"):
             keys.add(f"{comp['resource_type']}.{attrs['tf_name']}")

--- a/tests/test_pain_environmental.py
+++ b/tests/test_pain_environmental.py
@@ -132,3 +132,32 @@ def test_build_classification_index_keys_by_purl_and_tf_name():
     assert "silk_reeling" in idx
     assert "pkg:pypi/widget@1.0" in idx
     assert idx["pkg:pypi/widget@1.0"]["mission_criticality"] == "moderate"
+
+
+def test_build_classification_index_handles_dict_global_id():
+    """Regression: the real inventory carries global_id as a dict
+    ({"purl": ...} for software, {"sha256": ...} for static artifacts), not a
+    scalar. Indexing must read its scalar values, never add the dict to a set
+    (which raised TypeError: unhashable type: 'dict' and crashed the VDR build)."""
+    cls = {"data_sensitivity": "public", "mission_criticality": "moderate",
+           "internet_reachable": False, "agency_scope": "single"}
+    signal = {"components": [
+        {"component_id": "pypi::widget@1.0",
+         "native_id": "arn:aws:lambda:us-east-2:1:function:s",
+         "global_id": {"purl": "pkg:pypi/widget@1.0"},
+         "attributes": {"name": "widget", "classification": cls}},
+        {"component_id": "html::index.html",
+         "global_id": {"sha256": "abc123"},
+         "attributes": {"classification": cls}},
+    ]}
+    import json, tempfile, os
+    fd, path = tempfile.mkstemp(suffix=".json")
+    os.write(fd, json.dumps(signal).encode()); os.close(fd)
+    try:
+        idx = vdr.build_classification_index(path)  # must not raise
+    finally:
+        os.unlink(path)
+    # The purl and sha256 inside global_id become resolvable keys.
+    assert "pkg:pypi/widget@1.0" in idx
+    assert "abc123" in idx
+    assert "arn:aws:lambda:us-east-2:1:function:s" in idx


### PR DESCRIPTION
**Deploy-blocking hotfix.** The merge of #195 broke the deploy: Terraform applied cleanly, but the **Build VDR Report** step crashed and the fail-closed pipeline skipped publish.

## Changed
- `build_classification_index` (added in #195) iterated `native_id` and `global_id` and added each value straight into a set. On the real inventory `global_id` is a **dict** (`{"purl": ...}` for software, `{"sha256": ...}` for static artifacts), so the set add raised `TypeError: unhashable type: 'dict'`.
- Now indexes `global_id` by its **scalar values** (so the PURL and content digest become resolvable keys for SCA findings) and `native_id` as a string, guarding every key add to strings.

## Verified
- Reproduced the exact crash locally with a signal carrying a dict `global_id`, then confirmed the fix builds the report cleanly (0 crash).
- New regression test `test_build_classification_index_handles_dict_global_id` is built from the **real signal shape** (dict `global_id` with `purl` + `sha256`) — the coverage gap that let this through (my PR-B test used scalar ids). Full `test_pain_environmental.py` green (13 tests).

## Root cause / process note
PR-B's unit tests used string `native_id`/`global_id`, so they never exercised the dict shape the live inventory actually emits. The "couldn't verify locally — runs in CI on merge" caveat in #195 is exactly where this surfaced. The new test closes that gap.

## Residual / needs human
- None. Once merged, the next deploy should pass the VDR build and reach publish. No infra change.

CodeGuard: trivial type-guarding change; no security surface. Pure defensive `isinstance` checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)