### PR TITLE
viewer: show the signed divergence verdict instead of recomputing drift

### DIFF
--- a/tests/test_viewer_divergence.py
+++ b/tests/test_viewer_divergence.py
@@ -1,0 +1,186 @@
+"""The dashboard must render the signed divergence verdict, not recompute it.
+
+The Drift card previously derived its own verdict by diffing validation results
+between the two signals. That cannot distinguish a resource that regressed from
+an evaluator that could not read the resource: a validation carrying only a
+`resource_read_error` is a `fail` like any other, so a missing IAM grant showed
+up as infrastructure drift. The runtime emitter already makes that distinction
+and records it in the signed signal; the page should defer to it.
+
+These tests execute the real viewer.js in node against a DOM shim, so they
+exercise the shipped code rather than a reimplementation of it.
+"""
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+VIEWER_JS = REPO / "website" / "assets" / "js" / "viewer.js"
+VIEWER_HTML = REPO / "website" / "viewer.html"
+VIEWER_CSS = REPO / "website" / "assets" / "css" / "viewer.css"
+
+pytestmark = pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+
+DOM_SHIM = """
+// Minimal DOM: enough for the status cards and the divergence panel.
+function mkNode(id) {
+  return {
+    id, className: '', textContent: '', innerHTML: '',
+    _kids: {},
+    querySelector(sel) {
+      const k = sel.replace('.', '');
+      if (!this._kids[k]) this._kids[k] = { textContent: '', innerHTML: '' };
+      return this._kids[k];
+    },
+  };
+}
+const NODES = {};
+for (const id of ['status-signed','status-deploy','status-runtime','status-drift',
+                  'divergence-meta','divergence-body','ksi-meta','ksi-components',
+                  'ksi-component-summary','ksi-validations','oscal-meta','oscal-summary',
+                  'oscal-controls','oscal-filter-summary','filter-status',
+                  'filter-origination','filter-search']) NODES[id] = mkNode(id);
+
+global.document = {
+  getElementById: (id) => NODES[id] || null,
+  addEventListener: () => {},
+  readyState: 'complete',
+};
+global.window = {};
+global.fetch = () => Promise.reject(new Error('no network in test'));
+"""
+
+
+def run_viewer(runtime_signal, deploy_signal=None):
+    """Execute viewer.js's renderStatus + renderDivergencePanel and dump the DOM."""
+    src = VIEWER_JS.read_text()
+    # The IIFE keeps its functions private; re-expose the two under test.
+    src = src.replace(
+        "})();",
+        "global.__renderStatus = renderStatus;\n"
+        "global.__renderDivergencePanel = renderDivergencePanel;\n})();",
+        1,
+    )
+    script = (
+        DOM_SHIM
+        + src
+        + textwrap.dedent(f"""
+        const runtime = {json.dumps(runtime_signal)};
+        const deploy  = {json.dumps(deploy_signal or {"emitted_at": "2026-08-06T10:00:00Z"})};
+        global.__renderStatus(deploy, runtime, null);
+        global.__renderDivergencePanel(runtime);
+        const drift = NODES['status-drift'];
+        console.log(JSON.stringify({{
+          driftClass: drift.className,
+          driftValue: drift.querySelector('.status-value').textContent,
+          driftDetail: drift.querySelector('.status-detail').textContent,
+          body: NODES['divergence-body'].innerHTML,
+          meta: NODES['divergence-meta'].innerHTML,
+        }}));
+        """)
+    )
+    out = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True)
+    return json.loads(out.stdout.strip().splitlines()[-1])
+
+
+def sig(status, regressions=(), unassessed=(), unattributed=0, compared=6):
+    return {
+        "emitted_at": "2026-08-06T16:50:00Z",
+        "divergence": {
+            "status": status,
+            "compared_against": {"signal_id": "sig-1", "emitted_at": "2026-08-06T10:00:00Z",
+                                 "commit": "abc1234"},
+            "ksis_compared": compared,
+            "regressions": list(regressions),
+            "unassessed": list(unassessed),
+            "unattributed_failures": unattributed,
+        },
+    }
+
+
+def entry(ksi, rules, runtime="fail"):
+    return {"ksi_id": ksi, "deploy_status": "pass", "runtime_status": runtime,
+            "violation_ids": list(rules)}
+
+
+def test_converged_reads_as_in_sync():
+    r = run_viewer(sig("converged"))
+    assert "is-good" in r["driftClass"]
+    assert r["driftValue"] == "in sync"
+
+
+def test_diverged_is_bad_and_names_the_ksis():
+    r = run_viewer(sig("diverged", regressions=[entry("KSI-RPL-ABO", ["versioning_disabled"])]))
+    assert "is-bad" in r["driftClass"]
+    assert r["driftValue"] == "drift detected"
+    assert "KSI-RPL-ABO" in r["driftDetail"]
+    assert "Regressions" in r["body"]
+    assert "versioning_disabled" in r["body"]
+
+
+def test_degraded_warns_and_is_not_reported_as_drift():
+    """The four-week false positive, as the dashboard would have shown it."""
+    r = run_viewer(sig("degraded",
+                       unassessed=[entry("KSI-MLA-EVC", ["resource_read_error"], runtime="unassessed")]))
+    assert "is-warn" in r["driftClass"], "an evaluator fault must not read as drift"
+    assert "is-bad" not in r["driftClass"]
+    assert r["driftValue"] != "drift detected"
+    assert "Unassessed" in r["body"]
+    assert "observer" in r["body"]
+
+
+def test_unassessed_badge_does_not_borrow_the_failure_class():
+    r = run_viewer(sig("degraded",
+                       unassessed=[entry("KSI-MLA-EVC", ["resource_read_error"], runtime="unassessed")]))
+    assert "badge-unassessed" in r["body"]
+    assert "badge-fail" not in r["body"]
+
+
+def test_regression_and_unassessed_render_separately():
+    r = run_viewer(sig("diverged",
+                       regressions=[entry("KSI-RPL-ABO", ["versioning_disabled"])],
+                       unassessed=[entry("KSI-MLA-EVC", ["resource_read_error"], runtime="unassessed")]))
+    assert "Regressions" in r["body"] and "Unassessed" in r["body"]
+    assert r["body"].index("Regressions") < r["body"].index("Unassessed")
+
+
+def test_signal_without_divergence_block_falls_back_not_crashes():
+    """Rollout window: signals emitted before the verdict existed."""
+    r = run_viewer({"emitted_at": "2026-08-06T16:50:00Z", "validations": []})
+    assert "predates the signed divergence verdict" in r["driftDetail"]
+    assert "has not run since the check was added" in r["body"]
+
+
+def test_missing_runtime_signal_is_reported_as_unavailable():
+    r = run_viewer(None)
+    assert r["driftValue"] == "unavailable"
+    assert "status-card status-card" not in r["driftClass"]
+
+
+def test_comparison_provenance_is_shown():
+    r = run_viewer(sig("converged"))
+    assert "abc1234" in r["meta"] and "sig-1" in r["meta"]
+
+
+def test_unattributed_failures_are_surfaced():
+    r = run_viewer(sig("degraded", unattributed=2))
+    assert "no KSI mapping" in r["body"]
+
+
+# --- markup / style wiring --------------------------------------------------
+
+def test_panel_and_targets_exist_in_the_page():
+    html = VIEWER_HTML.read_text()
+    assert 'id="divergence-panel"' in html
+    assert 'id="divergence-body"' in html
+    assert 'id="divergence-meta"' in html
+    assert "/.well-known/ksi-signal-runtime.json" in html
+
+
+def test_unassessed_badge_is_styled():
+    assert ".badge-unassessed" in VIEWER_CSS.read_text()

