### PR TITLE
ci: lock-timeout on the OPA check's terraform plan (completes the lock fix)

### DIFF
--- a/scripts/terraform-plan.sh
+++ b/scripts/terraform-plan.sh
@@ -56,9 +56,12 @@ rm -f tfplan tfplan.json
 echo "Initializing Terraform..."
 terraform init
 
-# Create a plan showing exactly what infrastructure will be created/changed
+# Create a plan showing exactly what infrastructure will be created/changed.
+# -lock-timeout: this script also runs in every PR's compliance check, where
+# it can contend for the shared state lock with sibling PR checks or a
+# main-branch deploy mid-apply; wait for the lock instead of failing.
 echo "Generating Terraform plan..."
-terraform plan -out=tfplan
+terraform plan -lock-timeout=300s -out=tfplan
 
 # =============================================================================
 # CONVERT PLAN TO READABLE FORMAT


### PR DESCRIPTION
## Changed
The earlier lock-timeout fix covered the workflow's direct terraform plan/apply steps, but the OPA Compliance Check step delegates to scripts/terraform-plan.sh, whose internal terraform plan still failed immediately on lock contention — observed when a PR's check ran while the main-branch deploy held the lock mid-apply. Adds the same -lock-timeout=300s there.

## Verified
- Failing run's log shows the lock error inside 'Run OPA Compliance Check' (the script's plan), not the workflow's patched plan step.
- bash -n syntax check passes; the affected PR's check passes on serial re-run.

## Residual / needs human
None.

## Couldn't verify
The contention scenario end-to-end (same as the sibling fix; this is the standard Terraform wait mechanism).

CodeGuard (software-security) ran against this diff: no findings.

SCN-Type: routine-recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)