### PR TITLE
ci: stop the content sync from overwriting the RA-5(6) vuln trend ledger

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -977,7 +977,19 @@ jobs:
         
         cd ..
         
-        # Upload website files, skip infrastructure code
+        # Upload website files, skip infrastructure code.
+        #
+        # .well-known/vdr-trend.json is EXCLUDED because it is an accumulating
+        # ledger, not site content. Its history lives in the published object:
+        # the RA-5(6) trend step below fetches it, appends today's point, and
+        # re-publishes. A committed copy exists in website/ as a seed, and
+        # syncing that copy over the live object destroyed the accumulated
+        # history on every single deploy — the ledger was permanently stuck at
+        # [seed, today], two points, because the fetch downstream was reading a
+        # ledger this sync had just overwritten a few steps earlier. The
+        # published object is the source of truth for this file; the sync must
+        # not touch it. (Same reasoning as silk-reeling-auth.json below, which
+        # is published after the sync so --delete cannot remove it.)
         aws s3 sync website/ s3://$BUCKET_NAME/ \
           --exclude "*.tf" \
           --exclude "*.tfvars*" \
@@ -990,6 +1002,7 @@ jobs:
           --exclude "Makefile" \
           --exclude ".gitignore" \
           --exclude ".github/*" \
+          --exclude ".well-known/vdr-trend.json" \
           --delete
 
         echo "✅ Website content synced successfully"

