### PR TITLE
docs: bring README, POA&M narratives, and architecture decisions up to deployed truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is the central hub for what's going on with me. The repository also doubles
 - **Automated accessibility testing** — Section 508 checks run in the same gate as the infrastructure checks; same shape, same reporting.
 - **Continuous runtime validation** — A Lambda re-validates the live AWS configuration on a schedule against what was deployed.
 - **A KSI signal informed by a canonical inventory** — Every deploy publishes a JSON document at `/.well-known/ksi-signal.json` containing (1) a snapshot of this system's canonical inventory (PURL for software, ARN paired with a normalized type for cloud resources, sha256 for static artifacts) and (2) policy results attached to specific inventory components by reference, signed via Sigstore keyless. The inventory is the layer; the signal is one report built on it. SBOMs, vulnerability scans, license reports, and configuration drift reports could all ride on the same layer. See [docs/ksi-signal.md](docs/ksi-signal.md) for the full reference.
-- **An OSCAL Rev 5 System Security Plan** — Every deploy also generates and publishes a NIST OSCAL System Security Plan at `/.well-known/oscal-ssp.json`, deterministically derived from the canonical inventory and the FedRAMP KSI catalog. 331 NIST 800-53 Rev 5 implemented-requirements (the full FedRAMP Moderate baseline of 323 controls plus 8 KSI-extension controls) with differentiated `implementation-status` (74% implemented, 26% not-applicable, 0% partial) and FedRAMP-style `control-origination` (52% sp-system, 19% sp-corporate, 16% shared with AWS, 13% inherited) per control, plus an actual implementation statement per control rather than a mass-assigned default. Two views of the same truth: the KSI signal is the wire format; the OSCAL SSP is the human-and-tool-friendly compliance artifact.
+- **An OSCAL Rev 5 System Security Plan** — Every deploy also generates and publishes a NIST OSCAL System Security Plan at `/.well-known/oscal-ssp.json`, deterministically derived from the canonical inventory and the FedRAMP KSI catalog. <span data-figure="hub_total">331</span> NIST 800-53 Rev 5 implemented-requirements (the full FedRAMP Moderate baseline plus KSI-extension controls) with differentiated `implementation-status` and FedRAMP-style `control-origination` per control — including automatic downgrade to `partial` while a live validation is failing — plus an actual implementation statement per control rather than a mass-assigned default. Two views of the same truth: the KSI signal is the wire format; the OSCAL SSP is the human-and-tool-friendly compliance artifact.
 
 ## How the Compliance Pipeline Works
 
@@ -100,12 +100,12 @@ The repository ships a documentation set that closes 27 KSI indicators with rati
 | File | KSIs addressed | Purpose |
 |------|---------------|---------|
 | [`docs/ksi-signal.md`](docs/ksi-signal.md) | KSI-PIY-GIV, KSI-MLA-LET, KSI-CNA-EIS, KSI-SVC-VRI | Schema, join semantics, normalization decisions, verification |
-| [`docs/architecture-decisions.md`](docs/architecture-decisions.md) | KSI-CMT-RVP, KSI-CNA-RNT/03/05/06, KSI-IAM-JIT, KSI-MLA-OSM/02/08, KSI-PIY-RSD, KSI-SVC-EIS/06/08/09 | ADR-style records of architectural decisions per KSI |
+| [`docs/architecture-decisions.md`](docs/architecture-decisions.md) | KSI-CMT-RVP, KSI-CNA-RNT/ULN/RVP/OFA, KSI-IAM-JIT, KSI-MLA-OSM/RVL/ALA, KSI-PIY-RSD, KSI-SVC-EIS/ASM/PRR/VCM | ADR-style records of architectural decisions per KSI |
 | [`docs/incident-response.md`](docs/incident-response.md) | KSI-INR-RIR, KSI-INR-RPI, KSI-INR-AAR | IR runbook with detection sources, triage, after-action template |
 | [`docs/recovery-plan.md`](docs/recovery-plan.md) | KSI-RPL-RRO, KSI-RPL-ARP, KSI-RPL-ABO, KSI-RPL-TRC | RTO 21 days / RPO 24 hours, recovery procedure, tabletop log |
 | [`docs/security-review.md`](docs/security-review.md) | KSI-PIY-RIS | Annual security review template + first entry |
 | [`docs/supply-chain.md`](docs/supply-chain.md) | KSI-SCR-MIT, KSI-SCR-MON | SCRM with Dependabot config in `.github/dependabot.yml` |
