### PR TITLE
feat(scuba): publish the signed bundle at /.well-known/; verify-before-execute remote mode

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -1204,6 +1204,32 @@ jobs:
         cosign sign-blob --yes --bundle iiw.bundle iiw.csv
 
     # -------------------------------------------------------------------------
+    # BUILD THE SCuBA BUNDLE  (the executable CRM — customer-run assessment)
+    # -------------------------------------------------------------------------
+    # One policy (Rego + markdown) per SSP control, derived from the hub SSP,
+    # bound to the canonical inventory's signal_id, and published as ONE
+    # self-contained signed JSON so scuba.py --remote can fetch + cosign-verify
+    # before executing anything. Reconcile invariant (k) asserts the binding
+    # and that the bundle's control set equals the SSP's.
+    # -------------------------------------------------------------------------
+    - name: Build SCuBA bundle (executable CRM)
+      working-directory: infrastructure
+      run: |
+        echo "Building SCuBA customer-responsibility bundle..."
+        python3 ../scripts/build-scuba-bundle.py \
+          --ssp oscal-ssp.json \
+          --ksi-signal ksi-signal.json \
+          --out scuba-dist \
+          --inline-output scuba-bundle.json
+        jq '{policies: (.policies | length), ksi_signal_id}' scuba-bundle.json
+
+    - name: Sign SCuBA bundle
+      working-directory: infrastructure
+      run: |
+        echo "Signing scuba-bundle.json with cosign keyless..."
+        cosign sign-blob --yes --bundle scuba-bundle.bundle scuba-bundle.json
+
+    # -------------------------------------------------------------------------
     # BUILD THE OSCAL POA&M  (published after the reconciliation gate)
     # -------------------------------------------------------------------------
     # NIST OSCAL Plan of Action and Milestones format. Imports the OSCAL SSP
@@ -1330,6 +1356,9 @@ jobs:
         # IIW
         aws s3 cp iiw.csv "s3://$BUCKET_NAME/.well-known/iiw.csv" --content-type text/csv --cache-control "public, max-age=300"
         aws s3 cp iiw.bundle "s3://$BUCKET_NAME/.well-known/iiw.bundle" --content-type application/json --cache-control "public, max-age=300"
+
+        aws s3 cp scuba-bundle.json "s3://$BUCKET_NAME/.well-known/scuba-bundle.json" --content-type application/json --cache-control "public, max-age=300"
+        aws s3 cp scuba-bundle.bundle "s3://$BUCKET_NAME/.well-known/scuba-bundle.bundle" --content-type application/json --cache-control "public, max-age=300"
         # OSCAL POA&M
         aws s3 cp oscal-poam.json "s3://$BUCKET_NAME/.well-known/oscal-poam.json" --content-type application/oscal+json --cache-control "public, max-age=300"
         aws s3 cp oscal-poam.bundle "s3://$BUCKET_NAME/.well-known/oscal-poam.bundle" --content-type application/json --cache-control "public, max-age=300"
@@ -1450,6 +1479,7 @@ jobs:
         check availability.json .well-known/availability.json
         check policy-index.json .well-known/policy-index.json
         check security-decision-record.json .well-known/security-decision-record.json
+        check scuba-bundle.json .well-known/scuba-bundle.json
         check certification-package-overview.json .well-known/certification-package-overview.json
         check iiw.csv .well-known/iiw.csv
         # SLSA/in-toto provenance attestations (S2/S3): served bytes match the build.

--- a/scripts/build-scuba-bundle.py
+++ b/scripts/build-scuba-bundle.py
@@ -93,6 +93,12 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--ssp", required=True)
     ap.add_argument("--out", default=str(HERE / "scuba" / "dist"))
