### PR TITLE
ci: prove the external verification path on every deploy (reciprocity smoke test)

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -1469,13 +1469,36 @@ jobs:
         
         echo "✅ CloudFront distribution ID: $DISTRIBUTION_ID"
         echo "Creating cache invalidation..."
-        
-        # Tell CDN to refresh all cached content
-        aws cloudfront create-invalidation \
+
+        # Tell CDN to refresh all cached content. Capture the id + distribution so
+        # the external-verifier smoke test can wait for this invalidation to
+        # complete before checking the live edge.
+        INVALIDATION_ID=$(aws cloudfront create-invalidation \
           --distribution-id $DISTRIBUTION_ID \
-          --paths "/*"
-        
-        echo "✅ CloudFront cache invalidation created"
+          --paths "/*" \
+          --query 'Invalidation.Id' --output text)
+        echo "CLOUDFRONT_DISTRIBUTION_ID=$DISTRIBUTION_ID" >> "$GITHUB_ENV"
+        echo "CLOUDFRONT_INVALIDATION_ID=$INVALIDATION_ID" >> "$GITHUB_ENV"
+
+        echo "✅ CloudFront cache invalidation created ($INVALIDATION_ID)"
+
+    # -------------------------------------------------------------------------
+    # RECIPROCITY HANDSHAKE: prove the EXTERNAL verification path still works
+    # -------------------------------------------------------------------------
+    # Run the same verifier a third party would (scripts/verify-published.sh)
+    # against the LIVE public URL: fetch the artifacts, check the Sigstore
+    # signatures + SLSA provenance against the pinned identity, and reconcile
+    # them (AWS-free, invariants b–h). Waits for the invalidation above so the
+    # edge is serving this deploy's artifacts. Fails closed: if an outsider could
+    # not reproduce our verdict, the deploy is not done.
+    - name: External verifier smoke test (reciprocity handshake)
+      run: |
+        echo "Waiting for CloudFront invalidation $CLOUDFRONT_INVALIDATION_ID to complete..."
+        aws cloudfront wait invalidation-completed \
+          --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+          --id "$CLOUDFRONT_INVALIDATION_ID"
+        echo "Reproducing third-party verification against the live site:"
+        bash scripts/verify-published.sh
 
     # -------------------------------------------------------------------------
     # VERIFY EVERYTHING WORKED


### PR DESCRIPTION
PR-3 (final) of the external-verifiability thrust. #203 built the verifier and #206 surfaced it; this makes it **continuously proven** — every deploy runs the same script a third party would, against the live public URL.

## Changed
- After publish + CDN invalidation, a new **"External verifier smoke test"** step runs `bash scripts/verify-published.sh` against the **live** site.
- The invalidation step now captures its **id + distribution** into the env; the smoke step **waits for that invalidation to complete** (`aws cloudfront wait invalidation-completed`) so the edge is serving this deploy's artifacts before verifying — deterministic, not a retry against CDN propagation.
- **Fails closed:** if an outsider couldn't reproduce our verdict from the live site, the deploy isn't done. Because `GITHUB_SHA` is set in the deploy job, the verifier's reconciliation also confirms the live artifacts carry *this* deploy's commit (freshness), a strict superset of the external-party check.

## Verified
- Workflow YAML parses; step ordering confirmed: `Invalidate CloudFront Cache` → `External verifier smoke test` → `Run Post-Deployment Compliance Check`.
- The verifier itself was proven end-to-end against the live site in #203 (`RESULT: PASS`); `verify-published.sh` is tracked `100755` and invoked via `bash` (mode-independent).
- Tools (`cosign`, `jq`, `python3`, `curl`) are all present in the deploy job.

## Couldn't verify locally
- The step exercises AWS (`cloudfront wait`) + the live invalidation, so it only truly runs in the deploy job. I'll watch the deploy on merge and confirm the smoke step goes green (and that the invalidation-wait keeps it deterministic). Per the #195 lesson, this is the honest residual — the verifier logic is proven live, the CI wiring is proven on the first deploy.

CodeGuard: ran against the diff (CI/devops). Captures non-secret CloudFront IDs, waits deterministically, runs the committed verifier via `bash`; no secrets, no injection sink. No findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)