### PR TITLE
infra: classification tags + build-time completeness gate (PR-D Part 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ validate:
 	terraform validate
 	@echo "Validating OPA policies..."
 	opa fmt --list policies.rego
-	opa test policies.rego
+	opa test policies.rego policies_test.rego
 	@echo "✅ Validation complete"
 
 # Show outputs

--- a/infrastructure/cognito.tf
+++ b/infrastructure/cognito.tf
@@ -42,7 +42,7 @@ resource "aws_cognito_user_pool" "silk_reeling" {
     }
   }
 
-  tags = merge(local.silk_tags, { Name = "${var.domain_name}-silk-reeling-users" })
+  tags = merge(local.cls.identity_provider, local.silk_tags, { Name = "${var.domain_name}-silk-reeling-users" })
 }
 
 # Hosted UI login page (Cognito-prefix domain; free). Must be globally unique.

--- a/infrastructure/logging.tf
+++ b/infrastructure/logging.tf
@@ -12,12 +12,12 @@ resource "aws_s3_bucket" "logs" {
   # checkov:skip=CKV_AWS_145:SSE-S3 (AES256) is deliberate, consistent with the public website bucket — these are low-sensitivity access logs about public-facing resources, and SSE-S3 is the reliably-supported encryption for S3 server-access-log delivery targets. A customer CMK would require granting the AWS log-delivery services key access for no sensitivity benefit.
   # checkov:skip=CKV2_AWS_62:No event-driven workflow consumes these logs (same rationale as POAM-004 for the website bucket); retention is handled by the lifecycle rule.
   bucket = "${replace(var.domain_name, ".", "-")}-logs"
-  tags = {
+  tags = merge(local.cls.security_tooling, {
     Name               = "${var.domain_name}-logs"
     Environment        = var.environment
     DataClassification = "Internal"
     Owner              = var.owner
-  }
+  })
 }
 
 resource "aws_s3_bucket_public_access_block" "logs" {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -49,15 +49,62 @@ terraform {
 # Tell Terraform how to connect to AWS in different regions
 # =============================================================================
 
+# =============================================================================
+# Resource-level classification tags (docs/policies/resource-tagging-standard.md)
+# =============================================================================
+# Every taggable resource carries the six governed classification axes. The two
+# system-wide constant axes (AgencyScope, OwnerRole) are applied to every
+# resource via provider default_tags; the four varying axes are applied
+# per-resource from local.cls below, matching the inventory's derived
+# classification so the reconciliation gate (PR-D Part 2) can assert live tags ==
+# inventory. The build-time OPA completeness rule (policies.rego) fails the build
+# if any taggable resource is missing a classification key, so a new resource
+# cannot ship unclassified. AgencyScope is hardwired single (single operator, no
+# agency data); OwnerRole is a role label, never a personal identifier.
+locals {
+  classification_constant = {
+    AgencyScope = "single"
+    OwnerRole   = "platform-operator"
+  }
+
+  # Per-resource varying axes (data_sensitivity / mission_criticality /
+  # internet_reachable / archetype). Keyed by a profile that mirrors a component's
+  # derived classification in the canonical inventory.
+  cls = {
+    # KMS keys: low-confidentiality (public) control-plane key material.
+    identity_secrets_public = { DataSensitivity = "public", MissionCriticality = "moderate", InternetReachable = "false", Archetype = "identity-secrets" }
+    # IAM roles, Secrets Manager: moderate-confidentiality (internal) credentials.
+    identity_secrets_internal = { DataSensitivity = "internal", MissionCriticality = "moderate", InternetReachable = "false", Archetype = "identity-secrets" }
+    # Log groups, the log bucket, the internal compliance Lambda.
+    security_tooling = { DataSensitivity = "public", MissionCriticality = "moderate", InternetReachable = "false", Archetype = "security-tooling" }
+    # The compliance DLQ (not an inventory component; classified for completeness).
+    security_tooling_internal = { DataSensitivity = "internal", MissionCriticality = "moderate", InternetReachable = "false", Archetype = "security-tooling" }
+    # The public Silk Reeling app Lambda.
+    app_tier = { DataSensitivity = "public", MissionCriticality = "moderate", InternetReachable = "true", Archetype = "app-tier" }
+    # The public API Gateway (and its stage).
+    public_edge = { DataSensitivity = "public", MissionCriticality = "moderate", InternetReachable = "true", Archetype = "public-edge" }
+    # The daily EventBridge schedule.
+    internal_tooling_low = { DataSensitivity = "public", MissionCriticality = "low", InternetReachable = "false", Archetype = "internal-tooling" }
+    # The Cognito user pool: identity provider, reachable, holds credentials.
+    identity_provider = { DataSensitivity = "internal", MissionCriticality = "moderate", InternetReachable = "true", Archetype = "identity-secrets" }
+  }
+}
+
 # Main AWS connection for most resources
 provider "aws" {
   region = var.aws_region
+  default_tags {
+    tags = local.classification_constant
+  }
 }
 
 # Special connection for SSL certificates (they must be in us-east-1 for CloudFront)
 provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
+  default_tags {
+    tags = local.classification_constant
+  }
 }
 
 # =============================================================================
@@ -283,13 +330,13 @@ resource "aws_cloudwatch_log_group" "route53_query_log" {
   retention_in_days = 365                     # 1-year retention (AU-11, POAM-017)
   kms_key_id        = aws_kms_key.at_rest.arn # customer-CMK at rest (POAM-018)
 
-  tags = {
+  tags = merge(local.cls.security_tooling, {
     Name               = "${var.domain_name}-route53-logs"
     Environment        = var.environment
     CostCenter         = var.cost_center
     DataClassification = "Public"
     Owner              = var.owner
-  }
+  })
 
   lifecycle {
     create_before_destroy = true
@@ -338,13 +385,13 @@ resource "aws_iam_role" "lambda_opa" {
     ]
   })
 
-  tags = {
+  tags = merge(local.cls.identity_secrets_internal, {
     Name               = "${var.domain_name}-lambda-opa-role"
     Environment        = var.environment
     CostCenter         = var.cost_center
     DataClassification = "Internal"
     Owner              = var.owner
-  }
+  })
 }
 
 # Define the specific permissions the monitoring function needs