+    ap.add_argument("--ksi-signal", default=None,
+                    help="canonical inventory; stamps the signal_id/commit binding "
+                         "into the manifest so reconcile invariant (k) can assert it")
+    ap.add_argument("--inline-output", default=None,
+                    help="also emit ONE self-contained JSON (policy sources inlined) "
+                         "for signed publication at /.well-known/scuba-bundle.json")
     a = ap.parse_args()
 
     bespoke = {p["control"]: p for p in json.loads(BESPOKE_MANIFEST.read_text())["policies"]}
@@ -141,7 +147,25 @@ def main():
                                          "default_detail": f"No customer action required; satisfied by {WHO.get(resp)}."})
             kinds["default"] += 1
 
+    if a.ksi_signal:
+        sig = json.loads(Path(a.ksi_signal).read_text())
+        manifest["ksi_signal_id"] = sig.get("signal_id")
+        manifest["commit"] = (sig.get("provenance") or {}).get("source", {}).get("commit")
+        manifest["emitted_at"] = sig.get("emitted_at")
+
     (out / "bundle.json").write_text(json.dumps(manifest, indent=2) + "\n")
+
+    if a.inline_output:
+        # One self-contained artifact: the manifest with every policy's Rego
+        # and markdown inlined, so a consumer verifies ONE signed blob and
+        # needs no directory fetch. This is the published form.
+        inline = json.loads(json.dumps(manifest))
+        for p in inline["policies"]:
+            p["rego_source"] = (out / p["rego"]).read_text()
+            p["md_source"] = (out / p["md"]).read_text()
+        Path(a.inline_output).write_text(json.dumps(inline, indent=2) + "\n")
+        print(f"inline bundle -> {a.inline_output}")
+
     print(f"generated {len(manifest['policies'])} policies -> {out}")
     print(f"  kinds: {dict(kinds)}")
     print(f"  by responsibility: {dict(resp_counts)}")

--- a/scripts/reconcile.py
+++ b/scripts/reconcile.py
@@ -33,6 +33,11 @@
 #                        generated artifact resolves to a formal POA&M item
 #                        (or an explicitly retired ID), so a typo'd or
 #                        vanished cross-reference cannot publish silently
+#   (k) SCuBA bundle binding — when the published customer-assessment bundle
+#                        is present it binds to the same inventory signal_id
+#                        and its policy set equals the SSP's control set
+#                        (the executable CRM cannot drift from the SSP it
+#                        derives from)
 #
 # Usage:
 #   reconcile.py --artifacts-dir infrastructure [--live] [--expect-commit SHA]
@@ -504,6 +509,42 @@ def check_j_poam_ref_validity(signal, ssp, poam, vdr):
     return violations
 
 
