### PR TITLE
fix(scuba): SRM-AUTH-01 policy currency — assess the deployed auth, not the retired acceptance

### DIFF
--- a/scuba/bundle.json
+++ b/scuba/bundle.json
@@ -1,6 +1,6 @@
 {
-  "name": "Silk Reeling Mirror — Customer Responsibility SCuBA",
-  "version": "1.0.0",
+  "name": "Silk Reeling Mirror \u2014 Customer Responsibility SCuBA",
+  "version": "1.1.0",
   "description": "Secure-configuration baseline for the customer responsibilities of consuming this cloud service offering. Customer-run: fetch this signed bundle, assess your own configuration LOCALLY (nothing leaves your environment), and get a per-policy pass/fail plus the frameworks each result satisfies. Each policy maps to an 800-53 Rev5 control (the hub) and projects to every framework via the published control mappings.",
   "hub_catalog": "NIST 800-53 Rev5",
   "policies": [

--- a/scuba/policies/phishing_resistant_mfa.md
+++ b/scuba/policies/phishing_resistant_mfa.md
@@ -4,24 +4,26 @@
 **Severity:** high · **Customer responsibility**
 
 ## What it checks
-Whether access to the application is protected by **phishing-resistant MFA**
-(WebAuthn/FIDO2 or PIV), or — for a sole operator-as-customer — whether the
-single-factor residual risk has been explicitly accepted.
+Which **authenticator posture** the customer's application accounts operate.
+Since 2026-06-22 the CSO enforces mandatory TOTP MFA at the identity provider
+for every account (the POAM-021 closure), so single-factor access is not
+possible — the old sole-customer risk-acceptance branch no longer exists.
 
 ```
-auth.phishing_resistant == true   # WebAuthn/FIDO2 or PIV
-  OR
-auth.risk_accepted == true        # sole-customer risk acceptance (POAM-021)
+auth.mfa_type == "webauthn" | "fido2" | "piv"   # phishing-resistant — target posture
+auth.mfa_type == "totp"                         # CSO-enforced baseline — passes, flagged phishable
+anything else                                   # FAIL — inconsistent with this CSO
 ```
 
 ## Why
-Single-factor / OTP authentication is phishable. M-22-09 and modern FedRAMP/CMMC
-posture require phishing-resistant MFA for IA-2(1). A customer consuming this CSO
-must either federate to an IdP that enforces phishing-resistant MFA (or use native
-WebAuthn with FIPS-AAGUID attestation), or — if they are the sole user — accept the
-residual risk explicitly. Onboarding additional users re-opens this.
+TOTP satisfies IA-2(1)'s MFA requirement (and CMMC 3.5.3), but OTP codes are
+phishable; M-22-09 and modern FedRAMP/CJIS posture prefer phishing-resistant
+authenticators. The provider tracks the phishing-resistant direction under
+POAM-025; the customer's share is enrolling WebAuthn/FIDO2 (or PIV-federated)
+authenticators for their users when available.
 
-## How to remediate a fail
-Set `auth.phishing_resistant = true` after enabling WebAuthn/FIDO2 or IdP
-federation, **or** record an explicit `auth.risk_accepted = true` with an
-authorized acceptance.
+## How to remediate
+A **fail** means your configuration claims no MFA, which this CSO does not
+permit — fix the config (or confirm you are assessing the right deployment).
+A **pass on TOTP** is compliant today; to reach the target posture, enroll
+WebAuthn/FIDO2 authenticators and set `auth.mfa_type = "webauthn"`.

--- a/scuba/policies/phishing_resistant_mfa.rego
+++ b/scuba/policies/phishing_resistant_mfa.rego
@@ -1,29 +1,38 @@
 # SCuBA policy: phishing-resistant MFA for application access.
 # Maps to NIST 800-53 Rev5 IA-2(1). Evaluated locally by the customer against
 # their own configuration; nothing leaves their environment.
+#
+# Since 2026-06-22 the CSO enforces mandatory TOTP MFA at the identity provider
+# for every account (POAM-021 closed), so single-factor access is not possible
+# and the old sole-customer risk-acceptance branch is gone. The customer's
+# remaining responsibility is authenticator POSTURE: TOTP meets IA-2(1) but is
+# phishable; WebAuthn/FIDO2/PIV is the phishing-resistant target (M-22-09;
+# tracked directionally with POAM-025).
 package scuba.phishing_resistant_mfa
 
 import future.keywords.if
+import future.keywords.in
 
 default pass := false
 
-# Pass if the customer enforces phishing-resistant MFA (WebAuthn/FIDO2 or PIV)...
-pass if input.auth.phishing_resistant == true
+phishing_resistant if input.auth.mfa_type in {"webauthn", "fido2", "piv"}
 
-# ...or has explicitly accepted the single-factor residual risk (valid only for a
-# sole operator-as-customer; onboarding real users re-opens this — see POAM-021).
-pass if input.auth.risk_accepted == true
+# Phishing-resistant authenticators: the target posture.
+pass if phishing_resistant
 
-detail := "Phishing-resistant MFA (WebAuthn/PIV) enforced." if input.auth.phishing_resistant == true
+# TOTP: the CSO-enforced baseline. Meets IA-2(1) (MFA for privileged/all
+# accounts); flagged as phishable so the upgrade path stays visible.
+pass if input.auth.mfa_type == "totp"
 
-detail := "Single-factor auth; residual risk accepted by the sole customer (POAM-021)." if {
-	input.auth.phishing_resistant != true
-	input.auth.risk_accepted == true
+detail := "Phishing-resistant MFA (WebAuthn/FIDO2/PIV) enforced — target posture." if phishing_resistant
+
+detail := "TOTP MFA enforced (the CSO baseline) — meets IA-2(1); TOTP is phishable, WebAuthn/FIDO2 is the recommended upgrade (M-22-09)." if {
+	input.auth.mfa_type == "totp"
 }
 
-detail := "Single-factor auth and risk NOT accepted — IA-2(1) not satisfied." if {
-	input.auth.phishing_resistant != true
-	input.auth.risk_accepted != true
+detail := "No MFA claimed — inconsistent with this CSO (the identity provider enforces TOTP for every account since 2026-06-22); correct your configuration or verify you are assessing the right deployment." if {
+	not phishing_resistant
+	not input.auth.mfa_type == "totp"
 }
 
 result := {"pass": pass, "detail": detail}

--- a/scuba/sample-config.json
+++ b/scuba/sample-config.json
@@ -1,9 +1,8 @@
 {
-  "_comment": "Example customer configuration for assessment. In real use this is the customer's own config, read locally by the CLI; it never leaves their environment.",
+  "_comment": "Example customer configuration for assessment. In real use this is the customer's own config, read locally by the CLI; it never leaves their environment. auth.mfa_type reflects the authenticator posture of the customer's accounts (the CSO enforces TOTP minimum at the IdP).",
   "auth": {
-    "method": "basic",
-    "phishing_resistant": false,
-    "risk_accepted": true
+    "method": "cognito-hosted-ui",
+    "mfa_type": "totp"
   },
   "tls": {
     "min_version": "1.2"


### PR DESCRIPTION
## Changed
Found by running the live remote check: the bespoke SRM-AUTH-01 policy passed with 'single-factor auth; residual risk accepted (POAM-021)' — blessing a risk-acceptance that was retired on 2026-06-22 when mandatory TOTP replaced Basic Auth. The refreshed policy assesses the customer's authenticator posture against deployed reality:

- WebAuthn/FIDO2/PIV → pass, target posture (phishing-resistant, M-22-09).
- TOTP → pass, the CSO-enforced IA-2(1) baseline, explicitly flagged phishable with the upgrade note (aligned with POAM-025's direction).
- Anything else (including a missing field) → fail loudly as inconsistent with this CSO, since single-factor access is no longer possible.

The rule set is total (missing-key configs fail with a clear message rather than evaluating undefined — the failure mode found during branch testing). Sample config now models a current customer; bespoke bundle version 1.1.0; policy markdown rewritten.

## Verified
- All five input branches exercised via opa eval: totp and webauthn pass with the correct details; none / missing key / empty input fail with the inconsistency message.
- README demo passes on the refreshed sample config; full python suite passes.
- The published full bundle picks up the refreshed bespoke source on this PR's merge deploy; the next `scuba.py --remote` run then reports the honest TOTP-baseline detail.

## Residual / needs human
None.

## Couldn't verify
The republished bundle content pre-merge (requires the deploy).

CodeGuard (software-security) ran against this diff: no findings.

SCN-Type: routine-recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)