@@ -496,12 +543,12 @@ resource "aws_kms_key" "at_rest" {
     ]
   })
 
-  tags = {
+  tags = merge(local.cls.identity_secrets_public, {
     Name               = "${var.domain_name}-at-rest"
     Environment        = var.environment
     DataClassification = "Internal"
     Owner              = var.owner
-  }
+  })
 }
 
 resource "aws_kms_alias" "at_rest" {
@@ -535,12 +582,12 @@ resource "aws_kms_key" "runtime_signing" {
     ]
   })
 
-  tags = {
+  tags = merge(local.cls.identity_secrets_public, {
     Name               = "${var.domain_name}-runtime-signing"
     Environment        = var.environment
     DataClassification = "Internal"
     Owner              = var.owner
-  }
+  })
 }
 
 resource "aws_kms_alias" "runtime_signing" {
@@ -594,12 +641,12 @@ resource "aws_kms_key" "dnssec_ksk" {
     ]
   })
 
-  tags = {
+  tags = merge(local.cls.identity_secrets_public, {
     Name               = "${var.domain_name}-dnssec-ksk"
     Environment        = var.environment
     DataClassification = "Internal"
     Owner              = var.owner
-  }
+  })
 }
 
 resource "aws_kms_alias" "dnssec_ksk" {
@@ -635,12 +682,12 @@ resource "aws_cloudwatch_log_group" "opa_compliance" {
   retention_in_days = 365
   kms_key_id        = aws_kms_key.at_rest.arn
 
-  tags = {
+  tags = merge(local.cls.security_tooling, {
     Name               = "${var.domain_name}-opa-compliance-logs"
     Environment        = var.environment
     DataClassification = "Internal"
     Owner              = var.owner
-  }
+  })
 }
 
 # Dead-letter queue for the compliance Lambda's failed async invocations
@@ -652,12 +699,12 @@ resource "aws_sqs_queue" "compliance_dlq" {
   message_retention_seconds = 1209600 # 14 days
   sqs_managed_sse_enabled   = true
 
-  tags = {
+  tags = merge(local.cls.security_tooling_internal, {
     Name               = "${var.domain_name}-opa-compliance-dlq"
     Environment        = var.environment
     DataClassification = "Internal"
     Owner              = var.owner
-  }
+  })
 }
 
 resource "aws_lambda_function" "opa_compliance" {
@@ -695,13 +742,13 @@ resource "aws_lambda_function" "opa_compliance" {
     }
   }
 
-  tags = {
+  tags = merge(local.cls.security_tooling, {
     Name               = "${var.domain_name}-opa-compliance"
     Environment        = var.environment
     CostCenter         = var.cost_center
     DataClassification = "Internal"
     Owner              = var.owner
-  }
+  })
 }
 
 # =============================================================================
@@ -718,13 +765,13 @@ resource "aws_cloudwatch_event_rule" "opa_compliance" {
   description         = "Trigger OPA compliance checks"
   schedule_expression = var.compliance_check_schedule
 
-  tags = {
+  tags = merge(local.cls.internal_tooling_low, {
     Name               = "${var.domain_name}-opa-compliance"
     Environment        = var.environment
     CostCenter         = var.cost_center
     DataClassification = "Internal"
     Owner              = var.owner
-  }
+  })
 }
 
 # Connect the schedule to the monitoring function

