### PR TITLE
runtime: unreadable != failing, and gate deploys on deploy/runtime divergence

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -914,6 +914,26 @@ jobs:
           import_silk 'aws_cognito_user_pool_domain.silk_reeling[0]' 'samaydlette-com-silk-reeling'
         echo "Silk Reeling import step complete"
 
+    # -------------------------------------------------------------------------
+    # STOP THE LINE — refuse to deploy over a system already in drift.
+    #
+    # The runtime Lambda compares its daily live evaluation against the published
+    # deploy-time verdict and records the result in the signed runtime signal.
+    # This reads that verdict and blocks BEFORE anything is mutated: after
+    # `terraform apply` it would be too late to stop, and the reconciliation gate
+    # (which runs post-apply, pre-publish) answers a different question.
+    #
+    # It blocks ONLY on status=diverged with a fresh signal. An unreadable,
+    # missing, stale, or degraded signal warns and proceeds — a gate that can
+    # only be cleared by deploying must not be wedgeable by the absence of its
+    # own input. See the script header for the full rationale.
+    #
+    # Break glass when the deploy IS the fix:
+    #   --allow-divergence "reason"
+    # -------------------------------------------------------------------------
+    - name: Runtime divergence pre-flight (stop the line)
+      run: python3 scripts/check-runtime-divergence.py
+
     - name: Generate fresh Terraform plan
       working-directory: infrastructure
       run: terraform plan -lock-timeout=300s -out=tfplan

--- a/infrastructure/lambda/divergence.js
+++ b/infrastructure/lambda/divergence.js
@@ -1,0 +1,81 @@
+// =============================================================================
+// DEPLOY <-> RUNTIME DIVERGENCE
+// =============================================================================
+// The deploy gate evaluates a Terraform plan; this Lambda evaluates the live
+// account a day later. Both run the same compiled policy, so a disagreement is
+// meaningful: either the account drifted after apply, or the two enforcement
+// points were fed different facts about the same resource. Until this check
+// existed the disagreement was published on both sides and read by neither.
+//
+// The load-bearing distinction is between a resource that regressed and an
+// evaluator that could not look. A `category: "input"` violation
+// (resource_read_error, config_error, input_error) means this Lambda failed to
+// reach a verdict — an observer fault. Counting those as regressions would
+// report drift every time a permission is missing, which is exactly the
+// failure this pipeline has already published for four weeks. They are
+// reported separately as `unassessed`, and the overall status degrades rather
+// than diverging.
+//
+// Callers acting on this block (alerting, gating, any future rollback) must
+// key on `status === "diverged"` and on `regressions`, never on the raw
+// validation results, or they inherit that conflation.
+// =============================================================================
+
+function computeDivergence(deploySignal, validations) {
+    const deployStatus = new Map((deploySignal.ksis ?? []).map((k) => [k.id, k.status]));
+    const regressed = new Map();
+    const unassessed = new Map();
+    let unattributed = 0;
+
+    for (const v of validations) {
+        if (v.result !== 'fail') continue;
+        for (const viol of v.violations ?? []) {
+            const ksiIds = viol.ksi_ids ?? [];
+            if (ksiIds.length === 0) {
+                unattributed += 1;
+                continue;
+            }
+            const target = viol.category === 'input' ? unassessed : regressed;
+            for (const id of ksiIds) {
+                if (!target.has(id)) target.set(id, new Set());
+                target.get(id).add(viol.id);
+            }
+        }
+    }
+
+    const entries = (m, runtimeStatus, filter) =>
+        [...m.entries()]
+            .filter(([id]) => (filter ? filter(deployStatus.get(id)) : true))
+            .map(([id, ids]) => ({
+                ksi_id: id,
+                deploy_status: deployStatus.get(id) ?? 'unknown',
+                runtime_status: runtimeStatus,
+                violation_ids: [...ids].sort(),
+            }))
+            .sort((a, b) => a.ksi_id.localeCompare(b.ksi_id));
+
+    // Only a KSI the deploy gate published as PASSING can regress. Where both
+    // enforcement points already agree a KSI is failing there is no divergence
+    // to report — the finding is simply open.
+    const regressions = entries(regressed, 'fail', (s) => s === 'pass');
+    const unassessedList = entries(unassessed, 'unassessed', null);
+
+    let status = 'converged';
+    if (regressions.length > 0) status = 'diverged';
+    else if (unassessedList.length > 0 || unattributed > 0) status = 'degraded';
+
+    return {
+        status,
+        compared_against: {
+            signal_id: deploySignal.signal_id ?? null,
+            emitted_at: deploySignal.emitted_at ?? null,
+            commit: deploySignal.provenance?.source?.commit ?? null,
+        },
+        ksis_compared: deployStatus.size,
+        regressions,
+        unassessed: unassessedList,
+        unattributed_failures: unattributed,
+    };
+}
+
+module.exports = { computeDivergence };

--- a/infrastructure/lambda/index.js
+++ b/infrastructure/lambda/index.js
@@ -47,6 +47,7 @@ const {
     DescribeSecretCommand,
 } = require('@aws-sdk/client-secrets-manager');
 const { canonicalize } = require('./canonical');
+const { computeDivergence } = require('./divergence');
 
 const SIGNAL_VERSION = '1.0.0';
 const SCHEMA_URL = 'https://samaydlette.com/.well-known/ksi-signal.schema.json';
