### PR TITLE
verify: independent verifier for the published evidence (reciprocity handshake)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for Website Deployment with OPA Compliance
 
-.PHONY: help init plan deploy destroy check-compliance sync-content build-ksi-signal sync-ksi-signal build-oscal-ssp sync-oscal-ssp clean gate python-test figures-check reconcile
+.PHONY: help init plan deploy destroy check-compliance sync-content build-ksi-signal sync-ksi-signal build-oscal-ssp sync-oscal-ssp clean gate python-test figures-check reconcile verify-published
 
 # Default target
 help:
@@ -228,6 +228,14 @@ python-test:
 reconcile:
 	@echo "Running reconciliation gate..."
 	cd .. && python3 scripts/reconcile.py --artifacts-dir infrastructure $(RECONCILE_FLAGS)
+
+# Independent verification: fetch the LIVE published evidence and reproduce the
+# verdict from the public internet — cosign signature/provenance (Sigstore +
+# pinned identity), the dependency-free claims check, and the AWS-free
+# cross-artifact reconciliation. Needs no secrets and no AWS. Override the base
+# with VERIFY_BASE=https://host/.well-known.
+verify-published:
+	cd .. && scripts/verify-published.sh $(VERIFY_BASE)
 
 # Figure freshness gate: every <span data-figure> in the paper and dashboard
 # must match the value recomputed from the canonical artifacts. Fails if a

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,0 +1,76 @@
+# Verify the published evidence yourself
+
+Everything this system claims is published under
+[`/.well-known/`](https://samaydlette.com/.well-known/) and **signed by the exact
+GitHub Actions workflow that produced it.** You do not have to trust this repo's
+word for any of it — you can reproduce the verification from the public internet,
+with no credentials and no AWS access.
+
+That reproducibility is the whole point. Continuous authorization only becomes
+*reciprocity* when a second party can take the provider's evidence and reach the
+same verdict independently. This is that handshake.
+
+## One command
+
+From a clone of this public repo:
+
+```
+scripts/verify-published.sh                 # verify the live site
+make verify-published                       # same, via make
+scripts/verify-published.sh https://host/.well-known   # any other base
+```
+
+It fetches the live artifacts and runs three layers of checks, then prints
+`PASS` / `FAIL`.
+
+## What each layer proves — and how independent it is
+
+**1. Signatures + provenance — fully independent.** `cosign` confirms each
+artifact was produced by this repo's *pinned* workflow identity, recorded in the
+public Sigstore/Rekor transparency log. The trust roots are Sigstore and a
+public identity string — not this repo, and not the verifier script. You can run
+these two commands with nothing but `cosign` installed:
+
+```
+IDENTITY='https://github.com/sam-aydlette/samaydlette.com/.github/workflows/deploy-with-opa.yml@refs/heads/main'
+ISSUER='https://token.actions.githubusercontent.com'
+
+# the canonical inventory (Sigstore bundle)
+cosign verify-blob --bundle ksi-signal.bundle \
+  --certificate-identity "$IDENTITY" --certificate-oidc-issuer "$ISSUER" ksi-signal.json
+
+# a derived artifact (inline-DSSE in-toto attestation)
+cosign verify-blob-attestation --new-bundle-format --type slsaprovenance1 \
+  --bundle oscal-ssp.json.intoto.jsonl \
+  --certificate-identity "$IDENTITY" --certificate-oidc-issuer "$ISSUER" oscal-ssp.json
+```
+
+**2. Provenance claims — dependency-free.** `scripts/verify-attestation.py` reads
+the in-toto predicate (no cosign, no third-party libraries) and checks it binds
+each artifact's sha256 to the canonical inventory (`signal_id` + hash), the
+generator, and a commit.
+
+**3. Cross-artifact consistency — AWS-free.** `scripts/reconcile.py` (without
+`--live`) checks the published set is internally coherent: every artifact carries
+the same inventory `signal_id` and commit, the POA&M matches, and every VDR
+finding resolves to a remediation item (invariants **b–h**).
+
+## Honest scope
+
+The two **live-state** reconciliation invariants — **(a)** live-resource
+completeness and **(i)** live-tag ↔ inventory equality — require AWS credentials
+and **cannot** be reproduced by an external party. Those are the provider's to
+run in CI, and they are, on every deploy. This verifier says so rather than
+implying an outsider can check them. Everything else here, a stranger can.
+
+## Two signature formats (Task 15 note)
+
+The canonical inventory is signed with the legacy `cosign sign-blob` **Sigstore
+bundle** (`ksi-signal.bundle`); the derived OSCAL/VDR artifacts use the newer
+`cosign attest-blob --new-bundle-format` **inline-DSSE in-toto attestation**
+(`*.intoto.jsonl`). Both are Sigstore-signed against the same pinned identity, so
+both verify with `cosign`; the difference is that the DSSE form also carries a
+machine-readable SLSA provenance predicate that a non-cosign consumer can act on
+(layer 2 above). Converging the inventory onto the DSSE form is a tracked
+follow-up; keeping the `.bundle` in the meantime costs nothing and stays
+verifiable, so it is not urgent.

--- a/scripts/verify-published.sh
+++ b/scripts/verify-published.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# =============================================================================
+# verify-published.sh — reproduce samaydlette.com's compliance verification
+# from the public internet, with NO repo secrets and NO AWS access.
+# =============================================================================
+# This is the reciprocity handshake: a third party should be able to take the
+# evidence we publish under /.well-known/ and independently reach the same
+# verdict we do. Run it from a clone of this public repo:
+#
+#     scripts/verify-published.sh                       # verify the live site
+#     scripts/verify-published.sh https://host/.well-known   # or another base
+#
+# What it checks, and how independent each layer is:
+#   1. Signatures / provenance — FULLY INDEPENDENT. cosign confirms each artifact
+#      was produced by THIS repo's pinned GitHub Actions workflow on `main`, via
+#      the public Sigstore/Rekor transparency log. The trust roots are Sigstore
+#      and a pinned public identity — not us, and not this script.
+#   2. Provenance claims — dependency-free. verify-attestation.py reads the
+#      in-toto predicate and checks it binds each artifact to the canonical
+#      inventory (sha256 + signal_id), the generator, and a commit.
+#   3. Cross-artifact consistency — AWS-free. reconcile.py (without --live) checks
+#      the published set is internally consistent and bound to one inventory and
+#      one commit (invariants b–h).
+#
+# Honest scope: the live-state invariants — (a) live-resource completeness and
+# (i) live-tag reconciliation — require AWS credentials and CANNOT be reproduced
+# by an external party. Those are the provider's to run; everything else here a
+# stranger can reproduce. This script says so rather than implying otherwise.
+# =============================================================================
+set -euo pipefail
+
+BASE="${1:-https://samaydlette.com/.well-known}"
+IDENTITY='https://github.com/sam-aydlette/samaydlette.com/.github/workflows/deploy-with-opa.yml@refs/heads/main'
+ISSUER='https://token.actions.githubusercontent.com'
+SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+for t in curl cosign jq python3; do
+  command -v "$t" >/dev/null 2>&1 || { echo "verify-published: missing required tool: $t" >&2; exit 2; }
+done
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+fail=0
+ok()  { echo "  PASS  $1"; }
+bad() { echo "  FAIL  $1"; fail=1; }
+
+echo "== Fetching published evidence from $BASE =="
+for f in ksi-signal.json ksi-signal.bundle \
+         oscal-ssp.json oscal-ssp.json.intoto.jsonl \
+         oscal-poam.json \
+         vdr-report.json vdr-report.json.intoto.jsonl; do
+  if curl -fsS --max-time 30 -o "$work/$f" "$BASE/$f"; then
+    echo "  got  $f ($(wc -c < "$work/$f") bytes)"
+  else
+    echo "verify-published: could not fetch $BASE/$f" >&2; exit 1
+  fi
+done
+
+echo ""
+echo "== 1. Signatures + provenance (independent: Sigstore + pinned workflow identity) =="
+if cosign verify-blob --bundle "$work/ksi-signal.bundle" \
+     --certificate-identity "$IDENTITY" --certificate-oidc-issuer "$ISSUER" \
+     "$work/ksi-signal.json" >/dev/null 2>&1; then
+  ok "ksi-signal.json signed by the pinned workflow on main"
+else
+  bad "ksi-signal.json signature"
+fi
+for art in oscal-ssp.json vdr-report.json; do
+  if cosign verify-blob-attestation --new-bundle-format --type slsaprovenance1 \
+       --bundle "$work/$art.intoto.jsonl" \
+       --certificate-identity "$IDENTITY" --certificate-oidc-issuer "$ISSUER" \
+       "$work/$art" >/dev/null 2>&1; then
+    ok "$art attestation signed by the pinned workflow on main"
+  else
+    bad "$art attestation signature"
+  fi
+done
+
+echo ""
+echo "== 2. Provenance claims (dependency-free consumer) =="
+for art in oscal-ssp.json vdr-report.json; do
+  if python3 "$SCRIPTS/verify-attestation.py" \
+       --bundle "$work/$art.intoto.jsonl" --artifact "$work/$art" \
+       --ksi-signal "$work/ksi-signal.json" >/dev/null 2>&1; then
+    ok "$art predicate binds the canonical inventory + commit"
+  else
+    bad "$art predicate binding"
+  fi
+done
+
+echo ""
+echo "== 3. Cross-artifact consistency (AWS-free reconciliation, invariants b–h) =="
+if python3 "$SCRIPTS/reconcile.py" --artifacts-dir "$work" >/dev/null 2>&1; then
+  ok "published set reconciles: one inventory, one commit, POA&M/VDR coherent"
+else
+  bad "cross-artifact reconciliation"
+fi
+
+echo ""
+echo "== Scope =="
+echo "  Independently verified   : signatures + provenance (Sigstore + pinned identity)."
+echo "  Verified via public code : cross-artifact reconciliation (this repo, invariants b–h)."
+echo "  NOT externally verifiable: live-state invariants (a completeness, i tag-match) need AWS."
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo "RESULT: PASS — the published evidence is authentic (pinned-workflow-signed) and internally consistent."
+else
+  echo "RESULT: FAIL — see the FAIL lines above."
+  exit 1
+fi


### PR DESCRIPTION
First PR of the **external-verifiability** thrust — the panel + FedRAMP Director's top convergent ask: *let someone else reproduce the verdict from the published evidence.* This delivers exactly that.

## Changed
- **`scripts/verify-published.sh`** — fetches the live `/.well-known/` artifacts and runs three layers, then prints `PASS`/`FAIL`:
  1. **Signatures + provenance — fully independent.** `cosign verify-blob` / `verify-blob-attestation` against the **pinned** workflow identity via Sigstore/Rekor. Trust roots are Sigstore + a public identity — not this repo, not the script.
  2. **Claims — dependency-free.** `verify-attestation.py` checks the in-toto predicate binds each artifact to the inventory + commit.
  3. **Cross-artifact consistency — AWS-free.** `reconcile.py` (no `--live`) → invariants b–h.
- **`make verify-published`** + **`docs/verification.md`** (copy-paste `cosign` commands, honest scope, and the Task 15 note on the two coexisting signature formats).
- **Honest scope, stated in the tool:** the live-state invariants — (a) completeness, (i) tag-match — need AWS and can't be reproduced externally. The verifier says so.

## Verified — end to end against the LIVE site
```
== 1. Signatures + provenance (independent) ==
  PASS  ksi-signal.json signed by the pinned workflow on main
  PASS  oscal-ssp.json attestation signed by the pinned workflow on main
  PASS  vdr-report.json attestation signed by the pinned workflow on main
== 2. Provenance claims (dependency-free consumer) ==
  PASS  oscal-ssp.json predicate binds the canonical inventory + commit
  PASS  vdr-report.json predicate binds the canonical inventory + commit
== 3. Cross-artifact consistency (AWS-free reconciliation, invariants b–h) ==
  PASS  published set reconciles: one inventory, one commit, POA&M/VDR coherent
RESULT: PASS
```
`bash -n` clean; `make verify-published` runs the repo's standard way (from `infrastructure/`, like `reconcile`).

## Next in this thrust (follow-up PR)
Surface it in `viewer.html` as a **"Verify it yourself"** panel (the same `cosign` commands + pinned identity) and in the paper — the user-facing payoff. This PR is the engine; that PR is the hook.

CodeGuard: ran against the diff (shell/devops). `set -euo pipefail`, `curl -fsS --max-time`, `mktemp`+`trap` cleanup, verification against a pinned identity; no secrets, no injection sink. The `BASE` arg is an operator-chosen verification target. No findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)