### PR TITLE
fix(signal): baseline narratives match deployed config (DNSSEC on, 365-day CMK log retention; POAM-017/018)

### DIFF
--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -42,11 +42,21 @@ JIT machinery (e.g., AWS Identity Center session-bound access) would add operati
 
 CloudWatch Logs is the SIEM equivalent for this system. Sources collected:
 
-- Lambda execution logs (via the Lambda runtime's standard logging integration)
-- CloudFront access logs — currently excluded for cost; revisit if any incident response would have benefited from them
-- CloudTrail (account-wide) — captures all AWS API calls, including the deployer's
+- Lambda execution logs (via the Lambda runtime's standard logging integration; 365-day retention, customer-CMK encrypted — POAM-017/018)
+- API Gateway access logs for the Silk Reeling HTTP API (same retention and encryption — POAM-024)
+- S3 server access logs and CloudFront access logs, delivered to the dedicated locked-down log bucket (POAM-005, C-3; 400-day lifecycle)
 
-For a two-resource, one-Lambda system, this is meaningfully a SIEM. Tamper resistance: log groups have 7-day retention and CloudTrail is account-managed, so logs are write-once from the producing service. The deployer credentials cannot delete CloudTrail logs without an additional IAM action that is not granted by default.
+Not collected: there is **no CloudTrail trail** in this account. AWS API
+activity is visible only through the default CloudTrail Event History (90
+days, management events only, not durable). Until a durable, validated
+management-events trail with S3 delivery exists, this "SIEM" covers the
+workload and access-log surface but not the AWS control plane — a known,
+honestly-stated gap.
+
+For a small single-account system this is meaningfully a SIEM for the workload
+surface. Tamper resistance: log groups are write-once from the producing
+services, retained 365 days under a customer CMK, and the log bucket denies
+non-TLS access, blocks public access, and is lifecycle-managed.
 
 If the system grew to require true SIEM features (correlation rules, alerting, longer retention), the next step would be Amazon Security Lake or a third-party SIEM ingesting from CloudWatch. Out of scope today.
 

--- a/scripts/build-ksi-signal.py
+++ b/scripts/build-ksi-signal.py
@@ -361,7 +361,7 @@ IIW_DEFAULTS = {
         "function": "CloudWatch log group for Lambda execution / Route 53 query logs",
         "diagram_label": "CloudWatch Logs",
         "public": False,
-        "baseline_configuration": "AWS CloudWatch; 365-day retention (AU-11; POAM-017 closed); customer-CMK encryption at rest (POAM-018 closed)",
+        "baseline_configuration": "AWS CloudWatch; 365-day retention (AU-11; POAM-017); customer-CMK encryption at rest (POAM-018)",
         "iiw_asset_type": "Log Group (CloudWatch)",
     },
     "external_service": {

--- a/scripts/build-ksi-signal.py
+++ b/scripts/build-ksi-signal.py
@@ -319,7 +319,7 @@ IIW_DEFAULTS = {
         "function": "Authoritative DNS for the public domain",
         "diagram_label": "Route 53 hosted zone",
         "public": True,
-        "baseline_configuration": "AWS Route 53 default; DNSSEC not enabled",
+        "baseline_configuration": "AWS Route 53; DNSSEC signing enabled (customer-managed KSK in KMS us-east-1, D-3; SC-20/SC-21)",
         "iiw_asset_type": "DNS Zone (Route 53)",
     },
     "tls_certificate": {
@@ -361,7 +361,7 @@ IIW_DEFAULTS = {
         "function": "CloudWatch log group for Lambda execution / Route 53 query logs",
         "diagram_label": "CloudWatch Logs",
         "public": False,
-        "baseline_configuration": "AWS CloudWatch default; 7-day retention (POAM-017); AWS-default encryption (POAM-018)",
+        "baseline_configuration": "AWS CloudWatch; 365-day retention (AU-11; POAM-017 closed); customer-CMK encryption at rest (POAM-018 closed)",
         "iiw_asset_type": "Log Group (CloudWatch)",
     },
     "external_service": {


### PR DESCRIPTION
## Changed
Two hardcoded baseline_configuration strings in the canonical inventory builder predated their remediations and contradicted the deployed configuration in every published artifact: the DNS zone claimed 'DNSSEC not enabled' and the log groups claimed '7-day retention; AWS-default encryption'. Corrected to the deployed truth (DNSSEC signing enabled; 365-day retention under a customer CMK, POAM-017/018 closed). Also rewrites the SIEM-equivalent section of architecture-decisions.md, which claimed CloudTrail as a collected source and 7-day retention: no CloudTrail trail exists in the account, and the section now states that control-plane coverage gap explicitly (a follow-up PR adds the trail).

## Verified
- Live hosted-zone DNSSEC status returns SIGNING (read-only CLI).
- All three live log groups show 365-day retention with CMK encryption (read-only CLI), matching the corrected text.
- No CloudTrail trail exists: no Terraform resource, no delivery bucket in the account.
- Full python test suite passes.

## Residual / needs human
None for this change. The published signal carries the corrected strings after the next deploy.

## Couldn't verify
figures-check requires built artifacts and runs in CI, not in a bare checkout; this diff does not alter any injected figure.

CodeGuard (software-security) ran against this diff: no findings.

SCN-Type: routine-recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)