@@ -101,7 +102,18 @@ async function getPolicy() {
 
 const REQUIRED_TAGS = ['Environment', 'CostCenter', 'DataClassification', 'Owner'];
 
+// A failed describe call is NOT evidence that a setting is off. Every attribute
+// this transformer cannot read is recorded in `read_errors`, and policy.gate
+// turns those into a `resource_read_error` finding instead of letting the
+// attribute rules report a security violation on a value never observed.
+// Without this, an IAM gap on one bucket is published — signed — as
+// "encryption disabled / public access not blocked" against a bucket that is
+// correctly configured. The resource is still non-compliant either way, so the
+// gate does not fail open; only the stated reason changes, from a fabricated
+// control failure to an honest "could not assess".
 async function buildS3ResourceInput(s3, bucketName, tfName) {
+    const readErrors = [];
+
     let encryptionEnabled = false;
     try {
         const enc = await s3.send(new GetBucketEncryptionCommand({ Bucket: bucketName }));
@@ -109,7 +121,15 @@ async function buildS3ResourceInput(s3, bucketName, tfName) {
             ?.ApplyServerSideEncryptionByDefault?.SSEAlgorithm;
         encryptionEnabled = algorithm === 'AES256' || algorithm === 'aws:kms';
     } catch (err) {
-        console.warn(`GetBucketEncryption failed for ${bucketName}: ${err.name}`);
+        // ServerSideEncryptionConfigurationNotFoundError is a real answer:
+        // the bucket has no default encryption. Anything else means we did
+        // not get an answer at all.
+        if (err.name === 'ServerSideEncryptionConfigurationNotFoundError') {
+            encryptionEnabled = false;
+        } else {
+            readErrors.push('encryption');
+            console.warn(`GetBucketEncryption failed for ${bucketName}: ${err.name}`);
+        }
     }
 
     let versioningEnabled = false;
@@ -117,6 +137,7 @@ async function buildS3ResourceInput(s3, bucketName, tfName) {
         const ver = await s3.send(new GetBucketVersioningCommand({ Bucket: bucketName }));
         versioningEnabled = ver?.Status === 'Enabled';
     } catch (err) {
+        readErrors.push('versioning');
         console.warn(`GetBucketVersioning failed for ${bucketName}: ${err.name}`);
     }
 
@@ -129,7 +150,14 @@ async function buildS3ResourceInput(s3, bucketName, tfName) {
             cfg.IgnorePublicAcls && cfg.RestrictPublicBuckets
         );
     } catch (err) {
-        console.warn(`GetPublicAccessBlock failed for ${bucketName}: ${err.name}`);
+        // NoSuchPublicAccessBlockConfiguration is a real answer: no block
+        // configuration exists, which is genuinely non-compliant.
+        if (err.name === 'NoSuchPublicAccessBlockConfiguration') {
+            publicAccessBlocked = false;
+        } else {
+            readErrors.push('public_access_block');
+            console.warn(`GetPublicAccessBlock failed for ${bucketName}: ${err.name}`);
+        }
     }
 
     const tags = {};
@@ -140,11 +168,12 @@ async function buildS3ResourceInput(s3, bucketName, tfName) {
         // NoSuchTagSet is a normal AWS response when no tags are set; treat
         // as empty tag map. Rego will flag missing required tags.
         if (err.name !== 'NoSuchTagSet') {
+            readErrors.push('tags');
             console.warn(`GetBucketTagging failed for ${bucketName}: ${err.name}`);
         }
     }
 
-    return {
+    const resource = {
         type: 'aws_s3_bucket',
         name: tfName || bucketName,
         tags,
@@ -152,6 +181,10 @@ async function buildS3ResourceInput(s3, bucketName, tfName) {
         versioning_enabled: versioningEnabled,
         public_access_blocked: publicAccessBlocked,
     };
+    // Only present when something actually failed, so the plan-shaped
+    // contract and existing fixtures are unchanged.
+    if (readErrors.length > 0) resource.read_errors = readErrors;
+    return resource;
 }
 
 async function buildCloudFrontResourceInput(cf, distributionId, tfName) {
@@ -347,6 +380,9 @@ async function buildRuntimeSignal(deploySignal, s3, cf, sm, policy, policyVersio
         provenance,
         components,
         validations,
+        // Inside the signed payload, so the divergence verdict is as
+        // tamper-evident as the validations it is derived from.
+        divergence: computeDivergence(deploySignal, validations),
     };
 }
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -454,9 +454,17 @@ resource "aws_iam_role_policy" "lambda_opa" {
       {
         # The emitter re-validates every object_store component in the
         # canonical inventory, so it needs the same bucket-attribute reads on
-        # the access-log bucket. Bucket-level configuration metadata only —
+        # the audit buckets. Bucket-level configuration metadata only —
         # deliberately no s3:GetObject here, so the Lambda can never read the
-        # access logs themselves.
+        # access logs or the trail events themselves.
+        #
+        # EVERY object_store component in the inventory must appear here. A
+        # bucket that is inventoried but unreadable is not silently skipped:
+        # the transformer records the failed reads and the gate raises
+        # resource_read_error, so the omission surfaces as an unassessed
+        # resource rather than as fabricated security findings. The CloudTrail
+        # bucket was inventoried without this grant and produced exactly that
+        # failure mode.
         Effect = "Allow"
         Action = [
           "s3:GetBucketVersioning",
@@ -465,7 +473,8 @@ resource "aws_iam_role_policy" "lambda_opa" {
           "s3:GetBucketTagging"
         ]
         Resource = [
-          aws_s3_bucket.logs.arn
+          aws_s3_bucket.logs.arn,
+          aws_s3_bucket.cloudtrail.arn
         ]
       },
       {

--- a/infrastructure/policy/gate.rego
+++ b/infrastructure/policy/gate.rego
@@ -163,6 +163,68 @@ violations contains violation if {
 	)
 }
 
+# =============================================================================
+# RUNTIME READ FAILURES — "UNOBSERVED" IS NOT "OFF"
+# =============================================================================
+# The deploy path derives every security attribute from the plan, so an absent
+# attribute genuinely means "not configured" and must fail closed (see the S3
+# join LIMITATION above). The runtime path derives the same attributes from
+# AWS API calls, where a failed call means "not observed" — a different fact,
+# with a different remedy, pointing at the evaluator rather than the resource.
+#
+# Collapsing the two makes an IAM gap indistinguishable from a misconfigured
+# bucket. A role missing s3:GetBucketVersioning on some bucket then publishes
+# "versioning must be enabled" against a bucket that has versioning enabled —
+# a fabricated finding, signed, with a control id attached to a check that
+# never ran.
+#
+# A transformer that could not read an attribute lists it in `read_errors`.
+# Those attributes raise resource_read_error below INSTEAD of the attribute
+# rule's security finding. The resource still has a violation, so the gate
+# stays shut and nothing fails open; what changes is that the report says
+# "could not assess" rather than naming a control that was never evaluated.
+#
+# Plan input never carries read_errors, so deploy-time behaviour is unchanged:
+# an absent attribute with no declared read failure still fails closed.
+# =============================================================================
+
+# METADATA
+# title: Live resource facts were readable
+# description: >-
+#   A resource whose live configuration could not be read must be reported as
+#   unassessed, never as assessed-and-failing on attributes never observed.
+# custom:
+#   id: resource_read_error
+#   category: input
+#   severity: HIGH
+#   nist_controls: [cm-6, ca-7]
+#   ksi_ids: [KSI-MLA-EVC]
+violations contains violation if {
+	some r in resources
+	some attr in read_errors_of(r)
+	violation := make_violation(
+		rego.metadata.rule().custom,
+		r.name,
+		address_of(r),
+		sprintf(
+			concat(" ", [
+				"Live %s configuration for %s could not be read;",
+				"this resource is UNASSESSED for that attribute, not",
+				"assessed-and-failing. Check the evaluator's permissions.",
+			]),
+			[attr, address_of(r)],
+		),
+	)
+}
+
+read_errors_of(r) := e if {
+	e := r.read_errors
+	is_array(e)
+} else := []
+
+# True when `attr` was actually observed for this resource.
+attribute_read_ok(r, attr) if not attr in read_errors_of(r)
+
 # The parameter paths the guard above requires.
 required_config_paths := {
 	["gate", "required_tags"],
@@ -200,64 +262,6 @@ tags_of(obj, key) := t if {
 } else := {}
 
 address_of(r) := object.get(r, "address", object.get(r, "name", "unknown"))
-
-# =============================================================================
-# RUNTIME READ FAILURES — "UNOBSERVED" IS NOT "OFF"
-# =============================================================================
-# The deploy path derives every security attribute from the plan, so an absent
-# attribute genuinely means "not configured" and must fail closed (see the S3
-# join LIMITATION above). The runtime path derives the same attributes from
-# AWS API calls, where a failed call means "not observed" — a different fact,
-# with a different remedy, pointing at the evaluator rather than the resource.
-#
-# Collapsing the two makes an IAM gap indistinguishable from a misconfigured
-# bucket. A role missing s3:GetBucketVersioning on some bucket then publishes
-# "versioning must be enabled" against a bucket that has versioning enabled —
-# a fabricated finding, signed, with a control id attached to a check that
-# never ran.
-#
-# A transformer that could not read an attribute lists it in `read_errors`.
-# Those attributes raise resource_read_error below INSTEAD of the attribute
-# rule's security finding. The resource still has a violation, so the gate
-# stays shut and nothing fails open; what changes is that the report says
-# "could not assess" rather than naming a control that was never evaluated.
-#
-# Plan input never carries read_errors, so deploy-time behaviour is unchanged:
-# an absent attribute with no declared read failure still fails closed.
-# =============================================================================
-
-read_errors_of(r) := e if {
-	e := r.read_errors
-	is_array(e)
-} else := []
-
-# True when `attr` was actually observed for this resource.
-attribute_read_ok(r, attr) if not attr in read_errors_of(r)
-
-# METADATA
-# title: Live resource facts were readable
-# description: >-
-#   A resource whose live configuration could not be read must be reported as
-#   unassessed, never as assessed-and-failing on attributes never observed.
-# custom:
-#   id: resource_read_error
-#   category: input
-#   severity: HIGH
-#   nist_controls: [cm-6, ca-7]
-#   ksi_ids: [KSI-MLA-EVC]
-violations contains violation if {
-	some r in resources
-	some attr in read_errors_of(r)
-	violation := make_violation(
-		rego.metadata.rule().custom,
-		r.name,
-		address_of(r),
-		sprintf(
-			"Live %s configuration for %s could not be read; this resource is UNASSESSED for that attribute, not assessed-and-failing. Check the evaluator's permissions.",
-			[attr, address_of(r)],
-		),
-	)
-}
 
 resource_base(rc) := {
 	"address": rc.address,

--- a/infrastructure/policy/gate.rego
+++ b/infrastructure/policy/gate.rego
@@ -201,6 +201,64 @@ tags_of(obj, key) := t if {
 
 address_of(r) := object.get(r, "address", object.get(r, "name", "unknown"))
 
+# =============================================================================
+# RUNTIME READ FAILURES — "UNOBSERVED" IS NOT "OFF"
+# =============================================================================
+# The deploy path derives every security attribute from the plan, so an absent
+# attribute genuinely means "not configured" and must fail closed (see the S3
+# join LIMITATION above). The runtime path derives the same attributes from
+# AWS API calls, where a failed call means "not observed" — a different fact,
+# with a different remedy, pointing at the evaluator rather than the resource.
+#
+# Collapsing the two makes an IAM gap indistinguishable from a misconfigured
+# bucket. A role missing s3:GetBucketVersioning on some bucket then publishes
+# "versioning must be enabled" against a bucket that has versioning enabled —
+# a fabricated finding, signed, with a control id attached to a check that
+# never ran.
+#
+# A transformer that could not read an attribute lists it in `read_errors`.
+# Those attributes raise resource_read_error below INSTEAD of the attribute
+# rule's security finding. The resource still has a violation, so the gate
+# stays shut and nothing fails open; what changes is that the report says
+# "could not assess" rather than naming a control that was never evaluated.
+#
+# Plan input never carries read_errors, so deploy-time behaviour is unchanged:
+# an absent attribute with no declared read failure still fails closed.
+# =============================================================================
+
+read_errors_of(r) := e if {
+	e := r.read_errors
+	is_array(e)
+} else := []
+
+# True when `attr` was actually observed for this resource.
+attribute_read_ok(r, attr) if not attr in read_errors_of(r)
+
+# METADATA
+# title: Live resource facts were readable
+# description: >-
+#   A resource whose live configuration could not be read must be reported as
+#   unassessed, never as assessed-and-failing on attributes never observed.
+# custom:
+#   id: resource_read_error
+#   category: input
+#   severity: HIGH
+#   nist_controls: [cm-6, ca-7]
+#   ksi_ids: [KSI-MLA-EVC]
+violations contains violation if {
+	some r in resources
+	some attr in read_errors_of(r)
+	violation := make_violation(
+		rego.metadata.rule().custom,
+		r.name,
+		address_of(r),
+		sprintf(
+			"Live %s configuration for %s could not be read; this resource is UNASSESSED for that attribute, not assessed-and-failing. Check the evaluator's permissions.",
+			[attr, address_of(r)],
+		),
+	)
+}
+
 resource_base(rc) := {
 	"address": rc.address,
 	"type": rc.type,

--- a/infrastructure/policy/gate_test.rego
+++ b/infrastructure/policy/gate_test.rego
@@ -40,18 +40,18 @@ test_html_shape_now_rejected if {
 # still fails closed while the published reason stays honest.
 # =============================================================================
 
+_res(overrides) := {"resource": object.union(
+	{"type": "aws_s3_bucket", "name": "b"},
+	overrides,
+)}
+
 test_read_error_raises_one_finding_per_attribute if {
-	count(read_errors(gate.violations)) == 2 with input as {"resource": {
-		"type": "aws_s3_bucket", "name": "cloudtrail",
-		"read_errors": ["encryption", "tags"],
-	}}
+	count(read_errors(gate.violations)) == 2 with input as _res({"read_errors": ["encryption", "tags"]})
 }
 
 # MUST-FIRE the other way: a clean resource raises nothing.
 test_no_read_errors_when_all_attributes_observed if {
-	count(read_errors(gate.violations)) == 0 with input as {"resource": {
-		"type": "aws_s3_bucket", "name": "website",
-	}}
+	count(read_errors(gate.violations)) == 0 with input as _res({})
 }
 
 # The plan path never carries read_errors, so deploy-time behaviour is
@@ -67,9 +67,7 @@ test_plan_input_raises_no_read_errors if {
 # A malformed read_errors value must not silently disable the check by making
 # the rule body undefined.
 test_malformed_read_errors_ignored if {
-	count(read_errors(gate.violations)) == 0 with input as {"resource": {
-		"type": "aws_s3_bucket", "name": "b", "read_errors": "encryption",
-	}}
+	count(read_errors(gate.violations)) == 0 with input as _res({"read_errors": "encryption"})
 }
 
 # A gate whose parameters failed to load must fail closed, not enforce

--- a/infrastructure/policy/gate_test.rego
+++ b/infrastructure/policy/gate_test.rego
@@ -10,6 +10,8 @@ config_errors(v) := [x | some x in v; x.id == "config_error"]
 
 input_errors(v) := [x | some x in v; x.id == "input_error"]
 
+read_errors(v) := [x | some x in v; x.id == "resource_read_error"]
+
 # Unrecognized input must produce an explicit input_error.
 test_unrecognized_input_flagged if {
 	count(input_errors(gate.violations)) == 1 with input as {}
@@ -30,6 +32,44 @@ test_scan_shape_recognized if {
 # The retired raw-HTML shape is no longer a recognized input.
 test_html_shape_now_rejected if {
 	count(input_errors(gate.violations)) == 1 with input as {"html_content": "<p>x</p>", "file_name": "x.html"}
+}
+
+# =============================================================================
+# Read-failure contract: an attribute the evaluator could not observe must be
+# reported as unassessed, one finding per unreadable attribute, so the gate
+# still fails closed while the published reason stays honest.
+# =============================================================================
+
+test_read_error_raises_one_finding_per_attribute if {
+	count(read_errors(gate.violations)) == 2 with input as {"resource": {
+		"type": "aws_s3_bucket", "name": "cloudtrail",
+		"read_errors": ["encryption", "tags"],
+	}}
+}
+
+# MUST-FIRE the other way: a clean resource raises nothing.
+test_no_read_errors_when_all_attributes_observed if {
+	count(read_errors(gate.violations)) == 0 with input as {"resource": {
+		"type": "aws_s3_bucket", "name": "website",
+	}}
+}
+
+# The plan path never carries read_errors, so deploy-time behaviour is
+# unchanged and absent attributes keep failing closed as before.
+test_plan_input_raises_no_read_errors if {
+	count(read_errors(gate.violations)) == 0 with input as {"resource_changes": [{
+		"address": "aws_s3_bucket.b", "mode": "managed",
+		"type": "aws_s3_bucket", "name": "b",
+		"change": {"actions": ["create"], "after": {"bucket": "b", "tags": {}, "tags_all": {}}},
+	}]}
+}
+
+# A malformed read_errors value must not silently disable the check by making
+# the rule body undefined.
+test_malformed_read_errors_ignored if {
+	count(read_errors(gate.violations)) == 0 with input as {"resource": {
+		"type": "aws_s3_bucket", "name": "b", "read_errors": "encryption",
+	}}
 }
 
 # A gate whose parameters failed to load must fail closed, not enforce

--- a/infrastructure/policy/s3.rego
+++ b/infrastructure/policy/s3.rego
@@ -30,6 +30,7 @@ import data.policy.gate
 violations contains violation if {
 	some r in gate.resources
 	r.type == "aws_s3_bucket"
+	gate.attribute_read_ok(r, "versioning")
 	not r.versioning_enabled
 	violation := gate.make_violation(
 		rego.metadata.rule().custom,
@@ -51,6 +52,7 @@ violations contains violation if {
 violations contains violation if {
 	some r in gate.resources
 	r.type == "aws_s3_bucket"
+	gate.attribute_read_ok(r, "encryption")
 	not r.encryption_enabled
 	violation := gate.make_violation(
 		rego.metadata.rule().custom,
@@ -75,6 +77,7 @@ violations contains violation if {
 violations contains violation if {
 	some r in gate.resources
 	r.type == "aws_s3_bucket"
+	gate.attribute_read_ok(r, "public_access_block")
 	not r.public_access_blocked
 	violation := gate.make_violation(
 		rego.metadata.rule().custom,

--- a/infrastructure/policy/s3_test.rego
+++ b/infrastructure/policy/s3_test.rego
@@ -48,6 +48,32 @@ test_absent_fields_fail_closed if {
 	ids(s3.violations) == expected with input as {"resource": {"type": "aws_s3_bucket", "name": "b", "tags": {}}}
 }
 
+# =============================================================================
+# UNREADABLE != OFF. A runtime transformer that could not read an attribute
+# declares it in read_errors; the attribute rule must then stay silent so the
+# report does not name a control that was never evaluated. policy.gate raises
+# resource_read_error for the same resource (see gate_test), so the resource is
+# still non-compliant and the gate still fails closed.
+# =============================================================================
+
+test_unreadable_attributes_do_not_raise_security_findings if {
+	count(s3.violations) == 0 with input as _bucket({
+		"versioning_enabled": false,
+		"encryption_enabled": false,
+		"public_access_blocked": false,
+		"read_errors": ["versioning", "encryption", "public_access_block"],
+	})
+}
+
+# A read failure on one attribute must not mask a genuine failure on another.
+test_partial_read_error_still_reports_observed_failure if {
+	ids(s3.violations) == {"versioning_disabled"} with input as _bucket({
+		"versioning_enabled": false,
+		"encryption_enabled": false,
+		"read_errors": ["encryption"],
+	})
+}
+
 # Non-bucket types produce no S3 violations.
 test_other_types_ignored if {
 	count(s3.violations) == 0 with input as {"resource": {"type": "aws_lambda_function", "name": "f", "tags": {}}}

--- a/infrastructure/policy/tagging.rego
+++ b/infrastructure/policy/tagging.rego
@@ -83,6 +83,7 @@ missing_classification(r) := {key |
 violations contains violation if {
 	some r in gate.resources
 	is_managed(r)
+	gate.attribute_read_ok(r, "tags")
 	governance_tag_types[r.type]
 	count(missing_required_tags(r)) > 0
 	violation := gate.make_violation(
@@ -109,6 +110,7 @@ violations contains violation if {
 violations contains violation if {
 	some r in gate.resources
 	is_managed(r)
+	gate.attribute_read_ok(r, "tags")
 	taggable_types[r.type]
 	count(missing_classification(r)) > 0
 	violation := gate.make_violation(

--- a/infrastructure/schemas/ksi-signal.schema.json
+++ b/infrastructure/schemas/ksi-signal.schema.json
@@ -219,6 +219,10 @@
           "type": "string"
         }
       }
+    },
+    "divergence": {
+      "description": "Result of comparing this runtime evaluation against the deploy gate's published verdict for the same system. Emitted by the runtime emitter only; absent from deploy-time signals. `regressions` lists KSIs the deploy gate published as passing that this evaluation found failing \u2014 a genuine disagreement about the resource. `unassessed` lists KSIs this evaluation could not reach a verdict on (category:input violations such as resource_read_error), which is an observer fault and must never be treated as drift.",
+      "$ref": "#/$defs/divergence"
     }
   },
   "$defs": {
@@ -556,6 +560,118 @@
               }
             }
           }
+        }
+      }
+    },
+    "divergence_entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ksi_id",
+        "deploy_status",
+        "runtime_status",
+        "violation_ids"
+      ],
+      "properties": {
+        "ksi_id": {
+          "type": "string",
+          "description": "The KSI whose two verdicts disagree."
+        },
+        "deploy_status": {
+          "type": "string",
+          "description": "Status the deploy gate published for this KSI."
+        },
+        "runtime_status": {
+          "type": "string",
+          "enum": [
+            "fail",
+            "unassessed"
+          ],
+          "description": "'fail' means evaluated and failing; 'unassessed' means the evaluator could not reach a verdict."
+        },
+        "violation_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Distinct policy rule ids behind this entry."
+        }
+      }
+    },
+    "divergence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "compared_against",
+        "ksis_compared",
+        "regressions",
+        "unassessed",
+        "unattributed_failures"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "converged",
+            "diverged",
+            "degraded"
+          ],
+          "description": "'converged': runtime agrees with deploy. 'diverged': at least one KSI the deploy gate passed is failing at runtime. 'degraded': no regression, but the evaluator could not assess something."
+        },
+        "compared_against": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "signal_id",
+            "emitted_at",
+            "commit"
+          ],
+          "description": "Identity of the deploy-time signal this evaluation was compared against.",
+          "properties": {
+            "signal_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "emitted_at": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "commit": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "ksis_compared": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "How many KSIs the deploy signal carried."
+        },
+        "regressions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/divergence_entry"
+          },
+          "description": "KSIs passing at deploy time and failing at runtime. This is the actionable set."
+        },
+        "unassessed": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/divergence_entry"
+          },
+          "description": "KSIs the evaluator could not assess. Observer faults, not drift."
+        },
+        "unattributed_failures": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Failing violations carrying no ksi_ids, so attributable to no KSI."
         }
       }
     }

--- a/scripts/check-runtime-divergence.py
+++ b/scripts/check-runtime-divergence.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# =============================================================================
+# RUNTIME DIVERGENCE PRE-FLIGHT GATE  ("stop the line")
+# =============================================================================
+# The deploy gate evaluates a Terraform plan; the runtime Lambda re-evaluates
+# the live account daily. Both run the same compiled policy, so a disagreement
+# is a real signal — and until this gate existed it was published on both sides
+# and read by neither.
+#
+# This is the ANDON CORD, not an autopilot. It refuses to start a new deploy
+# while the currently-deployed system is diverged, so a human decides what to
+# do. It never reverts anything: the worst case is a blocked deploy, never a
+# mutated production system.
+#
+# POSITION IN THE PIPELINE: this runs BEFORE `terraform apply`. The
+# reconciliation gate (scripts/reconcile.py) runs after apply and before
+# publish, and checks a different thing — that the generated artifacts agree
+# with each other and with live reality. Stopping the line has to happen before
+# anything is mutated, so it cannot live in reconcile.
+#
+# WHAT BLOCKS AND WHAT DOES NOT
+#
+#   status=diverged  -> BLOCK. A KSI the deploy gate published as PASSING is
+#                       failing against the live account. Someone should look
+#                       before layering another change on top.
+#   status=degraded  -> WARN.  The runtime evaluator could not reach a verdict
+#                       (a category:input violation such as resource_read_error
+#                       — a missing IAM grant, an unreadable resource). That is
+#                       a fault in the OBSERVER, not evidence of drift, and
+#                       blocking deploys on it is how this pipeline would have
+#                       wedged itself for the four weeks it published exactly
+#                       that condition. It is loud, and it never blocks.
+#   status=converged -> PASS.
+#
+# DELIBERATE FAIL-OPEN ON AVAILABILITY, FAIL-CLOSED ON VERDICT
+#
+# A signal that is missing, unfetchable, or carries no `divergence` block does
+# NOT block the deploy; it warns. Two reasons, both load-bearing:
+#
+#   1. Rollout. The published runtime signal carries no `divergence` block
+#      until the Lambda that emits it has itself been deployed. A gate that
+#      blocked on its absence would refuse the very deploy that installs it.
+#   2. Deadlock. This gate can only be cleared by a deploy. If a transient
+#      network failure could wedge it shut, the gate would create a worse
+#      failure mode than the one it prevents — and the escape hatch would be
+#      needed routinely rather than exceptionally.
+#
+# The VERDICT still fails closed: a signal that is present, fresh, and diverged
+# blocks, and no amount of retrying changes that. Only --allow-divergence does,
+# and it is recorded in the log.
+#
+# REPLAY RESISTANCE: `emitted_at` lives inside the signed payload, so a replayed
+# older signal fails the staleness check rather than passing as fresh. This
+# script does not verify the KMS signature itself (that needs `cryptography`,
+# which the deploy job does not install; the recipe lives in
+# tests/test_runtime_signature.py). Scope is honest: transport is HTTPS from our
+# own distribution, and freshness is checked against signed content.
+#
+# Usage:
+#   check-runtime-divergence.py                       # default published URL
+#   check-runtime-divergence.py --max-age-hours 48
+#   check-runtime-divergence.py --allow-divergence "fixing forward: POAM-0xx"
+# =============================================================================
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+DEFAULT_URL = "https://samaydlette.com/.well-known/ksi-signal-runtime.json"
+
+BLOCK = 1
+PASS = 0
+
+# Every value below is interpolated from a document fetched over the network,
+# then printed into GitHub Actions logs. Actions parses `::` command syntax out
+# of a job's stdout, so an unsanitized field carrying CR/LF plus `::` could
+# forge workflow commands or annotations from inside a log line. The signal
+# comes from our own bucket over TLS, so this is defense in depth rather than a
+# live exposure — but a gate that decides whether a deploy proceeds should not
+# be the thing that trusts remote text verbatim.
+_SANITIZE = str.maketrans({"\r": " ", "\n": " ", "\x00": ""})
+_MAX_FIELD = 200
+
+
+def clean(value):
+    """Render an untrusted field safe to print into a CI log line."""
+    if value is None:
+        return "none"
+    text = str(value).translate(_SANITIZE).replace("::", ":")
+    return text[:_MAX_FIELD] + ("…" if len(text) > _MAX_FIELD else "")
+
+
+def warn(msg):
+    """Emit a GitHub Actions warning annotation that is also readable locally."""
+    print(f"::warning::divergence-gate: {msg}", file=sys.stderr)
+
+
+def fetch(url, timeout):
+    # urllib honours file:// and ftp:// as readily as https://. This URL is
+    # operator-supplied rather than user-supplied, but an unrestricted scheme
+    # turns a --url typo (or anyone who can edit the workflow) into a local
+    # file read whose contents decide whether a deploy proceeds. Allow-list the
+    # one scheme this gate has any business fetching.
+    if not url.lower().startswith("https://"):
+        raise ValueError(f"refusing to fetch a non-HTTPS runtime signal URL: {url!r}")
+    req = urllib.request.Request(url, headers={"Cache-Control": "no-cache"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:  # noqa: S310 (scheme checked above)
+        return json.loads(r.read().decode("utf-8"))
+
+
+def age_hours(emitted_at, now=None):
+    """Hours since `emitted_at`, or None if it is absent/unparseable."""
+    if not emitted_at:
+        return None
+    try:
+        ts = datetime.fromisoformat(str(emitted_at).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ((now or datetime.now(timezone.utc)) - ts).total_seconds() / 3600.0
+
+
+def rules_of(entry):
+    ids = entry.get("violation_ids")
+    return "/".join(clean(i) for i in ids) if isinstance(ids, list) and ids else "?"
+
+
+def describe(entries):
+    return ", ".join(
+        f"{clean(e.get('ksi_id'))} [{rules_of(e)}]" for e in entries
+    )
+
+
+def evaluate(signal, max_age_hours, now=None):
+    """Return (exit_code, lines_to_print). Pure, so the tests can drive it."""
+    out = []
+    div = signal.get("divergence")
+    if not isinstance(div, dict):
+        warn(
+            "published runtime signal carries no `divergence` block; the emitter "
+            "that produces it has not been deployed yet. Not blocking."
+        )
+        return PASS, out
+
+    status = div.get("status")
+    against = div.get("compared_against") or {}
+    age = age_hours(signal.get("emitted_at"), now)
+
+    out.append(
+        f"runtime signal emitted_at={clean(signal.get('emitted_at'))} "
+        f"({'age unknown' if age is None else f'{age:.1f}h old'}); "
+        f"status={clean(status)}; compared against deploy signal "
+        f"{clean(against.get('signal_id'))} @ commit {clean(against.get('commit'))}"
+    )
+
+    stale = age is None or age > max_age_hours
+    if stale:
+        warn(
+            f"runtime signal is stale or undateable "
+            f"({'no parseable emitted_at' if age is None else f'{age:.1f}h > {max_age_hours}h'}). "
+            "The daily evaluation may not be running, so this gate is not "
+            "currently protecting anything. Not blocking."
+        )
+
+    if status == "diverged":
+        regressions = div.get("regressions") or []
+        # A stale signal cannot be used to block: it describes a system state
+        # that may be hours or days out of date, and the operator has no way to
+        # clear it except by deploying.
+        if stale:
+            warn(
+                f"divergence reported ({describe(regressions)}) but the signal is "
+                "stale; not blocking on an out-of-date verdict. Check the dashboard."
+            )
+            return PASS, out
+        out.append("")
+        out.append("DEPLOY BLOCKED — the live system disagrees with its published compliance state.")
+        out.append("")
+        out.append(f"  {len(regressions)} KSI(s) published as PASSING at deploy time are FAILING at runtime:")
+        for e in regressions:
+            out.append(
+                f"    - {clean(e.get('ksi_id'))}: deploy={clean(e.get('deploy_status'))} "
+                f"runtime={clean(e.get('runtime_status'))} "
+                f"rules={rules_of(e)}"
+            )
+        out.append("")
+        out.append("  This is drift in the deployed system, not an evaluator fault.")
+        out.append("  Investigate before layering another change on top.")
+        out.append("")
+        out.append("  To deploy anyway (e.g. this deploy IS the fix):")
+        out.append('    check-runtime-divergence.py --allow-divergence "<reason>"')
+        return BLOCK, out
+
+    if status == "degraded":
+        unassessed = div.get("unassessed") or []
+        unattributed = div.get("unattributed_failures") or 0
+        warn(
+            "runtime evaluation is DEGRADED — the evaluator could not reach a "
+            f"verdict on {len(unassessed)} KSI(s)"
+            + (f" plus {unattributed} unattributed failure(s)" if unattributed else "")
+            + f". {describe(unassessed)}. "
+            "This is an observer fault (check the evaluator's permissions), not "
+            "drift, so it does not block. It does mean the gate is only partly "
+            "protecting this deploy."
+        )
+        return PASS, out
+
+    if status != "converged":
+        warn(f"unrecognized divergence status '{clean(status)}'; treating as non-blocking.")
+        return PASS, out
+
+    out.append("Runtime evaluation agrees with the published deploy-time verdict.")
+    return PASS, out
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--url", default=DEFAULT_URL,
+                    help="published runtime signal to read (default: %(default)s)")
+    ap.add_argument("--signal", default=None,
+                    help="read a local signal file instead of fetching (tests)")
+    ap.add_argument("--max-age-hours", type=float, default=48.0,
+                    help="older than this and the verdict is too stale to block on")
+    ap.add_argument("--timeout", type=float, default=15.0, help="fetch timeout in seconds")
+    ap.add_argument("--allow-divergence", metavar="REASON", default=None,
+                    help="break-glass: proceed despite divergence, recording REASON")
+    a = ap.parse_args()
+
+    if a.signal:
+        signal = json.loads(open(a.signal).read())
+    else:
+        try:
+            signal = fetch(a.url, a.timeout)
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as e:
+            warn(
+                f"could not read the published runtime signal ({type(e).__name__}). "
+                "Availability failures do not block deploys — see the header of "
+                "this script. Not blocking."
+            )
+            return PASS
+
+    code, lines = evaluate(signal, a.max_age_hours)
+    for line in lines:
+        print(line, file=sys.stderr if code == BLOCK else sys.stdout)
+
+    if code == BLOCK and a.allow_divergence:
+        print("", file=sys.stderr)
+        warn(
+            f"BREAK-GLASS: proceeding despite divergence. Reason: {clean(a.allow_divergence)}"
+        )
+        return PASS
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_divergence.py
+++ b/tests/test_divergence.py
@@ -1,0 +1,163 @@
+"""Deploy-vs-runtime divergence detection (infrastructure/lambda/divergence.js).
+
+The runtime Lambda re-evaluates the live account a day after the deploy gate
+evaluated the plan. Both run the same compiled policy, so a disagreement means
+something — but only if "the resource regressed" is kept distinct from "the
+evaluator could not look".
+
+That distinction is the whole point of these tests. The pipeline published four
+KSIs as failing at runtime and passing at deploy for four weeks, and the cause
+was an IAM gap on one bucket, not drift. Any consumer that acts on this signal
+(alerting, gating, rollback) keys on `status == "diverged"`, so a read failure
+being classified as a regression is a correctness defect with real blast radius,
+not a cosmetic one.
+
+The module under test is deliberately free of AWS-SDK imports (same reason
+canonical.js is), so it runs under plain node with no node_modules present.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+MODULE = REPO / "infrastructure" / "lambda" / "divergence.js"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node not available"
+)
+
+
+DEPLOY_SIGNAL = {
+    "signal_id": "sig-deploy-1",
+    "emitted_at": "2026-08-05T10:03:34Z",
+    "provenance": {"source": {"commit": "abc1234"}},
+    "ksis": [
+        {"id": "KSI-SVC-SIN", "status": "pass"},
+        {"id": "KSI-CNA-ULN", "status": "pass"},
+        {"id": "KSI-PIY-GIV", "status": "pass"},
+        {"id": "KSI-RPL-ABO", "status": "pass"},
+        {"id": "KSI-MLA-EVC", "status": "pass"},
+        {"id": "KSI-ALREADY-RED", "status": "fail"},
+    ],
+}
+
+
+def divergence(validations, deploy_signal=None):
+    """Call computeDivergence in node and return the parsed result."""
+    payload = json.dumps({
+        "deploy": deploy_signal if deploy_signal is not None else DEPLOY_SIGNAL,
+        "validations": validations,
+    })
+    script = (
+        f"const {{computeDivergence}} = require({json.dumps(str(MODULE))});"
+        "let raw='';process.stdin.on('data',d=>raw+=d).on('end',()=>{"
+        "const {deploy,validations}=JSON.parse(raw);"
+        "process.stdout.write(JSON.stringify(computeDivergence(deploy,validations)));});"
+    )
+    out = subprocess.run(
+        ["node", "-e", script], input=payload, capture_output=True, text=True, check=True
+    )
+    return json.loads(out.stdout)
+
+
+def fail(*violations):
+    return [{"result": "fail", "violations": list(violations)}]
+
+
+def viol(rule_id, category, ksi_ids):
+    return {"id": rule_id, "category": category, "ksi_ids": ksi_ids}
+
+
+def test_all_passing_converges():
+    d = divergence([{"result": "pass", "violations": []}])
+    assert d["status"] == "converged"
+    assert d["regressions"] == []
+    assert d["unassessed"] == []
+
+
+def test_genuine_drift_is_a_regression():
+    """A resource-category failure on a KSI the deploy gate passed is drift."""
+    d = divergence(fail(viol("versioning_disabled", "infrastructure", ["KSI-RPL-ABO"])))
+    assert d["status"] == "diverged"
+    assert [r["ksi_id"] for r in d["regressions"]] == ["KSI-RPL-ABO"]
+    assert d["regressions"][0]["deploy_status"] == "pass"
+    assert d["regressions"][0]["runtime_status"] == "fail"
+
+
+def test_read_failure_is_not_drift():
+    """THE regression test for the four-week false positive.
+
+    A category:input violation means the evaluator never reached a verdict. It
+    must degrade the signal, never report the resource as regressed — otherwise
+    a missing IAM grant reads as infrastructure drift and anything acting on
+    `diverged` fires on an observer fault.
+    """
+    d = divergence(fail(viol("resource_read_error", "input", ["KSI-MLA-EVC"])))
+    assert d["status"] == "degraded"
+    assert d["regressions"] == []
+    assert [r["ksi_id"] for r in d["unassessed"]] == ["KSI-MLA-EVC"]
+    assert d["unassessed"][0]["runtime_status"] == "unassessed"
+
+
+def test_read_failure_never_masks_real_drift():
+    """A read error on one attribute must not suppress a real regression."""
+    d = divergence(fail(
+        viol("versioning_disabled", "infrastructure", ["KSI-RPL-ABO"]),
+        viol("resource_read_error", "input", ["KSI-MLA-EVC"]),
+    ))
+    assert d["status"] == "diverged"
+    assert [r["ksi_id"] for r in d["regressions"]] == ["KSI-RPL-ABO"]
+    assert [r["ksi_id"] for r in d["unassessed"]] == ["KSI-MLA-EVC"]
+
+
+def test_no_divergence_when_both_sides_already_agree():
+    """A KSI already failing at deploy time is an open finding, not a divergence."""
+    d = divergence(fail(viol("some_rule", "infrastructure", ["KSI-ALREADY-RED"])))
+    assert d["status"] == "converged"
+    assert d["regressions"] == []
+
+
+def test_violation_without_ksi_ids_is_counted_not_dropped():
+    """An unattributable failure must degrade the signal rather than vanish."""
+    d = divergence(fail({"id": "input_error", "category": "input"}))
+    assert d["unattributed_failures"] == 1
+    assert d["status"] == "degraded"
+
+
+def test_multiple_rules_on_one_ksi_are_deduped_and_sorted():
+    d = divergence(fail(
+        viol("missing_required_tags", "infrastructure", ["KSI-PIY-GIV"]),
+        viol("missing_classification_tag", "infrastructure", ["KSI-PIY-GIV"]),
+    ))
+    assert [r["ksi_id"] for r in d["regressions"]] == ["KSI-PIY-GIV"]
+    assert d["regressions"][0]["violation_ids"] == [
+        "missing_classification_tag",
+        "missing_required_tags",
+    ]
+
+
+def test_records_what_it_compared_against():
+    """The verdict is only meaningful with the deploy signal it was compared to."""
+    d = divergence([{"result": "pass", "violations": []}])
+    assert d["compared_against"] == {
+        "signal_id": "sig-deploy-1",
+        "emitted_at": "2026-08-05T10:03:34Z",
+        "commit": "abc1234",
+    }
+    assert d["ksis_compared"] == 6
+
+
+def test_deploy_signal_without_ksis_reports_nothing_comparable():
+    """A deploy signal carrying no KSIs must not silently read as converged-and-clean."""
+    d = divergence(
+        fail(viol("versioning_disabled", "infrastructure", ["KSI-RPL-ABO"])),
+        deploy_signal={"signal_id": "s", "emitted_at": "t", "provenance": {}},
+    )
+    assert d["ksis_compared"] == 0
+    # Nothing to compare against, so no regression can be asserted.
+    assert d["regressions"] == []
+    assert d["compared_against"]["commit"] is None

--- a/tests/test_runtime_divergence_gate.py
+++ b/tests/test_runtime_divergence_gate.py
@@ -1,0 +1,180 @@
+"""The 'stop the line' pre-flight gate (scripts/check-runtime-divergence.py).
+
+This gate can only be cleared by a deploy, so both of its failure directions are
+expensive: blocking when it should not wedges the pipeline shut, and passing when
+it should not lets a change land on top of a system already in drift.
+
+The cases that matter most here are the ones that must NOT block — the rollout
+case (no divergence block yet), the observer-fault case (degraded), and the stale
+case. Each of them, if it blocked, would have deadlocked this repository at some
+point in its recorded history.
+"""
+
+import importlib.util
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "divgate", REPO / "scripts" / "check-runtime-divergence.py"
+)
+divgate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(divgate)
+
+NOW = datetime(2026, 8, 6, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def signal(status=None, *, age_hours=1.0, regressions=(), unassessed=(), unattributed=0,
+           omit_divergence=False):
+    emitted = (NOW - timedelta(hours=age_hours)).isoformat().replace("+00:00", "Z")
+    s = {"emitted_at": emitted, "emitter": "runtime"}
+    if not omit_divergence:
+        s["divergence"] = {
+            "status": status,
+            "compared_against": {"signal_id": "sig-1", "emitted_at": emitted, "commit": "abc1234"},
+            "ksis_compared": 46,
+            "regressions": list(regressions),
+            "unassessed": list(unassessed),
+            "unattributed_failures": unattributed,
+        }
+    return s
+
+
+def entry(ksi, rules, deploy="pass", runtime="fail"):
+    return {"ksi_id": ksi, "deploy_status": deploy, "runtime_status": runtime,
+            "violation_ids": list(rules)}
+
+
+def run(sig, max_age=48.0):
+    return divgate.evaluate(sig, max_age, now=NOW)[0]
+
+
+# --- the blocking case ------------------------------------------------------
+
+def test_fresh_divergence_blocks():
+    code = run(signal("diverged", regressions=[entry("KSI-RPL-ABO", ["versioning_disabled"])]))
+    assert code == divgate.BLOCK
+
+
+def test_block_message_names_the_ksi_and_the_rule():
+    _, lines = divgate.evaluate(
+        signal("diverged", regressions=[entry("KSI-RPL-ABO", ["versioning_disabled"])]),
+        48.0, now=NOW,
+    )
+    body = "\n".join(lines)
+    assert "DEPLOY BLOCKED" in body
+    assert "KSI-RPL-ABO" in body
+    assert "versioning_disabled" in body
+    assert "--allow-divergence" in body  # the escape hatch must be discoverable
+
+
+# --- the cases that must NOT block -----------------------------------------
+
+def test_converged_passes():
+    assert run(signal("converged")) == divgate.PASS
+
+
+def test_degraded_never_blocks():
+    """An observer fault (unreadable resource, missing grant) is not drift.
+
+    This is the condition the pipeline published for four weeks. Blocking on it
+    would have made the fix undeployable by the gate meant to protect the fix.
+    """
+    code = run(signal("degraded",
+                      unassessed=[entry("KSI-MLA-EVC", ["resource_read_error"],
+                                        runtime="unassessed")]))
+    assert code == divgate.PASS
+
+
+def test_missing_divergence_block_does_not_block():
+    """Rollout case: the emitter that produces the block is not deployed yet."""
+    assert run(signal(omit_divergence=True)) == divgate.PASS
+
+
+def test_stale_divergence_does_not_block():
+    """A verdict describing a days-old system state must not gate a new deploy."""
+    code = run(signal("diverged", age_hours=72.0,
+                      regressions=[entry("KSI-RPL-ABO", ["versioning_disabled"])]))
+    assert code == divgate.PASS
+
+
+def test_undateable_signal_does_not_block():
+    s = signal("diverged", regressions=[entry("KSI-RPL-ABO", ["versioning_disabled"])])
+    s["emitted_at"] = "not-a-timestamp"
+    assert run(s) == divgate.PASS
+
+
+def test_unrecognized_status_does_not_block():
+    assert run(signal("something-new")) == divgate.PASS
+
+
+# --- staleness boundary -----------------------------------------------------
+
+def test_just_inside_max_age_still_blocks():
+    code = run(signal("diverged", age_hours=47.0,
+                      regressions=[entry("KSI-RPL-ABO", ["versioning_disabled"])]))
+    assert code == divgate.BLOCK
+
+
+def test_just_outside_max_age_does_not_block():
+    code = run(signal("diverged", age_hours=49.0,
+                      regressions=[entry("KSI-RPL-ABO", ["versioning_disabled"])]))
+    assert code == divgate.PASS
+
+
+# --- untrusted-input handling (CodeGuard: log injection, SSRF scheme) -------
+
+def test_workflow_command_injection_is_neutralised():
+    """Signal fields are printed into GitHub Actions logs, which parse `::`.
+
+    A field carrying CR/LF plus `::` could otherwise forge annotations or
+    workflow commands from inside a log line the gate emits.
+    """
+    hostile = "KSI-X\n::error::forged\r::set-output name=x::y"
+    _, lines = divgate.evaluate(
+        signal("diverged", regressions=[entry(hostile, ["versioning_disabled"])]),
+        48.0, now=NOW,
+    )
+    body = "\n".join(lines)
+    assert "::error::" not in body
+    assert "::set-output" not in body
+    assert "\n::" not in body
+    assert "KSI-X" in body  # still legible, just defanged
+
+
+def test_untrusted_fields_are_length_bounded():
+    _, lines = divgate.evaluate(
+        signal("diverged", regressions=[entry("K" * 5000, ["r"])]), 48.0, now=NOW
+    )
+    assert max(len(x) for x in lines) < 600
+
+
+def test_clean_handles_non_string_and_missing_values():
+    assert divgate.clean(None) == "none"
+    assert divgate.clean(17) == "17"
+    assert divgate.clean({"a": 1})  # must not raise
+
+
+def test_violation_ids_of_wrong_type_do_not_crash():
+    _, lines = divgate.evaluate(
+        signal("diverged", regressions=[{"ksi_id": "K", "violation_ids": "notalist"}]),
+        48.0, now=NOW,
+    )
+    assert "DEPLOY BLOCKED" in "\n".join(lines)
+
+
+def test_non_https_url_is_refused():
+    """urllib honours file://; a gate deciding deploys must not read local files."""
+    import pytest
+    for bad in ("file:///etc/passwd", "http://example.com/s.json", "ftp://h/s.json"):
+        with pytest.raises(ValueError, match="non-HTTPS"):
+            divgate.fetch(bad, 1.0)
+
+
+# --- age helper -------------------------------------------------------------
+
+def test_age_hours_handles_naive_and_z_suffixed_timestamps():
+    assert divgate.age_hours("2026-08-06T10:00:00Z", NOW) == 2.0
+    assert divgate.age_hours("2026-08-06T10:00:00", NOW) == 2.0
+    assert divgate.age_hours(None, NOW) is None
+    assert divgate.age_hours("garbage", NOW) is None


### PR DESCRIPTION
## Changed

**The defect.** The runtime emitter treated a failed AWS describe call as evidence that the setting was off. An IAM gap on one inventoried bucket therefore published, in a signed artifact served continuously for four weeks, five HIGH/MEDIUM control failures against a resource that was correctly configured. Under this repo's own rule a dismissed finding must be dispositioned false-positive or risk-accepted; this one was silently carried, because a false positive has no remediation loop attached to it.

**1. Unreadable is no longer the same as off.** The transformer records attributes it could not read in `read_errors`; `policy.gate` raises a new `resource_read_error` finding (category `input`, alongside the existing `input_error`/`config_error`) instead of letting the attribute rules report a violation on a value never observed. Genuine AWS answers — `NoSuchTagSet`, `NoSuchPublicAccessBlockConfiguration`, `ServerSideEncryptionConfigurationNotFoundError` — still mean non-compliant.

The resource stays non-compliant either way, so the gate does not fail open; only the stated reason changes. Plan input never carries `read_errors`, so deploy-time behaviour is unchanged and an absent attribute still fails closed.

**2. Least privilege, corrected at the root.** The emitter re-validates every `object_store` component in the canonical inventory, but the role held bucket-attribute reads on only two of three. The audit bucket is added — metadata actions only, still deliberately no `s3:GetObject`, so the emitter cannot read trail events. A comment records that every inventoried `object_store` must appear here.

**3. The two enforcement points now reconcile.** The emitter compares its live evaluation against the published deploy-time verdict and records it in the signed signal; a pre-flight step reads that verdict and refuses to start a deploy over a system already in drift. It runs **before `terraform apply`** — the reconciliation gate runs after apply and answers a different question, and after apply there is nothing left to stop.

Change 1 is what makes change 3 safe: a `category: input` violation is an observer fault, so it degrades the signal and never reports drift. Blocking on that condition would have wedged this pipeline shut for precisely the four weeks it was publishing it.

| verdict | gate |
|---|---|
| `diverged` + fresh | **blocks** |
| `degraded` (observer fault) | warns |
| `converged` | passes |
| missing / stale / unfetchable | warns |

The gate **fails closed on the verdict and open on availability**, deliberately: the published signal carries no `divergence` block until the emitter producing it has shipped, and a gate clearable only by deploying must not be wedgeable by the absence of its own input. Break-glass is `--allow-divergence "<reason>"`, which records the reason rather than passing silently.

Adds the optional `divergence` property to the published signal schema (`additionalProperties: false`, so this is required for conformance) and 34 tests.

## Verified

Live AWS API, on the bucket the signal reported as failing — three of five violations disproved outright:

- versioning: **Enabled** (reported "versioning must be enabled")
- tags: **all ten present** — `AgencyScope`, `Archetype`, `CostCenter`, `DataClassification`, `DataSensitivity`, `Environment`, `InternetReachable`, `MissionCriticality`, `Owner`, `OwnerRole` (reported as missing across two separate findings)

Encryption and public-access-block could not be read with the assessment identity, which lacks those two actions — correct least privilege, recorded below as unverified.

Policy behaviour, evaluated through the compiled policy:

| input | before | after (grant not yet applied) | after (grant applied) |
|---|---|---|---|
| the live bucket | `compliant=false`, 5 fabricated control failures | `compliant=false`, 4 honest "UNASSESSED" | `compliant=true`, 0 |

Divergence behaviour on the same underlying cause: `diverged` before, `degraded` after — the discriminator the pre-flight gate keys on.

Gate behaviour: blocking path names the KSI, the rule, and the escape hatch; break-glass exits 0 with a recorded reason; run against the live published signal it takes the rollout path and exits 0.

Full suite on a clean checkout of `main` with this branch applied: **191 passed, 3 skipped, 0 failed**; OPA `test` 56/56 plus `fmt --fail`, `check --strict`, `--coverage --threshold 90`; `check-wasm-safe`; `check-policy-annotations` 12/12 against the KSI catalog; Wasm rebuild and **CLI-vs-Wasm parity across the full fixture corpus**; `terraform fmt -check`; `ruff` and `mypy` clean at the CI-pinned versions.

## CodeGuard

Run against this diff. Rules applied: hardcoded-credentials, crypto-algorithms, iac-security, devops-ci-cd, logging, input-validation-injection, api-web-services.

Two findings in the new code, both fixed in this branch:

- **Log injection / forged workflow commands.** The gate interpolates fields from a network-fetched document into CI logs, which parse `::` command syntax. CR/LF and `::` are now stripped and field lengths bounded. Defense in depth rather than live exposure — the signal comes from our own bucket over TLS — but a gate deciding whether a deploy proceeds should not trust remote text verbatim. Test: `test_workflow_command_injection_is_neutralised`.
- **Unrestricted URL scheme (SSRF-adjacent).** `urllib` honours `file://` and `ftp://`; the fetch is now restricted to `https://`, so a `--url` typo or workflow edit cannot make a local file decide a deploy. Test: `test_non_https_url_is_refused`.

Clean on the always-apply rules: no credentials, keys, account IDs, or ARNs introduced; no crypto touched (the signal remains KMS ECDSA P-256 / SHA-256, and the divergence verdict sits **inside** the signed payload). The IAM change carries no wildcard action or resource and narrows rather than broadens. `divergence.js` uses `Map`/`Set` rather than object literals, so the KSI ids it keys on cannot reach `__proto__`.

## Residual / needs human

- **The IAM grant needs a `terraform apply`.** Until then the emitter will report `resource_read_error` for that bucket — honest, and no longer a fabricated control failure. `terraform plan` could not be run here (provider packages not cached locally), so the plan output is not attached; please review it on apply.
- **Fail-open on availability is a deliberate risk acceptance,** reasoned in the script header. It means an attacker able to block the fetch can disable this gate. Accepted because the alternative deadlocks the pipeline, and because this is a safety interlock, not a security boundary.
- **Signature verification is out of scope for the gate.** It needs `cryptography`, which the deploy job does not install. Freshness is checked against `emitted_at`, which is inside the signed payload, so a replayed older signal fails the staleness check. Worth revisiting if the gate ever gains more authority.
- **Detection latency is bounded by deploy cadence.** The daily evaluation detects within 24h, but acting on it waits for the next deploy or a dashboard read. Recommend writing the dashboard-review step into the SDR as stated procedure rather than leaving it as habit.
- **Not addressed here, both pre-existing on `main`'s sibling branch and unrelated:** `tests/test_inject_figures.py` fails on a stale `README.md` figure (`hub_total` 331 vs 333), and `ruff` reports F401 on `tests/test_essay_renumber.py:13` (unused `sys`) from `9e1bf7b` — that one will fail the CI lint step.

## Couldn't verify

- Encryption and public-access-block configuration on the audit bucket, from outside the pipeline — the assessment identity lacks `s3:GetEncryptionConfiguration` and `s3:GetBucketPublicAccessBlock` on it. Terraform declares both sub-resources. Either extend the read-only assessment role or record the assessability gap explicitly.
- End-to-end behaviour of the emitter in Lambda. `computeDivergence` is unit-tested directly and the policy path is covered by CLI-vs-Wasm parity, but the assembled signal has not been produced by a real invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
