### PR TITLE
vdr: resolve LEV by the EPSS union, not a severity proxy (PR-C)

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -1065,6 +1065,24 @@ jobs:
           echo '{"vulnerabilities":[]}' > kev-catalog.json
         fi
 
+    # Fetch the daily FIRST EPSS scores so the VDR builder can resolve the
+    # Likely-Exploitable axis as the real EPSS union (EPSS >= threshold OR active)
+    # rather than the severity proxy. Non-blocking: if the feed is unreachable,
+    # fall back to an empty file — ingest_epss then returns no scores and LEV
+    # degrades safely to the conservative severity proxy, so the build still
+    # completes and nothing is silently downgraded.
+    - name: Fetch FIRST EPSS scores
+      working-directory: infrastructure
+      run: |
+        EPSS_URL="https://epss.cyentia.com/epss_scores-current.csv.gz"
+        if curl -sfL --retry 3 --retry-delay 2 -o epss-scores.csv.gz "$EPSS_URL" \
+            && [ -s epss-scores.csv.gz ]; then
+          echo "EPSS scores fetched ($(stat -c%s epss-scores.csv.gz) bytes gzipped)."
+        else
+          echo "::warning::Could not fetch EPSS scores; LEV falls back to the severity proxy this run."
+          printf 'cve,epss,percentile\n' > epss-scores.csv.gz
+        fi
+
     - name: Build VDR Report (FedRAMP 20x Class C)
       working-directory: infrastructure
       run: |
@@ -1079,6 +1097,7 @@ jobs:
           --grype grype.json \
           --zap ../security/zap/zap-report.json \
           --kev kev-catalog.json \
+          --epss epss-scores.csv.gz \
           --output vdr-report.json
         echo "VDR summary:"
         jq '{summary, rules_reference, risk_accepted_count: (.risk_accepted | length)}' vdr-report.json

--- a/scripts/build-vdr-report.py
+++ b/scripts/build-vdr-report.py
@@ -690,6 +690,58 @@ def ingest_kev(path):
     return {v.get("cveID") for v in (doc.get("vulnerabilities") or []) if v.get("cveID")}
 
 
+def ingest_epss(path):
+    """Load EPSS exploit-probabilities -> {cve: probability}. Accepts the FIRST
+    EPSS CSV (epss_scores-current.csv, optionally gzipped) or a JSON
+    {"data":[{"cve","epss"}]} form. A missing or garbled feed yields an empty map,
+    so every finding then falls back to the severity proxy (no silent downgrade)."""
+    if not path or not Path(path).exists():
+        return {}
+    raw = Path(path).read_bytes()
+    if raw[:2] == b"\x1f\x8b":  # gzip magic
+        import gzip
+        try:
+            raw = gzip.decompress(raw)
+        except OSError:
+            return {}
+    text = raw.decode("utf-8", "replace")
+    scores = {}
+    if text.lstrip().startswith("{"):
+        try:
+            doc = json.loads(text)
+        except json.JSONDecodeError:
+            return {}
+        for row in doc.get("data") or []:
+            cve = row.get("cve")
+            try:
+                if cve:
+                    scores[cve] = float(row.get("epss"))
+            except (TypeError, ValueError):
+                continue
+        return scores
+    import csv
+    import io
+    ci, ei = 0, 1
+    header_seen = False
+    for row in csv.reader(io.StringIO(text)):
+        if not row or row[0].startswith("#"):
+            continue
+        if not header_seen:
+            header_seen = True
+            try:
+                ci, ei = row.index("cve"), row.index("epss")
+            except ValueError:
+                ci, ei = 0, 1
+            continue
+        if len(row) <= max(ci, ei):
+            continue
+        try:
+            scores[row[ci]] = float(row[ei])
+        except ValueError:
+            continue
+    return scores
+
+
 def ingest_previous_ledger(path):
     """Read the previous VDR report and return {tracking_id: first_detected}.
 
@@ -740,14 +792,27 @@ def is_internet_reachable(finding):
     return any(hint in haystack for hint in INTERNET_REACHABLE_RESOURCE_HINTS)
 
 
-def is_likely_exploitable(finding):
-    """VER-EVA-ELX: heuristic for likely-exploitable vulnerability.
+def is_likely_exploitable(finding, epss_scores=None, epss_threshold=0.70, is_kev=False):
+    """VER-EVA-ELX: Likely-Exploitable by the memo's union. A finding is LEV if its
+    EPSS probability meets the governed threshold OR exploitation is observed
+    active (CISA KEV membership, or an explicit exploitation=active marker). The
+    two fire independently — whichever is true, with no blend between them.
 
-    Conservative for the PoC: anything HIGH or CRITICAL is treated as LEV.
-    A real provider would apply VER-EVA-EFA factors (criticality, reachability,
-    exploitability, detectability, prevalence, privilege, proximate
-    vulnerabilities, known threats) and could downgrade individual findings.
+    Fail-safe: when EPSS is unavailable for the finding's CVE (no feed loaded, or
+    the CVE is absent from it), missing data must not lower the determination, so
+    the finding falls back to the conservative severity proxy (HIGH/CRITICAL ->
+    LEV) rather than silently dropping to NLEV. When EPSS *is* available, its real
+    signal is trusted even if that means a sub-threshold HIGH finding is NLEV —
+    that is the classifier getting more accurate, not data going missing.
     """