-| [`docs/training-log.md`](docs/training-log.md) | KSI-CED-RAT, KSI-CED-RAT, KSI-CED-RAT, KSI-CED-RAT | Self-attested training log |
+| [`docs/training-log.md`](docs/training-log.md) | KSI-CED-RAT | Self-attested training log |
 | [`docs/poam.md`](docs/poam.md) | (cross-cutting — meta) | Plan of Action & Milestones for tracked security gaps with remediation plans (kept in sync with `/.well-known/oscal-poam.json`) |
 | [`docs/policies/`](docs/policies/) | NIST 800-53 Rev 5 *-1 controls (AC-1, AT-1, ... SR-1, PT-1) | Per-family policy and procedures docs, plus the FedRAMP 20x Secure Configuration Guide. Each file integrates the relevant 20x rules (SCN, VDR, MAS, SCG, CCM, ICP, FSI, UCM) and cites AWS authorization package AGENCYAMAZONEW for inherited families |
 | [`docs/continuous-monitoring-plan.md`](docs/continuous-monitoring-plan.md) | CA-7, KSI-MLA, FedRAMP 20x CCM | Continuous Monitoring strategy and mechanisms (deploy-time gate, runtime emitter, VDR aggregator, annual review) |
@@ -148,10 +148,12 @@ The repository ships a documentation set that closes 27 KSI indicators with rati
 
 ### Tracked POA&M items
 