--- a/infrastructure/policies.rego
+++ b/infrastructure/policies.rego
@@ -23,10 +23,10 @@ package terraform.compliance
 # =============================================================================
 
 required_tags := {
-    "Environment",      # dev, staging, prod - helps track what this is for
-    "CostCenter",       # who pays for this resource
-    "DataClassification", # public, internal, confidential - what kind of data
-    "Owner"            # who is responsible for this resource
+	"Environment", # dev, staging, prod - helps track what this is for
+	"CostCenter", # who pays for this resource
+	"DataClassification", # public, internal, confidential - what kind of data
+	"Owner", # who is responsible for this resource
 }
 
 # =============================================================================
@@ -37,8 +37,83 @@ required_tags := {
 
 # This rule finds tags that should be there but aren't
 missing_required_tags[tag] {
-    tag := required_tags[_]           # Look at each required tag
-    not input.resource.tags[tag]      # Check if this tag is missing
+	tag := required_tags[_] # Look at each required tag
+	not input.resource.tags[tag] # Check if this tag is missing
+}
+
+# =============================================================================
+# RESOURCE CLASSIFICATION COMPLETENESS (PR-D)
+# =============================================================================
+# Every taggable resource must carry the six governed classification axes (see
+# docs/policies/resource-tagging-standard.md). The two constant axes arrive via
+# provider default_tags (so they land in tags_all, not tags); the four varying
+# axes are per-resource. A taggable resource missing any axis fails the build, so
+# a new resource cannot ship unclassified. Value-correctness against the
+# inventory is enforced separately by the reconciliation gate (Part 2); this is
+# the build-time completeness check.
+required_classification_tags := {
+	"DataSensitivity",
+	"MissionCriticality",
+	"InternetReachable",
+	"AgencyScope",
+	"OwnerRole",
+	"Archetype",
+}
+
+# Resource types this system tags. Sub-resource configs (versioning, policies,
+# routes, permissions) do not accept AWS tags and are intentionally excluded.
+taggable_types := {
+	"aws_kms_key",
+	"aws_lambda_function",
+	"aws_iam_role",
+	"aws_s3_bucket",
+	"aws_cloudwatch_log_group",
+	"aws_sqs_queue",
+	"aws_secretsmanager_secret",
+	"aws_cognito_user_pool",
+	"aws_apigatewayv2_api",
+	"aws_apigatewayv2_stage",
+	"aws_cloudwatch_event_rule",
+}
+
+# A classification key counts as present if it is in either the resource's own
+# tags or the provider default_tags (which Terraform merges into tags_all).
+classification_present(key) {
+	input.resource.tags_all[key]
+}
+
+classification_present(key) {
+	input.resource.tags[key]
+}
+
+# Data sources share a managed resource's type (e.g. data.aws_s3_bucket.website)
+# but carry no tags; the gate applies only to managed resources. A missing mode
+# is treated as managed (fail-safe: the gate still applies).
+is_managed {
+	input.resource.mode != "data"
+}
+
+is_managed {
+	not input.resource.mode
+}
+
+missing_classification[key] {
+	is_managed
+	taggable_types[input.resource.type]
+	key := required_classification_tags[_]
+	not classification_present(key)
+}
+
+classification_violations[violation] {
+	is_managed
+	taggable_types[input.resource.type]
+	count(missing_classification) > 0
+	violation := {
+		"type": "missing_classification_tag",
+		"message": sprintf("%s.%s is missing classification tags: %v", [input.resource.type, input.resource.name, missing_classification]),
+		"severity": "HIGH",
+		"resource": input.resource.name,
+	}
 }
 
 # =============================================================================
@@ -49,38 +124,38 @@ missing_required_tags[tag] {
 
 # Flag S3 buckets that are missing required tags
 s3_bucket_violations[violation] {
-    input.resource.type == "aws_s3_bucket"    # Only check S3 buckets
-    count(missing_required_tags) > 0          # Some required tags are missing
-    violation := {
-        "type": "missing_required_tags",
-        "message": sprintf("S3 bucket missing required tags: %v", [missing_required_tags]),
-        "severity": "HIGH",
-        "resource": input.resource.name
-    }
+	input.resource.type == "aws_s3_bucket" # Only check S3 buckets
+	count(missing_required_tags) > 0 # Some required tags are missing
+	violation := {
+		"type": "missing_required_tags",
+		"message": sprintf("S3 bucket missing required tags: %v", [missing_required_tags]),
+		"severity": "HIGH",
+		"resource": input.resource.name,
+	}
 }
 
 # Flag S3 buckets that don't have versioning turned on
 s3_bucket_violations[violation] {
-    input.resource.type == "aws_s3_bucket"    # Only check S3 buckets
-    not input.resource.versioning_enabled     # Versioning is not enabled
-    violation := {
-        "type": "versioning_disabled", 
-        "message": "S3 bucket versioning must be enabled for compliance",
-        "severity": "MEDIUM",
-        "resource": input.resource.name
-    }
+	input.resource.type == "aws_s3_bucket" # Only check S3 buckets
+	not input.resource.versioning_enabled # Versioning is not enabled
+	violation := {
+		"type": "versioning_disabled",
+		"message": "S3 bucket versioning must be enabled for compliance",
+		"severity": "MEDIUM",
+		"resource": input.resource.name,
+	}
 }
 
 # Flag S3 buckets that don't have encryption turned on
 s3_bucket_violations[violation] {
-    input.resource.type == "aws_s3_bucket"    # Only check S3 buckets
-    not input.resource.encryption_enabled     # Encryption is not enabled
-    violation := {
-        "type": "encryption_disabled",
-        "message": "S3 bucket server-side encryption must be enabled",
-        "severity": "HIGH",
-        "resource": input.resource.name
-    }
+	input.resource.type == "aws_s3_bucket" # Only check S3 buckets
+	not input.resource.encryption_enabled # Encryption is not enabled
+	violation := {
+		"type": "encryption_disabled",
+		"message": "S3 bucket server-side encryption must be enabled",
+		"severity": "HIGH",
+		"resource": input.resource.name,
+	}
 }
 
 # Flag S3 buckets that don't have public access fully blocked. Evaluated at
@@ -88,14 +163,14 @@ s3_bucket_violations[violation] {
 # aws_s3_bucket_public_access_block resources) and at runtime (the Lambda
 # populates it from GetPublicAccessBlock API calls).
 s3_bucket_violations[violation] {
-    input.resource.type == "aws_s3_bucket"
-    not input.resource.public_access_blocked
-    violation := {
-        "type": "public_access_not_fully_blocked",
-        "message": "S3 bucket must block all public access (ACLs, policy, ignore, restrict)",
-        "severity": "HIGH",
-        "resource": input.resource.name
-    }
+	input.resource.type == "aws_s3_bucket"
+	not input.resource.public_access_blocked
+	violation := {
+		"type": "public_access_not_fully_blocked",
+		"message": "S3 bucket must block all public access (ACLs, policy, ignore, restrict)",
+		"severity": "HIGH",
+		"resource": input.resource.name,
+	}
 }
 
 # =============================================================================
@@ -106,26 +181,26 @@ s3_bucket_violations[violation] {
 
 # Flag CloudFront that allows insecure HTTP connections
 cloudfront_violations[violation] {
-    input.resource.type == "aws_cloudfront_distribution"    # Only check CloudFront
-    input.resource.viewer_protocol_policy != "redirect-to-https"    # Not forcing HTTPS
-    violation := {
-        "type": "insecure_protocol",
-        "message": "CloudFront must redirect HTTP to HTTPS",
-        "severity": "HIGH",
-        "resource": input.resource.name
-    }
+	input.resource.type == "aws_cloudfront_distribution" # Only check CloudFront
+	input.resource.viewer_protocol_policy != "redirect-to-https" # Not forcing HTTPS
+	violation := {
+		"type": "insecure_protocol",
+		"message": "CloudFront must redirect HTTP to HTTPS",
+		"severity": "HIGH",
+		"resource": input.resource.name,
+	}
 }
 
 # Flag CloudFront using old/weak encryption
 cloudfront_violations[violation] {
-    input.resource.type == "aws_cloudfront_distribution"    # Only check CloudFront
-    input.resource.minimum_protocol_version != "TLSv1.2_2021"    # Using old encryption
-    violation := {
-        "type": "weak_tls",
-        "message": "CloudFront must use TLS 1.2 or higher",
-        "severity": "MEDIUM",
-        "resource": input.resource.name
-    }
+	input.resource.type == "aws_cloudfront_distribution" # Only check CloudFront
+	input.resource.minimum_protocol_version != "TLSv1.2_2021" # Using old encryption
+	violation := {
+		"type": "weak_tls",
+		"message": "CloudFront must use TLS 1.2 or higher",
+		"severity": "MEDIUM",
+		"resource": input.resource.name,
+	}
 }
 
 # =============================================================================
@@ -136,73 +211,73 @@ cloudfront_violations[violation] {
 
 # Flag HTML files that don't have a language declaration
 accessibility_violations[violation] {
-    input.html_content != ""                              # Only check when HTML content exists
-    input.file_name != ""                                 # And we have a filename
-    not contains(input.html_content, "html lang=")        # Missing lang attribute
-    violation := {
-        "type": "missing_language_declaration",
-        "message": sprintf("HTML file %s missing language declaration (html lang attribute)", [input.file_name]),
-        "severity": "HIGH",
-        "resource": input.file_name
-    }
+	input.html_content != "" # Only check when HTML content exists
+	input.file_name != "" # And we have a filename
+	not contains(input.html_content, "html lang=") # Missing lang attribute
+	violation := {
+		"type": "missing_language_declaration",
+		"message": sprintf("HTML file %s missing language declaration (html lang attribute)", [input.file_name]),
+		"severity": "HIGH",
+		"resource": input.file_name,
+	}
 }
 
 # Flag HTML files that have images without alt text
 accessibility_violations[violation] {
-    input.html_content != ""                              # Only check when HTML content exists
-    input.file_name != ""                                 # And we have a filename
-    contains(input.html_content, "<img")                  # Contains images
-    img_without_alt := regex.find_all_string_submatch_n(
-        `<img[^>]*(?:(?!alt=)[^>])*>`, 
-        input.html_content, -1
-    )
-    count(img_without_alt) > 0                            # Found images without alt text
-    violation := {
-        "type": "missing_alt_text",
-        "message": sprintf("HTML file %s contains images without alt text", [input.file_name]),
-        "severity": "HIGH",
-        "resource": input.file_name
-    }
+	input.html_content != "" # Only check when HTML content exists
+	input.file_name != "" # And we have a filename
+	contains(input.html_content, "<img") # Contains images
+	img_without_alt := regex.find_all_string_submatch_n(
+		`<img[^>]*(?:(?!alt=)[^>])*>`,
+		input.html_content, -1,
+	)
+	count(img_without_alt) > 0 # Found images without alt text
+	violation := {
+		"type": "missing_alt_text",
+		"message": sprintf("HTML file %s contains images without alt text", [input.file_name]),
+		"severity": "HIGH",
+		"resource": input.file_name,
+	}
 }
 
 # Flag HTML files that don't have proper heading structure
 accessibility_violations[violation] {
-    input.html_content != ""                              # Only check when HTML content exists
-    input.file_name != ""                                 # And we have a filename
-    not contains(input.html_content, "<h1")               # No H1 heading found
-    violation := {
-        "type": "missing_main_heading",
-        "message": sprintf("HTML file %s missing main heading (h1 element)", [input.file_name]),
-        "severity": "MEDIUM",
-        "resource": input.file_name
-    }
+	input.html_content != "" # Only check when HTML content exists
+	input.file_name != "" # And we have a filename
+	not contains(input.html_content, "<h1") # No H1 heading found
+	violation := {
+		"type": "missing_main_heading",
+		"message": sprintf("HTML file %s missing main heading (h1 element)", [input.file_name]),
+		"severity": "MEDIUM",
+		"resource": input.file_name,
+	}
 }
 
 # Flag HTML files that have empty alt attributes (alt="" with no text)
 accessibility_violations[violation] {
-    input.html_content != ""                              # Only check when HTML content exists
-    input.file_name != ""                                 # And we have a filename
-    contains(input.html_content, `alt=""`)                # Contains empty alt attributes
-    not contains(input.html_content, "decorative")        # Unless marked as decorative
-    violation := {
-        "type": "empty_alt_text",
-        "message": sprintf("HTML file %s contains images with empty alt text", [input.file_name]),
-        "severity": "MEDIUM",
-        "resource": input.file_name
-    }
+	input.html_content != "" # Only check when HTML content exists
+	input.file_name != "" # And we have a filename
+	contains(input.html_content, `alt=""`) # Contains empty alt attributes
+	not contains(input.html_content, "decorative") # Unless marked as decorative
+	violation := {
+		"type": "empty_alt_text",
+		"message": sprintf("HTML file %s contains images with empty alt text", [input.file_name]),
+		"severity": "MEDIUM",
+		"resource": input.file_name,
+	}
 }
 
 # Flag HTML files missing proper document structure
 accessibility_violations[violation] {
-    input.html_content != ""                              # Only check when HTML content exists
-    input.file_name != ""                                 # And we have a filename
-    not contains(input.html_content, "<!DOCTYPE html>")   # Missing DOCTYPE declaration
-    violation := {
-        "type": "missing_doctype",
-        "message": sprintf("HTML file %s missing DOCTYPE declaration", [input.file_name]),
-        "severity": "LOW",
-        "resource": input.file_name
-    }
+	input.html_content != "" # Only check when HTML content exists
+	input.file_name != "" # And we have a filename
+	not contains(input.html_content, "<!DOCTYPE html>") # Missing DOCTYPE declaration
+	violation := {
+		"type": "missing_doctype",
+		"message": sprintf("HTML file %s missing DOCTYPE declaration", [input.file_name]),
+		"severity": "LOW",
+		"resource": input.file_name,
+	}
 }
 
 # =============================================================================
@@ -216,17 +291,21 @@ default compliant = true
 
 # Block deployment if any S3 bucket has violations
 compliant = false {
-    count(s3_bucket_violations) > 0
+	count(s3_bucket_violations) > 0
 }
 
 # Block deployment if any CloudFront has violations
 compliant = false {
-    count(cloudfront_violations) > 0
+	count(cloudfront_violations) > 0
 }
 
 # Block deployment if any accessibility violations are found
 compliant = false {
-    count(accessibility_violations) > 0
+	count(classification_violations) > 0
+}
+
+compliant = false {
+	count(accessibility_violations) > 0
 }
 
 # =============================================================================
@@ -236,7 +315,7 @@ compliant = false {
 # =============================================================================
 
 # Combine all violations from infrastructure and accessibility checks
-all_violations := s3_bucket_violations | cloudfront_violations | accessibility_violations
+all_violations := ((s3_bucket_violations | cloudfront_violations) | accessibility_violations) | classification_violations
 
 # =============================================================================
 # GENERATE FINAL COMPLIANCE REPORT
@@ -245,21 +324,22 @@ all_violations := s3_bucket_violations | cloudfront_violations | accessibility_v
 # =============================================================================
 
 compliance_report := {
-    "compliant": compliant,                              # Overall pass/fail
-    "total_violations": count(all_violations),           # How many problems found
-    "violations_by_severity": {                          # Break down by severity
-        "HIGH": count([v | v := all_violations[_]; v.severity == "HIGH"]),
-        "MEDIUM": count([v | v := all_violations[_]; v.severity == "MEDIUM"]),
-        "LOW": count([v | v := all_violations[_]; v.severity == "LOW"])
-    },
-    "violations_by_type": {                              # Break down by category
-        "infrastructure": count(s3_bucket_violations | cloudfront_violations),
-        "accessibility": count(accessibility_violations)
-    },
-    "violations": all_violations,                        # List of all problems
-    # The emitter (terraform-plan.sh or the runtime Lambda) supplies the
-    # observation timestamp via the KSI signal's `emitted_at`; not duplicated
-    # here. This also keeps the rule pure so it compiles to Wasm cleanly
-    # without needing the host to provide time.now_ns().
-    "policy_version": "1.0"                              # Version of these rules
+	"compliant": compliant, # Overall pass/fail
+	"total_violations": count(all_violations), # How many problems found
+	"violations_by_severity": {
+		"HIGH": count([v | v := all_violations[_]; v.severity == "HIGH"]), # Break down by severity
+		"MEDIUM": count([v | v := all_violations[_]; v.severity == "MEDIUM"]),
+		"LOW": count([v | v := all_violations[_]; v.severity == "LOW"]),
+	},
+	"violations_by_type": {
+		"infrastructure": count(s3_bucket_violations | cloudfront_violations), # Break down by category
+		"accessibility": count(accessibility_violations),
+		"classification": count(classification_violations),
+	},
+	"violations": all_violations, # List of all problems
+	# The emitter (terraform-plan.sh or the runtime Lambda) supplies the
+	# observation timestamp via the KSI signal's `emitted_at`; not duplicated
+	# here. This also keeps the rule pure so it compiles to Wasm cleanly
+	# without needing the host to provide time.now_ns().
+	"policy_version": "1.0", # Version of these rules
 }

--- a/infrastructure/policies_test.rego
+++ b/infrastructure/policies_test.rego
@@ -1,0 +1,76 @@
+package terraform.compliance
+
+# =============================================================================
+# PR-D: resource classification completeness gate tests
+# =============================================================================
+# Pins the build-time invariant: every taggable resource must carry all six
+# governed classification axes, with the two constant axes allowed to arrive via
+# provider default_tags (tags_all). The missing-tag case is the committed broken
+# fixture that must fail the gate.
+
+_complete_all := {
+	"DataSensitivity": "public",
+	"MissionCriticality": "moderate",
+	"InternetReachable": "false",
+	"Archetype": "identity-secrets",
+	"AgencyScope": "single",
+	"OwnerRole": "platform-operator",
+}
+
+# A fully-classified taggable resource passes.
+test_classification_complete_passes {
+	count(classification_violations) == 0 with input as {"resource": {
+		"type": "aws_kms_key", "name": "at_rest",
+		"tags": {}, "tags_all": _complete_all,
+	}}
+}
+
+# The constant axes may come only from default_tags (tags_all): still complete.
+test_constant_axes_from_default_tags_pass {
+	count(classification_violations) == 0 with input as {"resource": {
+		"type": "aws_apigatewayv2_api", "name": "silk_reeling",
+		"tags": {"DataSensitivity": "public", "MissionCriticality": "moderate", "InternetReachable": "true", "Archetype": "public-edge"},
+		"tags_all": {"DataSensitivity": "public", "MissionCriticality": "moderate", "InternetReachable": "true", "Archetype": "public-edge", "AgencyScope": "single", "OwnerRole": "platform-operator"},
+	}}
+}
+
+# BROKEN FIXTURE: a taggable resource missing classification keys fails the gate.
+test_missing_classification_fails {
+	count(classification_violations) > 0 with input as {"resource": {
+		"type": "aws_lambda_function", "name": "silk_reeling",
+		"tags": {"DataSensitivity": "public"},
+		"tags_all": {"DataSensitivity": "public", "AgencyScope": "single"},
+	}}
+}
+
+# A missing classification tag makes the whole resource non-compliant.
+test_missing_classification_makes_noncompliant {
+	compliant == false with input as {"resource": {
+		"type": "aws_lambda_function", "name": "silk_reeling",
+		"tags": {}, "tags_all": {"AgencyScope": "single"},
+	}}
+}
+
+# Sub-resource configs that do not accept AWS tags are not gated.
+test_non_taggable_type_ignored {
+	count(classification_violations) == 0 with input as {"resource": {
+		"type": "aws_s3_bucket_versioning", "name": "website",
+		"tags": {}, "tags_all": {},
+	}}
+}
+
+# A data source sharing a managed type (data.aws_s3_bucket.website) is not gated.
+test_data_source_not_gated {
+	count(classification_violations) == 0 with input as {"resource": {
+		"type": "aws_s3_bucket", "name": "website", "mode": "data",
+		"tags": {}, "tags_all": {},
+	}}
+}
+
+# A managed resource of the same type, missing tags, still fails.
+test_managed_resource_still_gated {
+	count(classification_violations) > 0 with input as {"resource": {
+		"type": "aws_s3_bucket", "name": "logs", "mode": "managed",
+		"tags": {}, "tags_all": {},
+	}}
+}

--- a/infrastructure/silk-reeling.tf
+++ b/infrastructure/silk-reeling.tf
@@ -113,7 +113,7 @@ resource "aws_kms_key" "silk_reeling" {
     ]
   })
 
-  tags = merge(local.silk_tags, { Name = "${var.domain_name}-silk-reeling-cmk" })
+  tags = merge(local.cls.identity_secrets_public, local.silk_tags, { Name = "${var.domain_name}-silk-reeling-cmk" })
 }
 
 resource "aws_kms_alias" "silk_reeling" {
@@ -134,7 +134,7 @@ resource "aws_secretsmanager_secret" "silk_anthropic" {
   description = "Anthropic API key used by the app Lambda for feedback generation"
   kms_key_id  = aws_kms_key.silk_reeling[0].arn
 
-  tags = merge(local.silk_tags, { Name = "${var.domain_name}-silk-reeling-anthropic" })
+  tags = merge(local.cls.identity_secrets_internal, local.silk_tags, { Name = "${var.domain_name}-silk-reeling-anthropic" })
 }
 
 # Secret VALUES are injected out-of-band by the deploy's "Seed Silk Reeling
@@ -158,7 +158,7 @@ resource "aws_iam_role" "silk_reeling" {
     }]
   })
 
-  tags = merge(local.silk_tags, { Name = "${var.domain_name}-silk-reeling-role" })
+  tags = merge(local.cls.identity_secrets_internal, local.silk_tags, { Name = "${var.domain_name}-silk-reeling-role" })
 }
 
 resource "aws_iam_role_policy" "silk_reeling" {
@@ -204,7 +204,7 @@ resource "aws_cloudwatch_log_group" "silk_reeling" {
   retention_in_days = 365                             # 1-year retention (AU-11, POAM-017)
   kms_key_id        = aws_kms_key.silk_reeling[0].arn # customer-CMK at rest (POAM-018)
 
-  tags = merge(local.silk_tags, { Name = "${var.domain_name}-silk-reeling-logs" })
+  tags = merge(local.cls.security_tooling, local.silk_tags, { Name = "${var.domain_name}-silk-reeling-logs" })
 }
 
 # -----------------------------------------------------------------------------
@@ -262,7 +262,7 @@ resource "aws_lambda_function" "silk_reeling" {
   # grant is scoped by alias (see bootstrap compliance-kms-encrypt).
   depends_on = [aws_cloudwatch_log_group.silk_reeling, aws_kms_alias.silk_reeling]
 
-  tags = merge(local.silk_tags, { Name = "${var.domain_name}-silk-reeling" })
+  tags = merge(local.cls.app_tier, local.silk_tags, { Name = "${var.domain_name}-silk-reeling" })
 }
 
 # -----------------------------------------------------------------------------
@@ -280,7 +280,7 @@ resource "aws_apigatewayv2_api" "silk_reeling" {
   name          = local.silk_name
   protocol_type = "HTTP"
 
-  tags = merge(local.silk_tags, { Name = "${var.domain_name}-silk-reeling-api" })
+  tags = merge(local.cls.public_edge, local.silk_tags, { Name = "${var.domain_name}-silk-reeling-api" })
 }
 
 resource "aws_apigatewayv2_integration" "silk_reeling" {
@@ -334,7 +334,7 @@ resource "aws_cloudwatch_log_group" "silk_apigw" {
   retention_in_days = 365
   kms_key_id        = aws_kms_key.silk_reeling[0].arn
 
-  tags = merge(local.silk_tags, { Name = "${var.domain_name}-silk-reeling-apigw-logs" })
+  tags = merge(local.cls.security_tooling, local.silk_tags, { Name = "${var.domain_name}-silk-reeling-apigw-logs" })
 }
 
 # HTTP API access logging delivers to CloudWatch Logs via the logs delivery
@@ -389,7 +389,7 @@ resource "aws_apigatewayv2_stage" "silk_reeling" {
 
   depends_on = [aws_cloudwatch_log_resource_policy.silk_apigw]
 
-  tags = merge(local.silk_tags, { Name = "${var.domain_name}-silk-reeling-api-stage" })
+  tags = merge(local.cls.public_edge, local.silk_tags, { Name = "${var.domain_name}-silk-reeling-api-stage" })
 }
 
 resource "aws_lambda_permission" "silk_reeling_apigw" {

--- a/scripts/terraform-plan.sh
+++ b/scripts/terraform-plan.sh
@@ -108,8 +108,16 @@ if 'planned_values' in plan and 'root_module' in plan['planned_values']:
             resource_config = {
                 'type': resource.get('type', ''),
                 'name': resource.get('name', ''),
+                # mode distinguishes managed resources from data sources; the
+                # classification gate only applies to managed resources (data
+                # sources like data.aws_s3_bucket.website carry no tags).
+                'mode': resource.get('mode', 'managed'),
                 'values': resource.get('values', {}),
-                'tags': resource.get('values', {}).get('tags', {})
+                'tags': resource.get('values', {}).get('tags', {}),
+                # tags_all includes provider default_tags merged in; the
+                # classification completeness rule reads it so the constant axes
+                # applied via default_tags are visible to the gate.
+                'tags_all': resource.get('values', {}).get('tags_all', {})
             }
             
             # Add special security-relevant fields for S3 buckets


### PR DESCRIPTION
Part 1 of 2 making the resource-tagging standard authoritative. This part applies the classification as **real AWS tags** on the per-deploy stack and adds a **fail-closed build gate** so a resource cannot ship unclassified. Part 2 (separate PR) adds the reconcile-against-live-tags invariant.

## Changed
- **Provider `default_tags`** apply the two constant axes (`AgencyScope=single`, `OwnerRole=platform-operator`) to every resource automatically.
- **`local.cls`** holds the four varying axes as profiles mirroring each component's derived inventory classification; all **19 taggable resources** (main / silk-reeling / cognito / logging) merge their profile.
- **`policies.rego` classification-completeness rule**: a managed taggable resource missing any of the six keys is a HIGH violation that fails the gate. Data sources sharing a managed type (e.g. `data.aws_s3_bucket.website`) are excluded (no tags); a missing `mode` is treated as managed (fail-safe).
- **`terraform-plan.sh`** now passes `tags_all` (so the `default_tags` constant axes are visible to the gate) and `mode` (to skip data sources).
- **`policies_test.rego`** pins the invariant — including the missing-tag **broken fixture that must fail the gate** — wired into `opa test` via the Makefile.

## Verified
- `opa test policies.rego policies_test.rego`: **7/7 pass** (complete passes; constant-axes-from-default-tags pass; missing-tag fails; missing makes non-compliant; non-taggable type ignored; data source not gated; managed still gated).
- Coverage audit script confirms **all 19 taggable-type resources carry `local.cls`** (caught and fixed an initially-missed `cognito.tf` user pool).
- `opa check` compiles; `terraform fmt` clean; `bash -n` on the plan script clean.
- Manual OPA eval: a fully-tagged KMS key → 0 classification violations; a Lambda missing `OwnerRole`+`Archetype` → `compliant=false`.

## Guardrails
- The gate is **completeness only** (keys present). Value-correctness vs the inventory is Part 2's reconcile. The two layer: Part 1 = every resource is classified; Part 2 = the classification is *right* and matches live.
- Scope is the per-deploy stack (the stack the build gates). The operator-applied bootstrap stack (CloudFront, Route53, state backend) is a **documented follow-up**.

## Couldn't verify locally
- I cannot run `terraform plan` offline (no provider init/creds), so the real `planned_values.tags_all` population and the gate's pass against the live plan only exercise in CI. The gate **fails closed at plan, pre-apply**, so any gap (e.g. an untagged resource) blocks the deploy rather than shipping — and per the #195 lesson I will watch the deploy on merge and confirm the OPA gate + plan + apply + publish stay green before calling it done.

CodeGuard: ran against the diff (IaC + shell). Additive tags and a fail-closed policy; no secrets or hardcoded credentials (`OwnerRole` is a role label; `var.owner` unchanged); plan-extraction reads are benign. No findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)