### PR TITLE
fix(runtime): re-validate every inventory bucket, not just the first

### DIFF
--- a/infrastructure/lambda/index.js
+++ b/infrastructure/lambda/index.js
@@ -255,13 +255,16 @@ async function buildRuntimeSignal(deploySignal, s3, cf, sm, policy, policyVersio
     const validations = [];
     let validationIdx = 0;
 
-    // S3 bucket: there is one in this system.
-    const bucket = findComponent(components, 'object_store', () => true);
-    if (bucket) {
+    // S3 buckets: evaluate every object_store component in the canonical
+    // inventory (website origin + access-log bucket), so buckets that only
+    // the deploy-time gate used to see are re-validated at runtime too.
+    // Discovery comes from the inventory, never a hard-coded bucket name.
+    for (const bucket of components.filter((c) => c.type === 'object_store')) {
         const bucketName =
             bucket.attributes?.id ||
             (bucket.native_id?.split(':::').pop()) ||
             process.env.S3_BUCKET;
+        if (!bucketName) continue;
         const tfName = bucket.attributes?.tf_name;
         const input = await buildS3ResourceInput(s3, bucketName, tfName);
         const result = await evaluateResource(policy, input);

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -452,6 +452,23 @@ resource "aws_iam_role_policy" "lambda_opa" {
         ]
       },
       {
+        # The emitter re-validates every object_store component in the
+        # canonical inventory, so it needs the same bucket-attribute reads on
+        # the access-log bucket. Bucket-level configuration metadata only —
+        # deliberately no s3:GetObject here, so the Lambda can never read the
+        # access logs themselves.
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketVersioning",
+          "s3:GetEncryptionConfiguration",
+          "s3:GetBucketPublicAccessBlock",
+          "s3:GetBucketTagging"
+        ]
+        Resource = [
+          aws_s3_bucket.logs.arn
+        ]
+      },
+      {
         # The runtime KSI emitter publishes its signal and signing public key back
         # to /.well-known/ on the same bucket. Scoped to exactly those two keys so
         # the Lambda cannot overwrite arbitrary site content.


### PR DESCRIPTION
## Changed
The runtime KSI emitter validated only the first object_store component it found ('there is one in this system' predated the access-log bucket), so the log bucket was checked at deploy time but never re-validated at runtime — which is why the two signals reported different tag findings for different buckets. The emitter now iterates every object_store component in the canonical inventory, mirroring its secrets_manager loop. The emitter role gains the four bucket-attribute reads (versioning, encryption, public-access-block, tagging) on the log bucket in a separate statement, deliberately without object-read access so the Lambda can never read the access logs themselves.

## Verified
- node --check on the Lambda source; full python suite passes; terraform fmt clean.
- The inventory carries exactly two object_store components, so the runtime signal gains one validation entry.

## Residual / needs human
None. The IAM addition is in the main stack (the emitter role), applied by the normal CI deploy.

## Couldn't verify
The next runtime emission's new validation entry (requires deploy + the daily run).

CodeGuard (software-security) ran against this diff: no findings (metadata-only reads, no new input surface, error logging emits only error names).

SCN-Type: routine-recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)