+    if is_kev:
+        return True
+    if str(finding.get("exploitation", "")).lower() == "active":
+        return True
+    cve = finding.get("cve")
+    epss_scores = epss_scores or {}
+    if cve and cve in epss_scores:
+        return epss_scores[cve] >= epss_threshold
     sev = (finding.get("severity") or "").upper()
     return sev in ("HIGH", "CRITICAL", "ERROR")
 
@@ -984,16 +1049,19 @@ def consolidate_by_cve(report_findings, risk_accepted):
     return out
 
 
-def build_report(findings, suppressions, kev_cves, ledger, index=None, config=None):
+def build_report(findings, suppressions, kev_cves, ledger, index=None, config=None,
+                 epss_scores=None):
     # index: inventory classification index (asset CR/IR/AR source). config: the
-    # governed PAIN config. Both default for callers that don't supply them (e.g.
-    # unit tests); the config is loaded fail-closed so scoring is never silently
-    # uncalibrated. Without an index, CVE findings resolve to the conservative
-    # fail-safe classification (memo s7).
+    # governed PAIN config. epss_scores: {cve: probability} for the LEV union.
+    # All default for callers that don't supply them (e.g. unit tests); the config
+    # is loaded fail-closed so scoring is never silently uncalibrated. Without an
+    # index, CVE findings resolve to the conservative fail-safe classification
+    # (memo s7); without EPSS, LEV falls back to the severity proxy.
     if config is None:
         config, _ = load_pain_config()
     if index is None:
         index = {}