--- a/website/assets/css/viewer.css
+++ b/website/assets/css/viewer.css
@@ -272,6 +272,10 @@
 
 .badge-pass        { color: #2a7d2a; }
 .badge-fail        { color: #b22222; }
+/* Divergence panel: an attribute the runtime evaluator could not read is not a
+   failure of the resource, so it must not borrow the failure colour. */
+.badge-unassessed  { color: #b07d00; }
+.badge-unknown     { color: var(--text-muted); }
 .badge-implemented { color: #2a7d2a; }
 .badge-partial     { color: #b07d00; }
 .badge-not-applicable { color: var(--text-muted); }

--- a/website/assets/js/viewer.js
+++ b/website/assets/js/viewer.js
@@ -94,20 +94,70 @@
         // Card 4: drift between deploy and runtime
         var driftCard = el('status-drift');
         if (driftCard) {
-            if (ksi && runtime) {
-                var d = compareValidations(ksi, runtime);
-                var cls = d.matches ? 'is-good' : 'is-bad';
-                driftCard.className = 'status-card ' + cls;
-                driftCard.querySelector('.status-value').textContent = d.matches ? 'in sync' : 'drift detected';
-                driftCard.querySelector('.status-detail').textContent = d.summary;
-            } else {
-                driftCard.className = 'status-card';
-                driftCard.querySelector('.status-value').textContent = 'unavailable';
-                driftCard.querySelector('.status-detail').textContent = ksi
-                    ? 'runtime signal needed to compare'
-                    : 'deploy-time signal needed to compare';
+            var verdict = divergenceVerdict(ksi, runtime);
+            driftCard.className = 'status-card ' + verdict.cls;
+            driftCard.querySelector('.status-value').textContent = verdict.value;
+            driftCard.querySelector('.status-detail').textContent = verdict.detail;
+        }
+    }
+
+    // The runtime emitter computes the deploy-vs-runtime comparison itself and
+    // records it in the SIGNED signal, so prefer that verdict: it is the one
+    // the deploy gate acts on, it is tamper-evident, and it separates a
+    // resource that regressed from an evaluator that could not look. Recomputing
+    // it here from raw validation results cannot make that distinction, because
+    // a validation carrying only a resource_read_error is a `fail` like any
+    // other -- which is how a missing IAM grant reads as infrastructure drift.
+    //
+    // compareValidations() below stays as the fallback for signals emitted
+    // before the divergence block existed.
+    function divergenceVerdict(ksi, runtime) {
+        var div = runtime && runtime.divergence;
+
+        if (div && div.status) {
+            var regressions = div.regressions || [];
+            var unassessed = div.unassessed || [];
+            if (div.status === 'diverged') {
+                return {
+                    cls: 'is-bad',
+                    value: 'drift detected',
+                    detail: regressions.length + ' KSI(s) passing at deploy time are failing at runtime: ' +
+                        regressions.slice(0, 3).map(function (r) { return r.ksi_id; }).join(', ') +
+                        (regressions.length > 3 ? ', …' : ''),
+                };
+            }
+            if (div.status === 'degraded') {
+                return {
+                    cls: 'is-warn',
+                    value: 'partly unassessed',
+                    detail: 'No drift found, but the runtime evaluator could not reach a verdict on ' +
+                        unassessed.length + ' KSI(s). This is an evaluator fault, not drift.',
+                };
+            }
+            if (div.status === 'converged') {
+                return {
+                    cls: 'is-good',
+                    value: 'in sync',
+                    detail: 'Runtime evaluation agrees with the published deploy-time verdict across ' +
+                        (div.ksis_compared || 0) + ' KSIs.',
+                };
             }
         }
+
+        if (ksi && runtime) {
+            var d = compareValidations(ksi, runtime);
+            return {
+                cls: d.matches ? 'is-good' : 'is-bad',
+                value: d.matches ? 'in sync' : 'drift detected',
+                detail: d.summary + ' (compared in-page; this signal predates the signed divergence verdict)',
+            };
+        }
+
+        return {
+            cls: '',
+            value: 'unavailable',
+            detail: ksi ? 'runtime signal needed to compare' : 'deploy-time signal needed to compare',
+        };
     }
 
     function formatRelative(iso) {
@@ -256,6 +306,93 @@
     function rowRaw(label, html) {
         if (html == null || html === '') return '';
         return '<dt>' + escape(label) + '</dt><dd>' + html + '</dd>';
+    }
+
+    // ---- Deploy <-> runtime divergence panel ------------------------------
+
+    function divergenceRows(entries) {
+        return entries.map(function (e) {
+            var rules = (e.violation_ids || []).map(escape).join(', ') || '—';
+            return '<tr>' +
+                '<td><code>' + escape(e.ksi_id) + '</code></td>' +
+                '<td><span class="badge badge-' + escape(e.deploy_status) + '">' +
+                    escape(e.deploy_status) + '</span></td>' +
+                '<td><span class="badge badge-' + escape(e.runtime_status) + '">' +
+                    escape(e.runtime_status) + '</span></td>' +
+                '<td class="wrap">' + rules + '</td>' +
+                '</tr>';
+        }).join('');
+    }
+
+    function divergenceTable(caption, entries) {
+        return '<h3>' + escape(caption) + '</h3>' +
+            '<div class="viewer-table-wrap"><table class="viewer-table">' +
+            '<thead><tr><th>KSI</th><th>deploy</th><th>runtime</th><th>rules</th></tr></thead>' +
+            '<tbody>' + divergenceRows(entries) + '</tbody></table></div>';
+    }
+
+    function renderDivergencePanel(runtime) {
+        var body = el('divergence-body');
+        var metaEl = el('divergence-meta');
+        if (!body) return;
+
+        if (!runtime) {
+            body.innerHTML = '<p class="viewer-note">Runtime signal not reachable, so no comparison is possible.</p>';
+            if (metaEl) metaEl.innerHTML = '';
+            return;
+        }
+
+        var div = runtime.divergence;
+        if (!div || !div.status) {
+            body.innerHTML = '<p class="viewer-note">This runtime signal carries no divergence verdict. ' +
+                'The emitter that produces it has not run since the check was added; the ' +
+                '<strong>Drift</strong> card above falls back to comparing validations in-page.</p>';
+            if (metaEl) metaEl.innerHTML = '';
+            return;
+        }
+
+        var against = div.compared_against || {};
+        if (metaEl) {
+            metaEl.innerHTML =
+                row('status', div.status) +
+                row('KSIs compared', div.ksis_compared) +
+                row('against deploy signal', against.signal_id) +
+                row('at commit', against.commit) +
+                row('deploy signal emitted', against.emitted_at);
+        }
+
+        var regressions = div.regressions || [];
+        var unassessed = div.unassessed || [];
+        var html = '';
+
+        if (div.status === 'converged') {
+            html += '<p class="component-summary">The daily runtime evaluation of the live account agrees ' +
+                'with the verdict published at deploy time. No KSI that passed the deploy gate is failing ' +
+                'against the running system.</p>';
+        }
+
+        if (regressions.length) {
+            html += '<p class="component-summary"><strong>These KSIs passed the deploy gate and are failing ' +
+                'against the live account.</strong> That is drift in the deployed system, and it blocks the ' +
+                'next deploy until it is investigated or explicitly overridden.</p>';
+            html += divergenceTable('Regressions', regressions);
+        }
+
+        if (unassessed.length) {
+            html += '<p class="component-summary">These KSIs could not be evaluated at all &mdash; the ' +
+                'runtime evaluator failed to read the resource, typically a missing permission. ' +
+                '<strong>This is a fault in the observer, not evidence that anything drifted</strong>, so it ' +
+                'is reported separately and does not block deploys. It does mean these controls are ' +
+                'currently unverified at runtime.</p>';
+            html += divergenceTable('Unassessed', unassessed);
+        }
+
+        if (div.unattributed_failures) {
+            html += '<p class="viewer-note">' + escape(String(div.unattributed_failures)) +
+                ' failing violation(s) carried no KSI mapping, so they are attributed to no indicator above.</p>';
+        }
+
+        body.innerHTML = html;
     }
 
     // ---- OSCAL SSP panel --------------------------------------------------
@@ -433,6 +570,7 @@
         Promise.all([ksiP, runtimeP, oscalP]).then(function (results) {
             var ksi = results[0], runtime = results[1], oscal = results[2];
             renderStatus(ksi, runtime, oscal);
+            renderDivergencePanel(runtime);
             if (ksi) renderKsiPanel(ksi);
             if (oscal) renderOscalPanel(oscal);
         });

--- a/website/viewer.html
+++ b/website/viewer.html
@@ -128,6 +128,19 @@ cosign verify-blob \
                 <p>The trust roots are Sigstore (Fulcio + Rekor) and the pinned public identity — not this site, and not the verifier script. <strong>Honest limit:</strong> the two live-state checks — that the inventory is complete against live AWS, and that live resource tags match the inventory — need cloud credentials, so the provider runs them on every deploy and an outsider verifies the signed evidence, not the live account. <a href="https://github.com/sam-aydlette/samaydlette.com/blob/main/docs/verification.md">Full walkthrough &rarr;</a></p>
             </div>
 
+            <section class="viewer-panel" id="divergence-panel">
+                <div class="viewer-panel-header">
+                    <h2>Deploy &harr; Runtime Divergence</h2>
+                    <span class="raw-link"><a href="/.well-known/ksi-signal-runtime.json">raw JSON</a></span>
+                </div>
+                <p>The deploy gate evaluates a Terraform plan; a Lambda re-evaluates the live account daily against the same compiled policy. This is the comparison between them, computed by the runtime emitter and carried inside the signed signal &mdash; not recomputed by this page.</p>
+                <p>Two failure modes are kept apart deliberately. A <strong>regression</strong> is a KSI that passed the deploy gate and is failing against the running system: real drift, and it blocks the next deploy. An <strong>unassessed</strong> KSI is one the evaluator could not reach a verdict on, usually a missing read permission &mdash; a fault in the observer rather than the system, which is reported but never treated as drift.</p>
+                <dl class="meta-grid" id="divergence-meta"></dl>
+                <div id="divergence-body">
+                    <p class="viewer-loading">Loading…</p>
+                </div>
+            </section>
+
             <section class="viewer-panel" id="vuln-trend-panel">
                 <div class="viewer-panel-header">
                     <h2>Vulnerability Trend</h2>


### PR DESCRIPTION
## Changed

Follow-up to #260, which makes the runtime emitter publish a `divergence` verdict inside the signed signal.

**Correction to something I said earlier:** I claimed the dashboard did not read the runtime signal at all. That was wrong — I had grepped `viewer.html` only. `viewer.js` has fetched `/.well-known/ksi-signal-runtime.json` and rendered a **Drift** card all along.

The real problem is subtler and worse. The card recomputed drift in-page by diffing validation results between the two signals — and that comparison **cannot distinguish a resource that regressed from an evaluator that could not read the resource.** A validation carrying only a `resource_read_error` is a `fail` like any other, so a missing IAM grant renders as infrastructure drift. That is the same conflation #260 fixes server-side, reproduced client-side; the dashboard has been showing red for a four-week false positive.

Now the card reads the verdict the emitter computed and signed, so the page agrees with the deploy gate by construction rather than by reimplementation:

| verdict | card | meaning |
|---|---|---|
| `converged` | green — *in sync* | runtime agrees with the published deploy-time verdict |
| `degraded` | amber — *partly unassessed* | evaluator could not assess something; an observer fault, never blocks |
| `diverged` | red — *drift detected* | a KSI that passed the deploy gate is failing live; blocks the next deploy |

A new **Deploy ↔ Runtime Divergence** panel lists the specifics: which KSIs regressed and under which rules, which are unassessed (and therefore currently unverified at runtime), the count of failures carrying no KSI mapping, and which deploy signal and commit the comparison was made against. Unassessed rows get their own badge colour rather than borrowing `badge-fail`.

The old in-page comparison remains as a labelled fallback for signals emitted before the block existed, so the rollout window degrades rather than showing nothing.

## Verified

**Tests execute the shipped `viewer.js` in node against a DOM shim** — the real code, not a reimplementation. The IIFE's private functions are re-exposed and `renderStatus` / `renderDivergencePanel` are driven directly. 11 tests: all three states, the fallback, the missing-signal case, table ordering, comparison provenance, unattributed failures, and that `badge-unassessed` is used where `badge-fail` must not be.

The load-bearing one is `test_degraded_warns_and_is_not_reported_as_drift` — the four-week false positive, as the dashboard would now show it: amber, not red, and never the words "drift detected".

Rendered output for a diverged signal:

```
DRIFT CARD: status-card is-bad | drift detected
  2 KSI(s) passing at deploy time are failing at runtime: KSI-RPL-ABO, KSI-SVC-SIN

PANEL: These KSIs passed the deploy gate and are failing against the live
account… Regressions | KSI-RPL-ABO pass fail versioning_disabled | KSI-SVC-SIN
pass fail encryption_disabled … This is a fault in the observer, not evidence
that anything drifted … Unassessed | KSI-MLA-EVC pass unassessed …
```

Full suite green (162 passed, 18 skipped — skips are OPA-not-on-PATH and generated-artifact fixtures); `ruff` clean; `node --check` clean on both viewer scripts; `viewer.html` tags balanced. Driven against the **real live artifacts** (today's published deploy and runtime signals) plus a synthetic diverged signal, since production is currently `degraded`-shaped.

## Residual / needs human

- **No browser screenshot.** I served the page locally and tried to drive Chrome, but the browser extension is not connected in this session, so I verified by executing the render logic and inspecting the emitted DOM instead. Layout and colour in a real viewport are unconfirmed — worth a look after merge, particularly that the new panel's tables scroll properly on mobile via the existing `.viewer-table-wrap`.
- **Merge order.** This is harmless before #260 (it takes the labelled fallback path), but the new panel only shows content once the emitter from #260 has actually run. Merging #260 first means one deploy plus one Lambda cycle before the panel is populated.
- **Dark mode not specifically checked.** The new badge colours reuse the existing palette values from `viewer.css`, so they inherit whatever the current theme handling does; I did not verify contrast in both themes.

## Couldn't verify

That the `divergence` block renders correctly from a *real* emitter run — production has no such block yet, so the diverged and degraded fixtures are synthetic, hand-built to the schema added in #260. The converged and fallback paths were exercised against genuinely published artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
