### PR TITLE
ci: wait for the terraform state lock instead of failing PR plans

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -280,10 +280,14 @@ jobs:
       working-directory: infrastructure
       run: terraform validate
 
-    # Create a plan showing what will be built
+    # Create a plan showing what will be built. The state lock is shared with
+    # every other run's plan; the workflow-level concurrency group only
+    # serializes runs on the SAME ref, so plans from different open PRs can
+    # race for the lock. -lock-timeout makes a contending plan wait its turn
+    # instead of failing the check.
     - name: Terraform Plan
       working-directory: infrastructure
-      run: terraform plan -out=tfplan
+      run: terraform plan -lock-timeout=300s -out=tfplan
 
     # -------------------------------------------------------------------------
     # THE ACTUAL SECURITY CHECK
@@ -835,11 +839,11 @@ jobs:
 
     - name: Generate fresh Terraform plan
       working-directory: infrastructure
-      run: terraform plan -out=tfplan
+      run: terraform plan -lock-timeout=300s -out=tfplan
 
     - name: Terraform Apply
       working-directory: infrastructure
-      run: terraform apply -auto-approve tfplan
+      run: terraform apply -lock-timeout=300s -auto-approve tfplan
 
     # -------------------------------------------------------------------------
     # SEED SILK REELING SECRETS (out-of-band) — set the Anthropic key into Secrets


### PR DESCRIPTION
## Changed
Four simultaneously-opened PRs all failed their OPA Compliance Check with 'Error acquiring the state lock'. The workflow-level concurrency group is keyed on the ref, so it serializes runs on the same branch but lets plans from different open PRs race for the single shared state lock. Adds -lock-timeout=300s to the compliance-check plan and the deploy job's plan/apply, so a contending run waits for the lock (held for seconds during a plan) instead of failing.

Chose lock-timeout over a job-level concurrency group deliberately: GitHub concurrency keeps at most one pending job per group and cancels older pending ones, which would fail sibling PR checks outright; waiting on the lock queues fairly with no cancellations.

## Verified
- Root cause from the failed run logs: lock holder was a sibling PR's runner, OperationTypePlan, created 13 seconds before the failure.
- All four affected runs passed when re-run serially — confirming pure contention, no content issue.
- YAML change is two flags plus comments; no gate logic touched.

## Residual / needs human
None.

## Couldn't verify
The contention scenario end-to-end (needs several PRs' checks queued at once again; the flag is the standard Terraform mechanism for exactly this).

CodeGuard (software-security) ran against this diff: no findings.

SCN-Type: routine-recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)