+# ----------------------------------------------------------------------------
+# (k) SCuBA bundle binding + derivation (presence-gated)
+# ----------------------------------------------------------------------------
+def check_k_scuba_binding(signal, ssp, scuba):
+    """(k) The published SCuBA bundle must bind to the same inventory
+    (ksi_signal_id) and derive from the same SSP (its policy set covers
+    exactly the SSP's implemented-requirements control ids). Skipped when no
+    bundle is staged."""
+    if scuba is None:
+        return []
+    violations = []
+    sid = signal.get("signal_id")
+    if scuba.get("ksi_signal_id") != sid:
+        violations.append(
+            f"(k) scuba bundle ksi_signal_id {scuba.get('ksi_signal_id')!r} "
+            f"!= inventory signal_id {sid!r}")
+    ssp_ids = {
+        r["control-id"]
+        for r in ssp.get("system-security-plan", {})
+        .get("control-implementation", {})
+        .get("implemented-requirements", []) or []
+    }
+    bundle_ids = {p.get("control") for p in scuba.get("policies", []) or []}
+    missing = sorted(ssp_ids - bundle_ids)
+    extra = sorted(bundle_ids - ssp_ids)
+    if missing:
+        violations.append(
+            f"(k) scuba bundle missing policies for {len(missing)} SSP "
+            f"controls (first: {missing[:5]})")
+    if extra:
+        violations.append(
+            f"(k) scuba bundle carries policies for {len(extra)} controls "
+            f"not in the SSP (first: {extra[:5]})")
+    return violations
+
+
 def check_g_poam_parity(poam, poam_md_text):
     """(g) The OSCAL POA&M's item set must exactly equal the formal POA&M items
     in docs/poam.md. Both registers are hand-maintained; without this check they
@@ -529,7 +570,7 @@ def check_g_poam_parity(poam, poam_md_text):
 # ----------------------------------------------------------------------------
 def run_all(signal, ssp, poam, vdr, dashboard_html, checkov_text,
             ckv_to_poam, poam_md_text, false_positive_ckvs,
-            live_arns=None, expected_commit=None, live_tags=None):
+            live_arns=None, expected_commit=None, live_tags=None, scuba=None):
     violations = []
     violations += check_d_impact(signal, ssp, poam, vdr, dashboard_html)
     violations += check_e_binding(signal, ssp, poam, vdr)
@@ -541,6 +582,7 @@ def run_all(signal, ssp, poam, vdr, dashboard_html, checkov_text,
     violations += check_g_poam_parity(poam, poam_md_text)
     violations += check_h_finding_coverage(vdr, poam)
     violations += check_j_poam_ref_validity(signal, ssp, poam, vdr)
+    violations += check_k_scuba_binding(signal, ssp, scuba)
     if live_arns is not None:
         violations += check_a_completeness(signal, live_arns)
     if live_tags is not None:
@@ -604,6 +646,12 @@ def main():
         print(f"reconcile: missing artifact: {e}", file=sys.stderr)
         return 2
 
+    # Optional artifact: the SCuBA customer-assessment bundle (invariant k).
+    # Presence-gated so pre-wiring checkouts and partial local builds still
+    # reconcile; in CI the bundle is built before this gate runs.
+    scuba_path = d / "scuba-bundle.json"
+    scuba = load_json(scuba_path) if scuba_path.exists() else None
+
     dashboard_html = Path(args.dashboard).read_text() if Path(args.dashboard).exists() else None
     checkov_text = Path(args.checkov).read_text()
     poam_md_text = Path(args.poam_md).read_text()
@@ -638,6 +686,7 @@ def main():
         signal, ssp, poam, vdr, dashboard_html, checkov_text,
         _load_ckv_to_poam(), poam_md_text, _load_false_positives(poam_md_text),
         live_arns=live_arns, expected_commit=args.expect_commit, live_tags=live_tags,
+        scuba=scuba,
     )
 
     if violations:
@@ -646,11 +695,11 @@ def main():
             print(f"  ✗ {v}", file=sys.stderr)
         return 1
     if live_arns is not None and live_tags is not None:
-        checks = "a-j"
+        checks = "a-j" + (",k" if scuba is not None else "")
     elif live_arns is not None:
-        checks = "a-h,j (i deferred: no live tags)"
+        checks = "a-h,j" + (",k" if scuba is not None else "") + " (i deferred: no live tags)"
     else:
-        checks = "b-h,j (a,i deferred: no --live)"
+        checks = "b-h,j" + (",k" if scuba is not None else "") + " (a,i deferred: no --live)"
     print(f"reconciliation OK — invariants {checks} hold across signal/SSP/POA&M/VDR/dashboard")
     return 0
 

--- a/scripts/verify-published.sh
+++ b/scripts/verify-published.sh
@@ -48,6 +48,7 @@ echo "== Fetching published evidence from $BASE =="
 for f in ksi-signal.json ksi-signal.bundle \
          oscal-ssp.json oscal-ssp.json.intoto.jsonl \
          oscal-poam.json \
+         scuba-bundle.json scuba-bundle.bundle \
          vdr-report.json vdr-report.json.intoto.jsonl; do
   if curl -fsS --max-time 30 -o "$work/$f" "$BASE/$f"; then
     echo "  got  $f ($(wc -c < "$work/$f") bytes)"
@@ -64,6 +65,14 @@ if cosign verify-blob --bundle "$work/ksi-signal.bundle" \
   ok "ksi-signal.json signed by the pinned workflow on main"
 else
   bad "ksi-signal.json signature"
+fi
+
+if cosign verify-blob --bundle "$work/scuba-bundle.bundle" \
+     --certificate-identity "$IDENTITY" --certificate-oidc-issuer "$ISSUER" \
+     "$work/scuba-bundle.json" >/dev/null 2>&1; then
+  ok "scuba-bundle.json signed by the pinned workflow on main"
+else
+  bad "scuba-bundle.json signature"
 fi
 for art in oscal-ssp.json vdr-report.json; do
   if cosign verify-blob-attestation --new-bundle-format --type slsaprovenance1 \

--- a/scuba/README.md
+++ b/scuba/README.md
@@ -19,10 +19,19 @@ control" — evidence, not an authorization.
 
 ## Run
 ```bash
-python3 scuba/scuba.py --config your-config.json --output results.json
-# demo:
+# production: fetch the signed bundle from the provider and verify it before
+# ANY policy executes (requires cosign; refuses to run unverified code):
+python3 scuba/scuba.py --remote --config your-config.json --output results.json
+
+# local demo (repo-committed bespoke bundle, no fetch):
 python3 scuba/scuba.py --config scuba/sample-config.json --output /tmp/results.json
 ```
+
+The published bundle at `/.well-known/scuba-bundle.json` is generated on every
+deploy from the hub SSP (one policy per control), carries the canonical
+inventory's `ksi_signal_id`, and is Sigstore-signed by the pinned CI workflow
+identity. Reconcile invariant (k) fails the deploy if the bundle's binding or
+its control set drifts from the SSP it derives from.
 
 ## A policy
 Each policy is `policies/<name>.rego` (the OPA check) + `policies/<name>.md` (the
@@ -40,5 +49,6 @@ SCG-ENH-CMP / SCG-ENH-API) — the SCuBA pattern, named.
 2 representative policies (phishing-resistant MFA → IA-2(1); TLS → SC-8).
 Framework projection currently lights up 800-53 Rev5/Rev4 + FedRAMP Moderate;
 CMMC / GovRAMP / TX-RAMP / IRAP light up automatically as their control mappings
-land at each spoke checkpoint. Bundle **signing** (Sigstore) + publication at
-`/.well-known/` is the next wiring step.
+land at each spoke checkpoint. The complete bundle (one policy per SSP control)
+is generated, signed, and published at `/.well-known/scuba-bundle.json` on every
+deploy; `--remote` fetches and cosign-verifies it before evaluation.

--- a/scuba/scuba.py
+++ b/scuba/scuba.py
@@ -21,6 +21,8 @@ import argparse
 import json
 import subprocess
 import sys
+import tempfile
+import urllib.request
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -28,6 +30,55 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 REPO = HERE.parent
 NS = uuid.UUID("5c0ba000-0000-5000-8000-000000000001")
+
+# The published bundle is signed by the provider's pinned CI workflow identity
+# (same pin as scripts/verify-published.sh). The bundle contains EXECUTABLE
+# Rego this tool will run, so remote mode refuses to evaluate anything that
+# does not verify: no cosign, no verification, no execution.
+DEFAULT_BASE = "https://samaydlette.com/.well-known"
+IDENTITY = "https://github.com/sam-aydlette/samaydlette.com/.github/workflows/deploy-with-opa.yml@refs/heads/main"
+ISSUER = "https://token.actions.githubusercontent.com"
+
+
+def fetch_verified_bundle(base):
+    """Fetch scuba-bundle.json + its Sigstore bundle, verify the signature
+    against the pinned workflow identity, and materialize the inlined policies
+    into a temp dir. Returns the temp bundle dir. Exits non-zero on ANY
+    verification problem — this path executes provider-shipped policy code."""
+    work = Path(tempfile.mkdtemp(prefix="scuba-remote-"))
+    for name in ("scuba-bundle.json", "scuba-bundle.bundle"):
+        url = f"{base}/{name}"
+        try:
+            with urllib.request.urlopen(url, timeout=30) as r:
+                (work / name).write_bytes(r.read())
+        except Exception as e:
+            sys.exit(f"scuba: could not fetch {url}: {e}")
+    probe = subprocess.run(["cosign", "version"], capture_output=True)
+    if probe.returncode != 0:
+        sys.exit("scuba: cosign is required for --remote (the bundle contains "
+                 "executable policy; it must be signature-verified before use). "
+                 "Install cosign or run against a local --bundle you trust.")
+    v = subprocess.run(
+        ["cosign", "verify-blob",
+         "--bundle", str(work / "scuba-bundle.bundle"),
+         "--certificate-identity", IDENTITY,
+         "--certificate-oidc-issuer", ISSUER,
+         str(work / "scuba-bundle.json")],
+        capture_output=True, text=True,
+    )
+    if v.returncode != 0:
+        sys.exit("scuba: SIGNATURE VERIFICATION FAILED for the fetched bundle — "
+                 "refusing to evaluate it. cosign said: " + v.stderr.strip()[:200])
+    print("  verified: scuba-bundle.json signed by the pinned workflow on main")
+    manifest = json.loads((work / "scuba-bundle.json").read_text())
+    (work / "policies").mkdir(exist_ok=True)
+    for p in manifest.get("policies", []):
+        rego_rel = p.get("rego") or f"policies/{p['name']}.rego"
+        if p.get("rego_source"):
+            (work / rego_rel).parent.mkdir(parents=True, exist_ok=True)
+            (work / rego_rel).write_text(p["rego_source"])
+    (work / "bundle.json").write_text(json.dumps(manifest))
+    return work
 
 
 def opa_eval(rego_path, package, config_path):
@@ -101,7 +152,15 @@ def main():
     ap.add_argument("--config", required=True)
     ap.add_argument("--bundle", default=str(HERE))
     ap.add_argument("--output", default=None)
+    ap.add_argument("--remote", nargs="?", const=DEFAULT_BASE, default=None,
+                    metavar="BASE_URL",
+                    help="fetch the signed bundle from the provider's "
+                         "/.well-known/ and cosign-verify it before evaluating "
+                         f"(default base: {DEFAULT_BASE})")
     a = ap.parse_args()
+
+    if a.remote:
+        a.bundle = str(fetch_verified_bundle(a.remote.rstrip("/")))
 
     bundle = json.loads((Path(a.bundle) / "bundle.json").read_text())
     proj = load_framework_projection()
@@ -159,7 +218,7 @@ def main():
     print(f"\n  NO CUSTOMER ACTION REQUIRED ({sum(default_by_resp.values())}):")
     for resp, n in default_by_resp.most_common():
         print(f"     {n:4}  {label.get(resp, resp)}")
-    print(f"  (every control still has a policy + markdown in the bundle: policies/<control>.md)\n")
+    print("  (every control still has a policy + markdown in the bundle: policies/<control>.md)\n")
     print(f"  ── {len(observations)}/{len(observations)} controls covered; "
           f"{n_pass_actions}/{len(actions)} customer actions pass ──\n")
     n_pass = n_pass_actions + sum(default_by_resp.values())

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -249,3 +249,39 @@ def test_j_register_items_and_valid_refs_pass():
     s["signal"]["components"][0]["baseline_configuration"] = "throttled (POAM-007)"
     v = rc.check_j_poam_ref_validity(s["signal"], s["ssp"], s["poam"], s["vdr"])
     assert v == [], v
+
+
+def _scuba_for(ssp, sid=SIGNAL_ID):
+    ids = [r["control-id"] for r in ssp["system-security-plan"]
+           .get("control-implementation", {}).get("implemented-requirements", [])]
+    return {"ksi_signal_id": sid,
+            "policies": [{"control": c} for c in ids]}
+
+
+def test_k_absent_bundle_skips():
+    s = clean_set()
+    assert rc.check_k_scuba_binding(s["signal"], s["ssp"], None) == []
+
+
+def test_k_binding_mismatch_fails():
+    s = clean_set()
+    scuba = _scuba_for(s["ssp"], sid="not-the-signal")
+    v = rc.check_k_scuba_binding(s["signal"], s["ssp"], scuba)
+    assert any("(k)" in x and "signal_id" in x for x in v)
+
+
+def test_k_control_set_drift_fails():
+    s = clean_set()
+    s["ssp"]["system-security-plan"]["control-implementation"] = {
+        "implemented-requirements": [{"control-id": "ac-2"}, {"control-id": "sc-8"}]}
+    scuba = {"ksi_signal_id": SIGNAL_ID, "policies": [{"control": "ac-2"}]}
+    v = rc.check_k_scuba_binding(s["signal"], s["ssp"], scuba)
+    assert any("missing policies" in x for x in v)
+
+
+def test_k_clean_bundle_passes():
+    s = clean_set()
+    s["ssp"]["system-security-plan"]["control-implementation"] = {
+        "implemented-requirements": [{"control-id": "ac-2"}, {"control-id": "sc-8"}]}
+    scuba = _scuba_for(s["ssp"])
+    assert rc.check_k_scuba_binding(s["signal"], s["ssp"], scuba) == []


### PR DESCRIPTION
## Changed
Implements SCuBA wiring steps 2 and 3 from the agency-customer audit (tool stays in this repo — no separate repo needed until a real external consumer appears):

**Step 2 — signed publication.** The deploy pipeline now generates the complete SCuBA bundle (one Rego + markdown policy per SSP control — 333 today: 2 customer-action, 331 default) from the freshly built SSP, stamps the canonical inventory's signal_id binding into the manifest, emits it as ONE self-contained JSON with all policy sources inlined, signs it with cosign keyless, and publishes /.well-known/scuba-bundle.json (+ .bundle) with a post-deploy round-trip check. New reconcile invariant (k), presence-gated: the staged bundle must carry the inventory's signal_id and its policy set must exactly equal the SSP's control set, so the executable CRM cannot drift from the SSP it derives from.

**Step 3 — verify-before-execute.** scuba.py gains --remote: fetch the published bundle, cosign-verify against the pinned workflow identity, and refuse to evaluate on missing cosign or any verification failure — deliberately with NO insecure override, because the bundle contains executable Rego the customer will run. verify-published.sh adds the bundle to the externally verified artifact set, and the README documents the production path.

## Verified
- Generated the full bundle from a real locally-built SSP + the live signal: 333 policies, binding stamped, all sources inlined.
- Invariant (k) passes against the real pair and fails on mutated fixtures (binding mismatch, control-set drift); absent-bundle skip covered. Four new unit tests; full suite passes (151).
- Simulated the post-verification materialization path and ran the CLI against the full inline bundle: 333/333 controls covered, OSCAL Assessment Results emitted, exit 0. Local demo mode unchanged.
- ruff + mypy (the pinned CI versions) pass over the tree including scuba/.

## Residual / needs human
- The --remote path's cosign verification can only be exercised end-to-end after this PR's own merge deploy publishes the first signed bundle; run `python3 scuba/scuba.py --remote --config scuba/sample-config.json` afterward as the closing check.
- verify-published.sh now requires the bundle, so the reciprocity smoke test on the merge deploy validates publication automatically (publish precedes the smoke test in the same run).

## Couldn't verify
Live fetch + signature verification pre-merge, as above.

CodeGuard (software-security) ran against this diff: no findings — the security-relevant design choice is refusing to execute unverified provider-shipped policy code, with identity pinned to the CI workflow.

SCN-Type: routine-recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)