-Known security gaps with remediation plans documented in [`docs/poam.md`](docs/poam.md):
+The authoritative register is [`docs/poam.md`](docs/poam.md), kept in sync with the machine-readable OSCAL POA&M published at [`/.well-known/oscal-poam.json`](https://samaydlette.com/.well-known/oscal-poam.json) on every deploy. The register currently runs POAM-001 through POAM-031 (POAM-016 was retired): a mix of closed remediations, documented false positives, and open risk acceptances, each with its rationale and — where open — a review trigger.
 
-- **POAM-001:** Migrate the deployer from long-lived AWS access keys to GitHub OIDC role assumption. (Medium severity; the Sigstore signing chain in this repo already proves the OIDC pattern works for cosign — POAM-001 extends it to AWS.)
-- **POAM-002:** Sign the runtime KSI signal cryptographically (currently trusted implicitly via S3 + IAM). (Low for PoC, Medium in portfolio context; KMS asymmetric signing is the proposed approach.)
+Two early items this README used to track as open are now closed:
+
+- **POAM-001** (closed 2026-06-15): the deployer was migrated from long-lived AWS access keys to GitHub OIDC role assumption; the legacy IAM user, its keys, and the repository secrets were deleted.
+- **POAM-002** (closed 2026-06-17): the runtime KSI signal is signed with a KMS ECC P-256 key; the public key is published at `/.well-known/runtime-signing-pubkey.pem` and the signature travels in the signal's `provenance.attestation`.
 
 ## Architecture
 
@@ -336,14 +338,12 @@ Push to `main` branch triggers automatic deployment with compliance validation.
 
 | Feature | Security Benefit | Annual Cost | Decision | POA&M |
 |---------|------------------|-------------|----------|-------|
-| CloudFront WAF | DDoS/attack protection | +$120 | **Risk-accepted** — static content, low risk | [POAM-007](docs/poam.md) |
+| CloudFront WAF | DDoS/attack protection | +$120 | **Risk-accepted** — managed interfaces + Shield Standard + throttling cover SC-7/SC-5; WAF's incremental layer-7 filtering is the documented residual | [POAM-007](docs/poam.md) |
 | Lambda in VPC | Network isolation | +$540 | **Risk-accepted** — no sensitive data processing | [POAM-010](docs/poam.md) |
-| S3 access logging | Detailed audit trail | +$180 | **Risk-accepted** — CloudTrail provides the audit basics | [POAM-005](docs/poam.md) |
-| Multi-region active-passive | Regional failover | +$300 | **Risk-accepted** — declared 21-day RTO accommodates regional failure | [POAM-016](docs/poam.md) |
+| S3 access logging | Detailed audit trail | ~$0 at current traffic | **Implemented** (2026-06-18) — S3 server-access + CloudFront logs delivered to a dedicated locked-down log bucket | [POAM-005](docs/poam.md) (closed) |
+| Multi-region active-passive | Regional failover | +$300 | **Risk-accepted** — declared 21-day RTO accommodates regional failure ([recovery plan](docs/recovery-plan.md)) | POAM-016 (retired) |
 
-The full register of risk-accepted items, including the 13 inline Checkov suppressions in `infrastructure/main.tf`, lives in [`docs/poam.md`](docs/poam.md) as POA&M entries with status `Risk-accepted`. This table is the budget-context summary; the POA&M is the authoritative register.
-
-**For Enterprise Use:** Remove the `#checkov:skip` comments and reopen the corresponding POA&M entries to enable these features.
+The full register of dispositions — closed remediations, documented false positives, and open risk acceptances, including the scanner suppressions carried with inline rationale — lives in [`docs/poam.md`](docs/poam.md). This table is the budget-context summary; the POA&M is the authoritative register.
 
 ## When Things Break (And They Will)
 

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -12,19 +12,20 @@ There is no separate change-management ticketing system because there is no sepa
 
 ## Ingress and egress restriction (KSI-CNA-RNT)
 
-The system has exactly one ingress: CloudFront, fronting an S3 bucket whose public access is fully blocked. CloudFront's origin access is restricted to the bucket via a service-principal policy with a `SourceArn` condition; no other principal can read the bucket directly. There is no public ingress to any compute resource.
+The system has two ingress paths:
 
-Egress: the Lambda calls AWS APIs for S3 and CloudFront within the account. The Lambda has no internet egress and no NAT gateway. Outbound traffic from the Lambda to AWS service endpoints stays within the AWS network.
+1. **CloudFront → S3** for the static site: the bucket's public access is fully blocked and CloudFront's origin access is restricted via a service-principal policy with a `SourceArn` condition; no other principal can read the bucket directly.
+2. **API Gateway → Silk Reeling Lambda** for the gated app: the HTTP API's data routes (`ANY /api/{proxy+}`) require a Cognito JWT authorizer, the stage is throttled (20 req/s, burst 10), and access-logged. This is the only public ingress to compute, added with SCN-2026-001.
 
-There are no other ingress or egress paths to control because there are no other moving parts.
+Egress: the compliance Lambda calls AWS APIs only, within the AWS network — no internet egress, no NAT gateway. The Silk Reeling Lambda additionally calls the external Anthropic API for feedback text; that interconnection is tracked as [POAM-020](poam.md) (SA-9/CA-3, risk-accepted).
 
 ## Traffic flow controls (KSI-CNA-ULN)
 
-The system has two logical paths: viewer→CloudFront→S3 (read-only, all viewers) and Lambda→AWS API (scoped via IAM). There is no internal east-west traffic to control. The IAM policy on the Lambda role is the entire traffic-flow control mechanism for the only non-public path that exists.
+The system has four logical paths: viewer→CloudFront→S3 (read-only, all viewers), authenticated user→API Gateway→Silk Reeling Lambda (JWT-gated, throttled), Silk Reeling Lambda→Anthropic API (egress interconnection, POAM-020), and compliance Lambda→AWS APIs (scoped via IAM). There is no internal east-west traffic to control; the IAM policies on the two Lambda roles and the gateway authorizer are the traffic-flow control mechanisms for the non-public paths.
 
 ## DDoS and unwanted-activity protection (KSI-CNA-RVP)
 
-CloudFront includes AWS Shield Standard at no cost; this is the baseline protection. AWS WAF was evaluated and consciously excluded as a cost trade-off (~$120/year) documented in the README. The threat model for a static personal site does not justify it: there are no forms, no authentication endpoints, no APIs, and no expensive backend resources to protect from request floods. Shield Standard handles the L3/L4 cases that exist.
+CloudFront includes AWS Shield Standard at no cost; this is the baseline protection. AWS WAF was evaluated and consciously excluded as a cost trade-off (~$120/year) documented in the README and POAM-007. Since the Silk Reeling app was added, the system does have an authentication endpoint and an API — those are protected by API Gateway stage throttling (20 req/s, burst 10), Cognito account lockout, and Shield Standard, which together cover the SC-5 cases at this scale. POAM-023's closure keeps a standing trigger: credential-guessing evidence in the app's logs forces the WAF rate-rule immediately.
 
 **Effectiveness review:** annually (see [`security-review.md`](security-review.md)). If traffic patterns change or the threat profile shifts (e.g., the site starts serving forms or APIs), the WAF decision is revisited.
 
@@ -54,7 +55,7 @@ If the system grew to require true SIEM features (correlation rules, alerting, l
 
 Quarterly. Specifically:
 
-- Review CloudTrail for any unexpected API calls (especially IAM and CloudFront writes from non-CI principals)
+- Review CloudTrail records for any unexpected API calls, especially IAM and CloudFront writes from non-CI principals (capture depth is documented in the SIEM section above)
 - Review Lambda execution logs for runtime KSI emitter failures
 - Review GitHub Actions workflow run history for unexpected workflow modifications
 
@@ -62,14 +63,14 @@ A no-finding review does not require a commit. Anomalies are recorded in [`secur
 
 ## Log access scoping (KSI-MLA-ALA)
 
-Log access is scoped via AWS IAM. The deployer credentials have CloudWatch Logs read access account-wide; the Lambda role has none. No other principal exists in the system.
+Log access is scoped via AWS IAM. The operator's IAM user holds the CloudWatch Logs read access (through group-attached policies); the OIDC-assumed deploy role can enumerate log groups for reconciliation but not read log events; neither Lambda role can read logs. No other principal exists in the system.
 
 ## CISA Secure-by-Design alignment (KSI-PIY-RSD)
 
 This system aligns with CISA Secure-by-Design principles by design and by accident, both:
 
-- **Memory safety:** N/A (no native code; the only compute is a short-lived Node.js Lambda)
-- **Eliminate default passwords:** No passwords in this system; AWS root requires MFA, deployer credentials are GitHub Actions encrypted secrets, signing is keyless
+- **Memory safety:** N/A (no native code; compute is a short-lived Node.js Lambda and a Python 3.13 Lambda)
+- **Eliminate default passwords:** No default or shared passwords; the app's Cognito pool enforces a 14-character policy with mandatory TOTP MFA, AWS root requires MFA, CI deploys via ephemeral OIDC role assumption, signing is keyless
 - **Single sign-on:** GitHub for repo access, AWS for cloud access
 - **Provenance for software components:** the canonical inventory carries PURL, ARN, and content hashes for every component; the deploy chain is signed via Sigstore; the bundle is verifiable against the public Rekor transparency log
 - **Vulnerability disclosure:** see [`/.well-known/security.txt`](../website/.well-known/security.txt)
@@ -87,7 +88,8 @@ The annual security review (see [`security-review.md`](security-review.md)) is t
 
 Secrets in scope:
 
-- **AWS access keys (deployer):** stored as GitHub Actions encrypted secrets; rotated every 90 days as a compensating control while the OIDC migration in [POAM-001](poam.md) remains deferred. Rotation procedure is in [`docs/policies/secure-configuration-guide.md`](policies/secure-configuration-guide.md); rotation events are logged in [`docs/security-review.md`](security-review.md).
+- **Deployer credentials:** none stored. CI deploys via GitHub OIDC role assumption ([POAM-001](poam.md), closed 2026-06-15); the ephemeral token exists only for the workflow run. The legacy long-lived access keys and their 90-day rotation procedure were retired with the migration.
+- **Anthropic API key (Silk Reeling app):** held in Secrets Manager under a customer CMK; a third-party credential with no programmatic rotation source, so the compensating control is an annual manual rotation whose currency the runtime emitter verifies daily against the secret's `LastChangedDate` (SC-12).
 - **TLS certificate:** ACM-managed, auto-rotated by AWS.
 - **GitHub PATs:** none in use. All GitHub access uses the workflow's `GITHUB_TOKEN` with workflow-scoped permissions, plus the OIDC token for cosign keyless signing (which is ephemeral).
 - **Sigstore signing identity:** ephemeral, generated per-run by Fulcio, never stored anywhere.
@@ -114,8 +116,8 @@ Token threat model, sized to the system's actual blast radius. Methodology: STRI
 **Top threats considered:**
 
 1. **GitHub repository compromise → arbitrary deploy.** An attacker with write access to `main` can push code that the OPA gate would have to flag. *Mitigations:* GitHub branch protection on `main`, OPA gate evaluating Terraform plan + content + IAM policy on every PR, Sigstore signing chain that records every produced artifact in the public Rekor log so a falsified deploy is externally detectable.
-2. **Deployer credential leak → AWS account access.** The long-lived AWS access keys in GitHub Actions secrets are the largest standing-privilege surface. *Mitigations:* GitHub secret scanning with push protection, scoped IAM permissions on the deployer principal, 90-day key rotation as an active compensating control (procedure in the [Secure Configuration Guide](policies/secure-configuration-guide.md), rotation events logged in [`security-review.md`](security-review.md)), and the planned migration to GitHub OIDC role assumption ([POAM-001](poam.md)) which is the durable answer.
-3. **Runtime Lambda compromise → falsified runtime signal.** An attacker with Lambda code-modification access could publish misleading runtime KSI signals. *Mitigations:* tight Lambda IAM (write only to one S3 key, read-only on three S3 config APIs and one CloudFront distribution), drift between deploy-time and runtime signals is detectable from outside, runtime signal is not currently signed (POAM-002).
+2. **Deploy-identity compromise → AWS account access.** CI assumes a scoped IAM role via GitHub OIDC ([POAM-001](poam.md), closed): there are no long-lived deployer keys to leak, and the token is valid only for the workflow run. *Mitigations:* OIDC trust policy scoped to this repository, scoped IAM permissions on the deploy role, GitHub secret scanning with push protection for the few remaining repository secrets (which carry no AWS credentials).
+3. **Runtime Lambda compromise → falsified runtime signal.** An attacker with Lambda code-modification access could publish misleading runtime KSI signals. *Mitigations:* tight Lambda IAM (write only to two S3 keys, read-only configuration-metadata access on the inventory's buckets and one CloudFront distribution), drift between deploy-time and runtime signals is detectable from outside, and the runtime signal is signed with a KMS ECC P-256 key (POAM-002, closed) whose public key is published for independent verification.
 4. **Sigstore-chain compromise.** A compromise of Fulcio, Rekor, or the GitHub OIDC issuer would invalidate the signing chain. *Mitigations:* none operator-side — these are public infrastructure components with thousands of independent observers; compromise of any one is detectable by anyone running independent verification.
 5. **Bucket policy weakening.** A change to the S3 bucket policy or public-access block that re-enabled public read or write. *Mitigations:* OPA gate at deploy time blocks the change; runtime KSI emitter detects the drift within 24 hours.
 
@@ -133,7 +135,9 @@ Cross-component communications:
 
 - viewer ↔ CloudFront: TLS 1.2+
 - CloudFront ↔ S3: TLS within the AWS network, with origin authentication via service principal + SourceArn
+- authenticated user ↔ API Gateway ↔ Silk Reeling Lambda: TLS, Cognito JWT verified at the gateway
+- Silk Reeling Lambda ↔ Anthropic API: TLS to the external endpoint (interconnection, POAM-020)
 - Lambda ↔ AWS service APIs: TLS within the AWS network
-- CI ↔ AWS APIs: TLS, with credentials scoped via IAM
+- CI ↔ AWS APIs: TLS, with an ephemeral OIDC-assumed role scoped via IAM
 
 Authenticity at the application layer: the canonical inventory is signed (KSI-SVC-VRI). Communication integrity at the transport layer is AWS-default TLS. End-to-end signed-message integrity at the application layer beyond the signed signal is not implemented because no application-layer protocol exists between components beyond the standard AWS APIs.

--- a/docs/poam.md
+++ b/docs/poam.md
@@ -80,61 +80,38 @@ accepted risk — rotation currency is now **verified automatically**: the runti
 KSI emitter reads the secret's `LastChangedDate` daily and fails an SC-12
 validation if rotation lapses past the cadence.
 
-**POAM-021 (added with the gated Silk Reeling app):** Access to the gated app is
-authenticated by an operator-configured username/password (HTTP Basic Auth) —
-single-factor, shared credential, with no MFA (IA-2(2)) and no account lockout
-(AC-7). This is a **customer-responsibility control**: the operator configures
-and owns the credential and accepts the residual risk. At the system's Moderate
-categorization this is a real IA-2(2)/AC-7 weakness, accepted only on an interim
-basis while remediation is implemented (see **Remediation** below: Cognito MFA +
-API Gateway authorizer, Task 3). The interim acceptance rests on the compensating
-controls, not on the categorization: the credential is held in Secrets Manager
-(CMK), transmitted only over TLS, and compared in constant time. The credential gate runs in the Lambda itself, so it
-applies to every request regardless of how the API Gateway endpoint is reached.
-**Risk acceptance:** the operator, acting as the **sole customer and sole user** of
-the system, has approved this operational requirement and accepted the residual
-risk — no third party bears it, so the acceptance is complete and authoritative.
-It is valid **only while the operator remains the sole customer**: onboarding any
-real user is a re-assessment trigger, and **any customer onboarded must explicitly
-accept this risk (recorded in the CRM) or adopt the upgrade path below**.
-**Upgrade path (available on request — not a deficiency):** federation to a
-customer IdP via SAML/OIDC, or native WebAuthn/FIDO2 with FIPS-AAGUID attestation,
-would provide phishing-resistant MFA (IA-2(1)) and move authentication to
-`customer-configured`; offered on request, not pre-built. FedRAMP control
-origination is tracked per-control in the OSCAL SSP (`control-origination` props)
-and is surfaced in the forthcoming CRM/SCuBA as a customer-accepted shared
-responsibility.
+**POAM-021 (closed 2026-06-22, Task 3 — historical record):** As shipped, access
+to the gated app was authenticated by an operator-configured username/password
+(HTTP Basic Auth) — single-factor, shared credential, no MFA (IA-2(2)), no
+account lockout (AC-7). The weakness was risk-accepted on an interim,
+sole-customer basis with compensating controls (credential in CMK-encrypted
+Secrets Manager, TLS-only, constant-time comparison) while the remediation was
+built. **Closure:** the Basic Auth gate was replaced by Amazon Cognito with
+mandatory TOTP MFA, a 14-character password policy, and admin-only user
+creation, fronted by an API Gateway JWT authorizer on the data routes. The
+shared single-factor credential no longer exists. Phishing-resistant
+authenticators (WebAuthn/FIDO2, IA-2(1)) remain the documented upgrade path and
+are tracked in the same family as POAM-025's hardware-token direction.
 
-**POAM-022 (API Gateway no authorizer):** An API Gateway HTTP API fronts the app
-Lambda and its `$default` route specifies no authorizer (Checkov CKV_AWS_309).
-This is deliberate: access control is enforced in the Lambda via HTTP Basic Auth,
-and a Gateway-level JWT/IAM authorizer would consume the `Authorization` header the
-app needs to read. API Gateway replaces a Lambda Function URL (which this AWS
-account blocks for public access); the Gateway passes the viewer's `Authorization`
-header through unchanged and the app rejects any request lacking a valid
-credential. **Remediation:** if the app later federates to an IdP (see POAM-021), a
-JWT authorizer on the route supersedes this acceptance. Applies only while the app
-is deployed.
+**POAM-022 (closed 2026-06-22, Task 3 — historical record):** The app's API
+Gateway HTTP API originally specified no authorizer on any route (Checkov
+CKV_AWS_309) — deliberate at the time, because the Lambda's Basic Auth gate
+consumed the `Authorization` header. **Closure:** the HTTP API now carries a
+Cognito JWT authorizer on the `ANY /api/{proxy+}` data routes; an
+unauthenticated request to the data API is rejected at the gateway (401) before
+the Lambda runs. The `$default` route intentionally stays open so the SPA shell
+and login page can load — that route serves static content only.
 
-**POAM-023 (no brute-force protection):** The Basic Auth endpoint has no account
-lockout (AC-7) and no rate limiting / WAF (SC-5) in front of it, so credential
-guessing is not throttled. Surfaced by the `software-security` review. At the
-system's Moderate categorization this is a real AC-7/SC-5 weakness, accepted only
-on an interim basis pending remediation (see **Remediation** below: API Gateway
-usage-plan throttling + Cognito lockout, Task 3). The interim acceptance rests on
-the compensating controls, not the categorization: the credential is a
-high-entropy operator-set secret compared in constant time, and a single shared
-credential is the only valid pair (no user enumeration). **Assessor
-posture:** a FedRAMP Recognized assessor penetration test may re-rate an unauthenticated-reachable,
-unthrottled credential endpoint above Low regardless of the compensating controls
-above; the operator's accepted position is explicitly conditional — any evidence of
-credential-guessing in the Lambda execution logs (`/aws/lambda/samaydlette-com-silk-reeling`)
-or CloudFront logs triggers **immediate** implementation of the deferred WAF
-rate-rule rather than continued acceptance, and an assessor finding that re-rates
-the residual is treated as that trigger. **Remediation:** attach AWS WAF with a
-rate-based rule to the CloudFront distribution, or add an API Gateway usage-plan
-throttle; deferred on cost (~$120/yr WAF, consistent with POAM-007). Applies only
-while the app is deployed.
+**POAM-023 (closed 2026-06-22, Task 3 — historical record):** The Basic Auth
+endpoint originally had no account lockout (AC-7) and no rate limiting (SC-5),
+so credential guessing was unthrottled. The interim acceptance carried an
+explicit trigger: any credential-guessing evidence in the app's execution logs
+would force the deferred WAF rate-rule immediately. **Closure:** API Gateway
+stage throttling (20 req/s, burst 10) now fronts the app and Cognito provides
+account lockout, so the trigger condition is structurally addressed at $0
+rather than via WAF (~$120/yr, still pre-authorized under this item's original
+terms if credential-guessing evidence ever appears in
+`/aws/lambda/samaydlette-com-silk-reeling` or the API access logs).
 
 **POAM-017 and POAM-024 closed (Task 7) — audit logging + retention.** *POAM-017:*
 every CloudWatch log group now has 365-day retention (AU-11) — the route53 query-log

--- a/scripts/inject-figures.py
+++ b/scripts/inject-figures.py
@@ -52,6 +52,9 @@ PROFILES = {
 TARGETS = [
     REPO / "website" / "research" / "the-plumbing.html",
     REPO / "website" / "viewer.html",
+    # README carries the headline implemented-requirements figure; GitHub
+    # renders inline HTML spans, so the same data-figure markers work there.
+    REPO / "README.md",
 ]
 
 

--- a/website/silk-reeling-mirror.html
+++ b/website/silk-reeling-mirror.html
@@ -241,7 +241,7 @@
       <div class="cta-row">
         <a class="cta" href="/silk-reeling/">Enter the App <span class="arrow" aria-hidden="true">→</span></a>
         <p class="cta-note">
-          <span class="lock" aria-hidden="true">🔒</span> Private beta — you'll be asked for a username and password.
+          <span class="lock" aria-hidden="true">🔒</span> Private beta — sign-in requires an invited account with multi-factor authentication.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Changed
Truth-reconciliation sweep of the human-readable surfaces, correcting every claim found stale against the deployed system:

- README: the 'Tracked POA&M items' section presented POAM-001/002 as open (both closed in June); it now describes the full POAM-001..031 register. The budget table's S3-access-logging row credited a CloudTrail that does not exist and is now marked Implemented per POAM-005's closure; the multi-region row pointed at the retired POAM-016. Old numeric KSI IDs replaced with CR26 mnemonics. The headline implemented-requirements figure now carries a data-figure marker with README.md added to the figure injector's targets, so the count is machine-stamped rather than hand-typed; volatile percentages are described rather than hardcoded.
- docs/poam.md: the POAM-021/022/023 narrative paragraphs still described the retired Basic Auth gate in the present tense; rewritten as historical records of the accepted interim risk plus the Cognito/JWT/throttling closure, preserving POAM-023's WAF trigger condition.
- docs/architecture-decisions.md: the ingress/egress, traffic-flow, DDoS, log-access, CISA SbD, secret-management, threat-model, and communication-integrity sections predated the app, the OIDC migration, and the runtime-signal signing; each now describes the deployed state including the external-inference interconnection (POAM-020).
- website/silk-reeling-mirror.html: beta note now says invited account with MFA instead of username-and-password.

## Verified
- Each corrected claim was checked against live state (read-only CLI) or the authoritative register before rewriting: OIDC role assumption in the workflow, signed runtime signal + published public key, Cognito/authorizer/throttling live, 30-item OSCAL POA&M regenerated daily.
- Full python suite passes (includes the figure-injection tests).

## Residual / needs human
None.

## Couldn't verify
figures-check end-to-end (needs built artifacts; runs in CI).

CodeGuard (software-security) ran against this diff: no findings (docs only; no sensitive identifiers introduced).

SCN-Type: routine-recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)