--- a/tests/test_vdr_trend_ledger.py
+++ b/tests/test_vdr_trend_ledger.py
@@ -1,0 +1,113 @@
+"""The RA-5(6) vuln trend ledger accumulates, and the deploy must not clobber it.
+
+`website/.well-known/vdr-trend.json` is the one artifact that is BOTH committed
+(as a seed) and published (as an accumulating ledger). The deploy's
+`aws s3 sync website/ --delete` therefore uploaded the one-point seed over the
+live ledger on every run, a few hundred lines before the trend step fetched
+"the published ledger" and appended to it. The ledger was permanently pinned at
+two points -- the seed and today -- for three months.
+
+Two guards here:
+
+  1. The builder genuinely accumulates (so a regression in the upsert is caught
+     directly rather than inferred from the published file months later).
+  2. The workflow excludes the ledger from the content sync, and the sync still
+     precedes the trend build, which is what makes the exclusion necessary.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO = Path(__file__).resolve().parent.parent
+BUILDER = REPO / "scripts" / "build-vdr-trend.py"
+WORKFLOW = REPO / ".github" / "workflows" / "deploy-with-opa.yml"
+LEDGER_KEY = ".well-known/vdr-trend.json"
+
+
+# --- the builder accumulates ------------------------------------------------
+
+def write_report(path, date, **summary):
+    path.write_text(json.dumps({
+        "system_id": "urn:test:sys",
+        "emitted_at": f"{date}T10:00:00+00:00",
+        "summary": {"unique_cves": 0, "unique_cves_open": 0, "blocking": 0,
+                    "kev": 0, "by_pain": {}, "total_findings": 0,
+                    "risk_accepted": 0, **summary},
+    }))
+
+
+def run_builder(report, trend):
+    subprocess.run([sys.executable, str(BUILDER), "--report", str(report),
+                    "--trend", str(trend)], check=True, capture_output=True)
+    return json.loads(trend.read_text())
+
+
+def test_successive_runs_append_rather_than_replace(tmp_path):
+    trend = tmp_path / "trend.json"
+    for day in ("2026-05-08", "2026-05-09", "2026-05-10"):
+        report = tmp_path / "r.json"
+        write_report(report, day)
+        out = run_builder(report, trend)
+    assert [p["date"] for p in out["points"]] == ["2026-05-08", "2026-05-09", "2026-05-10"]
+
+
+def test_same_day_upserts_instead_of_duplicating(tmp_path):
+    trend, report = tmp_path / "trend.json", tmp_path / "r.json"
+    write_report(report, "2026-05-08", risk_accepted=15)
+    run_builder(report, trend)
+    write_report(report, "2026-05-08", risk_accepted=13)
+    out = run_builder(report, trend)
+    assert [p["date"] for p in out["points"]] == ["2026-05-08"]
+    assert out["points"][0]["risk_accepted"] == 13
+
+
+def test_starting_from_a_seed_preserves_the_seed(tmp_path):
+    """The exact live shape: a one-point seed plus today must give two points.
+
+    This is what the published ledger looked like every day for three months.
+    It is correct behaviour for ONE run -- the bug was that every run started
+    from the seed again.
+    """
+    trend, report = tmp_path / "trend.json", tmp_path / "r.json"
+    trend.write_text(json.dumps({"points": [{"date": "2026-05-08", "open_cves": 0}]}))
+    write_report(report, "2026-08-06")
+    out = run_builder(report, trend)
+    assert [p["date"] for p in out["points"]] == ["2026-05-08", "2026-08-06"]
+
+
+# --- the deploy must not overwrite the published ledger ---------------------
+
+def sync_step_body():
+    wf = yaml.safe_load(WORKFLOW.read_text())
+    for job in wf["jobs"].values():
+        for step in job.get("steps", []):
+            if "aws s3 sync website/" in (step.get("run") or ""):
+                return step["run"]
+    pytest.fail("no step running `aws s3 sync website/` was found")
+
+
+def test_content_sync_excludes_the_accumulating_ledger():
+    """Without this exclusion the sync replaces the live ledger with the seed."""
+    body = sync_step_body()
+    assert f'--exclude "{LEDGER_KEY}"' in body, (
+        f"`aws s3 sync website/ ... --delete` must exclude {LEDGER_KEY}; the "
+        "published object is the source of truth for this file and the sync "
+        "would otherwise overwrite it with the committed seed."
+    )
+
+
+def test_sync_still_precedes_the_trend_build():
+    """The exclusion matters only because the sync runs first; pin that order.
+
+    If the trend build ever moves ahead of the sync this test still passes and
+    the exclusion becomes harmless -- but if someone removes the exclusion
+    believing order protects them, the test above fails and says why.
+    """
+    text = WORKFLOW.read_text()
+    assert text.index("aws s3 sync website/") < text.index("build-vdr-trend.py")


### PR DESCRIPTION
## Changed

The published vuln trend ledger held **two points across three months** of daily successful deploys — the committed seed (`2026-05-08`) and whatever today is. The dashboard's RA-5(6) trend chart has therefore been effectively empty since it was built.

It is not a builder bug; the upsert is correct. It is an ordering collision.

`website/.well-known/vdr-trend.json` is the only artifact that is **both committed** (as a seed) **and published** (as an accumulating ledger). Every sibling under `/.well-known/` is gitignored precisely because, in the words of `.gitignore`, they are "uploaded directly to S3 at /.well-known/, not via the website/ tree". This one is the exception, and being the exception is what broke it:

1. line 1001 — `aws s3 sync website/ s3://… --delete` uploads the one-point committed seed **over the live ledger**, destroying accumulated history
2. line 1253 — the trend step fetches "the published ledger" and gets the seed the sync just wrote
3. it appends today's point → 2 points
4. line 1442 — publishes 2 points

Repeat daily, forever. Excluding the key from the sync makes the published object the sole source of truth, matching how `silk-reeling-auth.json` is already handled (published *after* the sync so `--delete` cannot remove it).

## Verified

**Object versions on the live key prove the mechanism** — on 2026-08-06 the sync PUT an object the exact size of the committed seed, then the trend step PUT the seed-plus-one:

```
2026-08-06T10:06:43Z  PUT  size=479   <- content sync, = committed seed byte size
2026-08-06T10:07:57Z  PUT  size=768   <- trend step, seed + today
```

Observed across two days, confirming replacement rather than accumulation — yesterday's point was gone, not appended to:

```
2026-08-05: points = [2026-05-08, 2026-08-05]
2026-08-06: points = [2026-05-08, 2026-08-06]
```

**`aws s3 sync --dryrun` against the live bucket with this change**: no operation touches `.well-known/vdr-trend.json`. Before the change the same dry run rewrites it.

**Tests** (5 new, `tests/test_vdr_trend_ledger.py`): the builder accumulates across successive runs, upserts within a day rather than duplicating, and reproduces the exact live seed-plus-today shape for a single run. Two structural guards assert the workflow keeps the exclusion and that the sync still precedes the trend build — the ordering that makes the exclusion necessary. **Deleting the one-line exclusion fails `test_content_sync_excludes_the_accumulating_ledger`**, verified by reverting it.

Full suite green; `ruff` clean; workflow YAML parses.

## Residual / needs human

**The ledger's lost history is not recoverable from this change.** It starts accumulating from the next deploy. The bucket is versioned, so prior daily VDR summaries could in principle be reconstructed from `vdr-report.json` object versions and backfilled into the ledger — worth doing if the trend chart needs depth sooner than three months from now. Say the word.

**Separate, lower-severity finding, not fixed here.** The same `--delete` removes **48 objects** under `/.well-known/` on every deploy, because the generated artifacts are gitignored and so absent from `website/`. They are restored by the explicit `aws s3 cp` steps and by the runtime Lambda, but the delete markers are real and dated to each deploy:

| key | delete markers | latest |
|---|---|---|
| `ksi-signal-runtime.json` | 156 | 2026-08-06T10:06:43Z |
| `runtime-signing-pubkey.pem` | 101 | 2026-08-06T10:06:43Z |
| `policy-index.md` | 86 | 2026-08-06T10:06:43Z |
| `ksi-signal.json.intoto.jsonl` | 61 | 2026-08-06T10:06:43Z |

Measured restore gap for the runtime signal on 2026-08-06: DELETE 10:06:43 → PUT 10:09:57, about **3 minutes**. So there is a short window each deploy where published compliance artifacts — including the public key needed to verify the runtime signal — return 404 to an external verifier. Modest, and self-healing, but it undercuts the "anyone can `curl` and verify, any time" property. The clean fix is to exclude `.well-known/*` from the sync entirely and publish `security.txt` explicitly like the other artifacts; that is a larger change and I did not want to bundle it with a one-line ledger fix.

## Couldn't verify

The post-merge behaviour itself — that the ledger reaches three points on the next deploy and keeps growing. The dry run proves the sync no longer touches the key, but only a real run proves accumulation end to end. Worth a glance at `/.well-known/vdr-trend.json` after the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
