### PR TITLE
fix(scuba): README demo crashes on the committed manifest (KeyError: rego)

### DIFF
--- a/scuba/scuba.py
+++ b/scuba/scuba.py
@@ -122,7 +122,8 @@ def main():
             ok, detail = True, p.get("default_detail", "")
             default_by_resp[p.get("responsibility", "implemented")] += 1
         else:  # customer-action -> evaluate with OPA locally
-            res = opa_eval(Path(a.bundle) / p["rego"], p["package"], a.config)
+            rego_rel = p.get("rego") or f"policies/{p['name']}.rego"
+            res = opa_eval(Path(a.bundle) / rego_rel, p["package"], a.config)
             ok, detail = bool(res.get("pass")), res.get("detail", "")
             n_pass_actions += ok
             actions.append((p, ok, detail))


### PR DESCRIPTION
## Changed
Running the documented demo (`python3 scuba/scuba.py --config scuba/sample-config.json`) crashes: the committed bespoke bundle.json has no `rego` key per policy, but the CLI requires it. The CLI now falls back to `policies/<name>.rego`, matching the bundle's actual layout; an explicit `rego` key still wins when present (the generated full bundle can keep using it).

## Verified
- The README demo runs end-to-end: both policies evaluate locally via OPA, framework projection renders, and the OSCAL Assessment Results document is written.
- Full python suite passes.

## Residual / needs human
None.

## Couldn't verify
N/A.

CodeGuard (software-security) ran against this diff: no findings.

SCN-Type: routine-recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)