+    epss_scores = epss_scores or {}
     now = datetime.now(timezone.utc)
     report_findings = []
     summary = {
@@ -1008,9 +1076,10 @@ def build_report(findings, suppressions, kev_cves, ledger, index=None, config=No
 
     for f in findings:
         pain = assign_pain(f, index, config)
-        lev = is_likely_exploitable(f)
-        irv = is_internet_reachable(f)
         is_kev = bool(f.get("cve") and f["cve"] in kev_cves)
+        lev = is_likely_exploitable(f, epss_scores=epss_scores,
+                                    epss_threshold=config["epss_threshold"], is_kev=is_kev)
+        irv = is_internet_reachable(f)
 
         # Disposition: a config finding whose check is a documented suppression
         # (centralized .checkov.yaml, inline #checkov:skip=, or a tfsec/AVD
@@ -1237,6 +1306,7 @@ def main():
     parser.add_argument("--zap", default=None, help="OWASP ZAP JSON report (committed monthly DAST scan)")
     parser.add_argument("--zap-max-age-days", type=int, default=14, help="Fail the build if the ZAP report is older than this or missing; default 14 tracks the VDR-TFR-PDD Class C drift-detection cadence (0 disables)")
     parser.add_argument("--kev", default=None, help="CISA KEV catalog JSON")
+    parser.add_argument("--epss", default=None, help="EPSS scores (FIRST epss_scores-current.csv, optionally gzipped, or JSON). Enables the EPSS likely-exploitable union (EPSS >= threshold OR active); without it, LEV falls back to the severity proxy.")
     parser.add_argument("--checkov-yaml", default=".checkov.yaml", help="Path to .checkov.yaml whose skip-check list defines suppressions (default: .checkov.yaml in CWD)")
     parser.add_argument("--previous-vdr", default=None, help="Path to previous VDR report; preserves first_detected timestamps across builds for SLA-clock enforcement.")
     parser.add_argument("--output", default="vdr-report.json", help="Output report path")
@@ -1283,6 +1353,7 @@ def main():
                     return 1
 
     kev_cves = ingest_kev(args.kev)
+    epss_scores = ingest_epss(args.epss)
     suppressions = ingest_suppressions(args.checkov_yaml)
     false_positives = ingest_false_positives(args.checkov_yaml)
     ledger = ingest_previous_ledger(args.previous_vdr)
@@ -1292,16 +1363,22 @@ def main():
     classification_index = build_classification_index(args.ksi_signal)
 
     report, blocking = build_report(findings, suppressions, kev_cves, ledger,
-                                    index=classification_index, config=pain_config)
+                                    index=classification_index, config=pain_config,
+                                    epss_scores=epss_scores)
     report["ksi_signal_id"] = ksi_signal_id
     report["false_positives"] = false_positives
     # Provenance for the PAIN derivation: which classifier produced these N-levels
     # and which governed config calibrated it. CVE findings with a CVSS vector are
     # scored by the CVSS-Environmental method; vectorless IaC/config/DAST findings
-    # keep the documented severity-proxy fallback.
+    # keep the documented severity-proxy fallback. LEV is the EPSS union (>=
+    # threshold OR active-exploitation), with a severity-proxy fallback where EPSS
+    # is unavailable.
     report["methodology"] = {
         "pain_classifier": "cvss-environmental",
         "pain_classifier_fallback": "severity-proxy (findings without a CVSS vector)",
+        "lev_method": "EPSS union (>= threshold) OR active-exploitation (CISA KEV); severity-proxy fallback where EPSS is unavailable",
+        "epss_threshold": pain_config["epss_threshold"],
+        "epss_scores_loaded": len(epss_scores),
         "pain_config_version": pain_config["version"],
         "pain_config_sha256": pain_config_sha256,
         "reference": pain_config.get("method_reference", ""),

--- a/tests/test_lev_epss.py
+++ b/tests/test_lev_epss.py
@@ -1,0 +1,100 @@
+"""PR-C: EPSS-driven Likely-Exploitable (LEV) union.
+
+LEV = (EPSS >= governed threshold) OR (active exploitation: CISA KEV /
+exploitation=active), with a severity-proxy fail-safe when EPSS is unavailable.
+"""
+import gzip
+import importlib.util
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _vdr():
+    spec = importlib.util.spec_from_file_location("vdr", REPO / "scripts" / "build-vdr-report.py")
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+vdr = _vdr()
+THRESH = 0.70
+
+EPSS_CSV = (
+    "#model_version:v2026.06.30,score_date:2026-06-30T00:00:00+0000\n"
+    "cve,epss,percentile\n"
+    "CVE-2026-HIGH,0.91234,0.990\n"
+    "CVE-2026-LOWP,0.00100,0.200\n"
+)
+
+
+# --- ingest_epss ---------------------------------------------------------------
+
+def test_ingest_epss_csv(tmp_path):
+    p = tmp_path / "epss.csv"
+    p.write_text(EPSS_CSV)
+    scores = vdr.ingest_epss(str(p))
+    assert scores["CVE-2026-HIGH"] == 0.91234
+    assert scores["CVE-2026-LOWP"] == 0.001
+
+
+def test_ingest_epss_gzip(tmp_path):
+    p = tmp_path / "epss.csv.gz"
+    p.write_bytes(gzip.compress(EPSS_CSV.encode()))
+    scores = vdr.ingest_epss(str(p))
+    assert scores["CVE-2026-HIGH"] == 0.91234
+
+
+def test_ingest_epss_json(tmp_path):
+    p = tmp_path / "epss.json"
+    p.write_text(json.dumps({"data": [{"cve": "CVE-2026-HIGH", "epss": "0.8"}]}))
+    assert vdr.ingest_epss(str(p))["CVE-2026-HIGH"] == 0.8
+
+
+def test_ingest_epss_missing_returns_empty():
+    assert vdr.ingest_epss(None) == {}
+    assert vdr.ingest_epss("/no/such/file.csv") == {}
+
+
+# --- the LEV union -------------------------------------------------------------
+
+def test_lev_true_when_epss_at_or_above_threshold():
+    f = {"cve": "CVE-2026-HIGH", "severity": "LOW"}
+    assert vdr.is_likely_exploitable(f, {"CVE-2026-HIGH": 0.91}, THRESH) is True
+
+
+def test_lev_false_when_epss_below_threshold_overrides_severity_proxy():
+    """EPSS is present and sub-threshold: trust the real signal even though the
+    finding is HIGH. This is the classifier getting more accurate, not data
+    missing — so a sub-threshold HIGH is NLEV."""
+    f = {"cve": "CVE-2026-LOWP", "severity": "HIGH"}
+    assert vdr.is_likely_exploitable(f, {"CVE-2026-LOWP": 0.001}, THRESH) is False
+
+
+def test_lev_true_for_kev_regardless_of_epss():
+    f = {"cve": "CVE-2026-LOWP", "severity": "LOW"}
+    assert vdr.is_likely_exploitable(f, {"CVE-2026-LOWP": 0.001}, THRESH, is_kev=True) is True
+
+
+def test_lev_true_for_explicit_active_exploitation():
+    f = {"cve": "CVE-2026-LOWP", "severity": "LOW", "exploitation": "active"}
+    assert vdr.is_likely_exploitable(f, {"CVE-2026-LOWP": 0.001}, THRESH) is True
+
+
+def test_lev_failsafe_high_when_epss_unavailable():
+    """No EPSS for this CVE (or no feed): missing data must not lower the
+    determination, so HIGH/CRITICAL falls back to the conservative proxy."""
+    f = {"cve": "CVE-2026-NOEPSS", "severity": "HIGH"}
+    assert vdr.is_likely_exploitable(f, {}, THRESH) is True
+
+
+def test_lev_failsafe_medium_stays_nlev_when_epss_unavailable():
+    f = {"cve": "CVE-2026-NOEPSS", "severity": "MEDIUM"}
+    assert vdr.is_likely_exploitable(f, {}, THRESH) is False
+
+
+def test_lev_union_is_not_a_blend():
+    """Either input firing is sufficient; KEV wins even with a tiny EPSS."""
+    f = {"severity": "LOW", "cve": "CVE-2026-LOWP"}
+    assert vdr.is_likely_exploitable(f, {"CVE-2026-LOWP": 0.0}, THRESH, is_kev=True) is True


### PR DESCRIPTION
Final classifier step: replace the HIGH/CRITICAL severity proxy for Likely-Exploitable with the memo's union — `LEV = (EPSS >= governed threshold) OR (active exploitation)`. Quality/defensibility, **not** a change to compliance posture. Based on current `main` (includes the #197 hotfix).

## Changed
- New `ingest_epss` reads the FIRST EPSS feed (`epss_scores-current.csv`, optionally gzipped, or a JSON form) into `{cve: probability}`.
- `is_likely_exploitable` now takes the EPSS map, the governed threshold (#194 config), and the KEV flag. KEV / `exploitation=active` always implies LEV. Where EPSS is available, its real signal is trusted — even to downgrade a sub-threshold HIGH to NLEV (more accurate classification). Where EPSS is **unavailable**, it falls back to the conservative severity proxy so missing data never silently lowers the determination.
- The deploy workflow fetches the daily EPSS feed **non-blocking** (unreachable → empty file → LEV degrades to the proxy, build still completes) and passes `--epss`.
- The `methodology` block records the LEV method, the EPSS threshold, and the score count loaded.

## Guardrails
- **LEV only selects the remediation SLA column — it never changes the PAIN level**, and `CLASS_C_SLA_DAYS` (the FedRAMP VDR-TFR-PVR matrix) is untouched.
- **With no feed loaded, behavior is identical to the prior severity proxy** (verified). There are currently 0 open CVE-bearing findings, so enabling EPSS changes nothing live until real SCA CVEs appear.

## Verified
- New `tests/test_lev_epss.py` (11 tests): CSV/gzip/JSON ingest, EPSS≥threshold→LEV, sub-threshold EPSS overriding the HIGH proxy→NLEV, KEV/active→LEV regardless of EPSS, the fail-safe (no EPSS + HIGH→LEV; +MEDIUM→NLEV), and union-not-blend.
- Full suite: **130 passed** (only the 3 pre-existing `test_inject_figures` failures remain).
- Zero-change check: with no `--epss` feed, a HIGH dependabot finding's LEV is `True` (the proxy) and `epss_scores_loaded: 0` — identical to today.

## Couldn't verify
- The **live** EPSS feed fetch + large-file parse and any resulting SLA-column shifts run in CI on merge. The fail-safe (empty feed → proxy) and the 0-open-findings state bound the risk. Given #195's lesson, I'll watch the deploy on merge and confirm the VDR build + gate + publish stay green and `methodology.lev_method` appears in the published artifact.

CodeGuard: ran against the diff (Python input-validation, supply-chain, logging). `ingest_epss` parses defensively (handles bad gzip / non-numeric / missing file); the EPSS feed is fetched over HTTPS from the canonical FIRST/Cyentia source and is only parsed for float probabilities (never executed); non-blocking fetch with a safe empty fallback. No secrets. No findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)