### PR TITLE
fix(ssp): partial-downgrades follow the signal's per-KSI verdict, not a hardcoded map

### DIFF
--- a/scripts/build-oscal-ssp.py
+++ b/scripts/build-oscal-ssp.py
@@ -1414,30 +1414,34 @@ def build_control_implementation(signal, catalog):
 
 
 def _failing_ksis_from_signal(signal):
-    """Return the set of KSI ids whose contributing validations include any
-    `result: "fail"` in the live signal. Used to downgrade affected controls
-    from `implemented` to `partial` automatically.
+    """Return the set of KSI ids the signal itself marks as failing. Used to
+    downgrade affected controls from `implemented` to `partial` automatically.
+
+    The signal's ksis[] block is the authoritative per-KSI verdict (status
+    plus evidence.failed_validation_ids), so consume that attribution rather
+    than re-deriving it here from validations[] with a coarse policy-id map —
+    the map both missed KSIs the signal marks failing and dragged in KSIs the
+    signal marks passing.
     """
+    ksi_records = signal.get("ksis") or []
+    if ksi_records:
+        return {
+            k["id"]
+            for k in ksi_records
+            if k.get("status") == "fail"
+            or (k.get("evidence") or {}).get("failed_validation_ids")
+        }
+    # Legacy fallback for signals predating the ksis[] block: coarse
+    # policy-id convention mapping over raw validations.
     failing = set()
-    # The KSI signal's validations carry policy.id and component_refs. Only
-    # the runtime emitter currently uses a policy id like 'runtime.s3_security';
-    # the deploy-time gate's validations use 'terraform.compliance' and don't
-    # encode a KSI id directly. So we surface failures conservatively: any
-    # validation with result=='fail' marks the catch-all bucket so SSP
-    # consumers know to look at the signal.
     for v in signal.get("validations") or []:
         if v.get("result") == "fail":
-            # Map runtime-policy ids to KSI ids by convention. Best-effort.
             policy_id = (v.get("policy") or {}).get("id", "")
             if policy_id == "runtime.s3_security":
                 failing.update({"KSI-SVC-ACM", "KSI-SVC-SIN", "KSI-CMT-LMC"})
             elif policy_id == "runtime.cloudfront_security":
                 failing.update({"KSI-SVC-VCM", "KSI-CNA-ULN"})
             elif policy_id == "terraform.compliance":
-                # Deploy-time policy: granular KSI mapping not encoded.
-                # Mark representative ids so the downgrade fires for affected
-                # controls; we treat infrastructure findings as touching
-                # config/monitoring families broadly.
                 failing.update({"KSI-MLA-EVC", "KSI-SVC-ACM"})
     return failing
 

--- a/tests/test_ssp_failing_ksis.py
+++ b/tests/test_ssp_failing_ksis.py
@@ -1,0 +1,61 @@
+# The SSP's implemented->partial auto-downgrade must follow the signal's own
+# per-KSI verdict (ksis[].status / evidence.failed_validation_ids), not a
+# hardcoded policy-id heuristic that can both miss failing KSIs and drag in
+# passing ones.
+
+import importlib.util
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+spec = importlib.util.spec_from_file_location("ssp", REPO / "scripts" / "build-oscal-ssp.py")
+ssp = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ssp)
+
+
+def _signal(ksis=None, validations=None):
+    sig = {}
+    if ksis is not None:
+        sig["ksis"] = ksis
+    if validations is not None:
+        sig["validations"] = validations
+    return sig
+
+
+def test_uses_signal_ksi_attribution_not_heuristic():
+    sig = _signal(
+        ksis=[
+            {"id": "KSI-SVC-ACM", "status": "fail",
+             "evidence": {"failed_validation_ids": ["v-0015"]}},
+            {"id": "KSI-MLA-EVC", "status": "pass",
+             "evidence": {"failed_validation_ids": []}},
+        ],
+        # A failing terraform.compliance validation used to hardcode-in
+        # KSI-MLA-EVC; the signal above says it passes, so it must stay out.
+        validations=[{"result": "fail", "policy": {"id": "terraform.compliance"}}],
+    )
+    assert ssp._failing_ksis_from_signal(sig) == {"KSI-SVC-ACM"}
+
+
+def test_failed_validation_ids_alone_marks_failing():
+    sig = _signal(ksis=[
+        {"id": "KSI-CMT-LMC", "status": "pass",
+         "evidence": {"failed_validation_ids": ["v-0002"]}},
+    ])
+    assert ssp._failing_ksis_from_signal(sig) == {"KSI-CMT-LMC"}
+
+
+def test_all_pass_means_no_downgrade():
+    sig = _signal(
+        ksis=[{"id": "KSI-SVC-ACM", "status": "pass",
+               "evidence": {"failed_validation_ids": []}}],
+        validations=[{"result": "fail", "policy": {"id": "terraform.compliance"}}],
+    )
+    assert ssp._failing_ksis_from_signal(sig) == set()
+
+
+def test_legacy_signal_without_ksis_falls_back_to_policy_map():
+    sig = _signal(validations=[
+        {"result": "fail", "policy": {"id": "terraform.compliance"}},
+    ])
+    assert ssp._failing_ksis_from_signal(sig) == {"KSI-MLA-EVC", "KSI-SVC-ACM"}


### PR DESCRIPTION
## Changed
The SSP's implemented-to-partial auto-downgrade re-derived failing KSIs from raw validations through a hardcoded policy-id map. That both dragged in KSIs the signal marks passing (a KSI with no failing evidence was downgraded, taking CA-7/SI-7(7) partial with it) and could miss KSIs the signal actually attributes a failure to. The builder now consumes the signal's own ksis[] attribution (status and failed_validation_ids); the old map remains only as a fallback for legacy signals without a ksis[] block.

## Verified
- Confirmed in the live SSP: controls went partial citing a KSI whose failed_validation_ids were empty in the same signal.
- New unit tests cover signal-attribution, the no-failure case, and the legacy fallback; full suite passes.
- Smoke-built the SSP from the live signal with the patched builder: downgrades now track only the KSIs the signal marks failing.

## Residual / needs human
None. Combined with the tag fixes, the SSP returns to zero unexplained partials at the next deploy.

## Couldn't verify
The post-merge published SSP (requires the deploy).

CodeGuard (software-security) ran against this diff: no findings.

SCN-Type: routine-recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)