### PR TITLE
ci: stop deleting published evidence mid-deploy, and rebuild the lost RA-5(6) trend history

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -999,17 +999,26 @@ jobs:
         
         # Upload website files, skip infrastructure code.
         #
-        # .well-known/vdr-trend.json is EXCLUDED because it is an accumulating
-        # ledger, not site content. Its history lives in the published object:
-        # the RA-5(6) trend step below fetches it, appends today's point, and
-        # re-publishes. A committed copy exists in website/ as a seed, and
-        # syncing that copy over the live object destroyed the accumulated
-        # history on every single deploy — the ledger was permanently stuck at
-        # [seed, today], two points, because the fetch downstream was reading a
-        # ledger this sync had just overwritten a few steps earlier. The
-        # published object is the source of truth for this file; the sync must
-        # not touch it. (Same reasoning as silk-reeling-auth.json below, which
-        # is published after the sync so --delete cannot remove it.)
+        # ALL of .well-known/ is EXCLUDED. Everything served from there is a
+        # generated, signed artifact published by an explicit `aws s3 cp` later
+        # in this job — none of it is in website/, because .gitignore keeps
+        # generated artifacts out of the tree. That meant `--delete` removed 48
+        # published objects on every deploy and the later steps put them back
+        # roughly three minutes afterwards, so a third party fetching during a
+        # deploy got a 404 for the compliance artifacts and, worse, for
+        # runtime-signing-pubkey.pem — the key needed to verify the runtime
+        # signal. A verifiable-by-anyone system should not be unverifiable for
+        # several minutes a day.
+        #
+        # It also subsumes the vdr-trend.json exclusion: that ledger accumulates
+        # in the published object, and syncing the committed seed over it reset
+        # the history on every deploy.
+        #
+        # Consequence: any file genuinely served from .well-known/ must be
+        # published explicitly below (see security.txt), exactly as
+        # silk-reeling-auth.json already is. tests/test_wellknown_publish.py
+        # fails if a tracked file under website/.well-known/ has no publish
+        # step, so this cannot silently drop content.
         aws s3 sync website/ s3://$BUCKET_NAME/ \
           --exclude "*.tf" \
           --exclude "*.tfvars*" \
@@ -1022,8 +1031,15 @@ jobs:
           --exclude "Makefile" \
           --exclude ".gitignore" \
           --exclude ".github/*" \
-          --exclude ".well-known/vdr-trend.json" \
+          --exclude ".well-known/*" \
           --delete
+
+        # Site content that genuinely lives under .well-known/ and is committed
+        # (not generated) has to be published by hand now that the sync skips
+        # the whole prefix. RFC 9116 requires text/plain.
+        aws s3 cp website/.well-known/security.txt "s3://$BUCKET_NAME/.well-known/security.txt" \
+          --content-type "text/plain; charset=utf-8" --cache-control "public, max-age=3600"
+        echo "✅ Published /.well-known/security.txt"
 
         echo "✅ Website content synced successfully"
 
@@ -1272,6 +1288,20 @@ jobs:
           echo "::warning::No previous VDR trend ledger; starting a fresh one."
           rm -f vdr-trend.json
         fi
+        # Merge the reconstructed history (data/vdr-trend-backfill.json) before
+        # appending today. Those points were rebuilt from stored vdr-report.json
+        # object versions after the sync bug reset the ledger, and they are
+        # committed so the reconstruction is reviewable in a diff rather than
+        # materialising from an S3 listing nobody sees. Merging here means the
+        # repaired ledger is signed by the same run that builds it; uploading a
+        # rebuilt ledger by hand would publish an object that disagreed with its
+        # signature until the next deploy.
+        #
+        # Reads no AWS API, so it needs no permission the deploy role lacks, and
+        # existing points always win — idempotent, a no-op once absorbed, and it
+        # re-heals the ledger if it is ever reset again.
+        python3 ../scripts/backfill-vdr-trend.py \
+          --points ../data/vdr-trend-backfill.json --trend vdr-trend.json
         python3 ../scripts/build-vdr-trend.py --report vdr-report.json --trend vdr-trend.json
         cosign sign-blob --yes --bundle vdr-trend.bundle vdr-trend.json
 

--- a/data/vdr-trend-backfill.json
+++ b/data/vdr-trend-backfill.json
@@ -1,0 +1,998 @@
+{
+  "source": "s3://samaydlette.com/.well-known/vdr-report.json object versions",
+  "note": "Reconstructed RA-5(6) trend points. Merged into the published ledger by the pipeline; existing points always win.",
+  "points": [
+    {
+      "date": "2026-05-08",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 15
+    },
+    {
+      "date": "2026-06-04",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 18
+    },
+    {
+      "date": "2026-06-05",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 18
+    },
+    {
+      "date": "2026-06-06",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 18
+    },
+    {
+      "date": "2026-06-07",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 18
+    },
+    {
+      "date": "2026-06-08",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 18
+    },
+    {
+      "date": "2026-06-09",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 18
+    },
+    {
+      "date": "2026-06-10",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 18
+    },
+    {
+      "date": "2026-06-11",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 18
+    },
+    {
+      "date": "2026-06-12",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 18
+    },
+    {
+      "date": "2026-06-13",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 18
+    },
+    {
+      "date": "2026-06-14",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 18
+    },
+    {
+      "date": "2026-06-15",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 1,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 1,
+      "risk_accepted": 14
+    },
+    {
+      "date": "2026-06-16",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 2,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 2,
+      "risk_accepted": 12
+    },
+    {
+      "date": "2026-06-17",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 2,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 2,
+      "risk_accepted": 12
+    },
+    {
+      "date": "2026-06-18",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 8,
+        "N3": 1,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 9,
+      "risk_accepted": 5
+    },
+    {
+      "date": "2026-06-22",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 8,
+        "N3": 1,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 9,
+      "risk_accepted": 3
+    },
+    {
+      "date": "2026-06-23",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 17,
+        "N3": 1,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 18,
+      "risk_accepted": 3
+    },
+    {
+      "date": "2026-06-24",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 17,
+        "N3": 1,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 18,
+      "risk_accepted": 3
+    },
+    {
+      "date": "2026-06-25",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 17,
+        "N3": 1,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 18,
+      "risk_accepted": 3
+    },
+    {
+      "date": "2026-06-26",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 17,
+        "N3": 1,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 18,
+      "risk_accepted": 3
+    },
+    {
+      "date": "2026-06-27",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 17,
+        "N3": 1,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 18,
+      "risk_accepted": 3
+    },
+    {
+      "date": "2026-06-28",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 17,
+        "N3": 1,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 18,
+      "risk_accepted": 3
+    },
+    {
+      "date": "2026-06-29",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 10
+    },
+    {
+      "date": "2026-06-30",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 10
+    },
+    {
+      "date": "2026-07-01",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 10
+    },
+    {
+      "date": "2026-07-02",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 10
+    },
+    {
+      "date": "2026-07-03",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 10
+    },
+    {
+      "date": "2026-07-04",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 10
+    },
+    {
+      "date": "2026-07-05",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 10
+    },
+    {
+      "date": "2026-07-06",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 10
+    },
+    {
+      "date": "2026-07-07",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 10
+    },
+    {
+      "date": "2026-07-08",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 10
+    },
+    {
+      "date": "2026-07-09",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-10",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-11",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-12",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-13",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-14",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-15",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-16",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-17",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-18",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-19",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-20",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-21",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-22",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-23",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-24",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-25",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-26",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-27",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-28",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-29",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-30",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-07-31",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-08-01",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-08-02",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-08-03",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-08-04",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-08-05",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    },
+    {
+      "date": "2026-08-06",
+      "unique_cves": 0,
+      "open_cves": 0,
+      "blocking": 0,
+      "kev": 0,
+      "by_pain": {
+        "N1": 0,
+        "N2": 0,
+        "N3": 0,
+        "N4": 0,
+        "N5": 0
+      },
+      "total_findings": 0,
+      "risk_accepted": 13
+    }
+  ]
+}

--- a/scripts/backfill-vdr-trend.py
+++ b/scripts/backfill-vdr-trend.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# =============================================================================
+# VDR TREND BACKFILL  (RA-5(6) history reconstruction)
+# =============================================================================
+# Repairs a trend ledger that lost its history, and keeps it repaired.
+#
+# The ledger accumulated only two points across three months because the website
+# content sync uploaded the committed one-point seed over the published ledger
+# before the trend step fetched it (fixed separately). The daily data was never
+# lost, only unaccumulated: every deploy also published a signed vdr-report.json,
+# and the bucket is versioned, so each run survives as an object version.
+#
+# TWO MODES, DELIBERATELY SPLIT
+#
+#   reconstruct:  --bucket BUCKET --out FILE
+#       Reads stored vdr-report.json object versions and writes a plain points
+#       file. Needs s3:ListBucketVersions + s3:GetObjectVersion, which an
+#       operator has and the CI deploy role does not. Run once, by hand; the
+#       output is committed and reviewed in a pull request.
+#
+#   merge:        --points FILE --trend LEDGER
+#       Merges that reviewed file into the ledger. Reads no AWS API at all, so
+#       CI runs it with no new permission, and the ledger it produces is signed
+#       and published by the same run that built it.
+#
+# The split is what keeps this honest. Hand-uploading a reconstructed ledger
+# would leave the published object disagreeing with its signature until the next
+# deploy re-signed it -- an unverifiable artifact on a site whose whole claim is
+# that you can verify it. Instead the reconstruction is committed as reviewable
+# input, and the generator still produces the artifact.
+#
+# Every point is derived from an authentic published report through the same
+# point_from_report() the live builder uses, so a reconstructed point and a live
+# one are the same function of the same input. This is not a hand-edit of a
+# generated artifact.
+#
+# IDEMPOTENT: existing ledger points always win, so merging cannot rewrite
+# history the live pipeline already recorded and a second run is a no-op. Safe
+# to run on every deploy, which also means the ledger self-heals if it is ever
+# reset again.
+#
+# Usage:
+#   backfill-vdr-trend.py --bucket samaydlette.com --out data/vdr-trend-backfill.json
+#   backfill-vdr-trend.py --points ../data/vdr-trend-backfill.json --trend vdr-trend.json
+# =============================================================================
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# build-vdr-trend.py has a hyphen, so it cannot be imported by name. Loading it
+# by path is what keeps reconstructed points identical to live ones.
+_spec = importlib.util.spec_from_file_location(
+    "vdr_trend_builder", Path(__file__).resolve().parent / "build-vdr-trend.py"
+)
+if _spec is None or _spec.loader is None:  # pragma: no cover - packaging error
+    raise SystemExit("backfill: cannot load scripts/build-vdr-trend.py")
+_builder = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_builder)
+
+REPORT_KEY = ".well-known/vdr-report.json"
+
+
+def list_report_versions(bucket, key):
+    """(last_modified, version_id) for every stored version, oldest first."""
+    out = subprocess.run(
+        ["aws", "s3api", "list-object-versions", "--bucket", bucket,
+         "--prefix", key, "--output", "json"],
+        capture_output=True, text=True, check=True,
+    )
+    data = json.loads(out.stdout) if out.stdout.strip() else {}
+    return sorted(
+        (v["LastModified"], v["VersionId"])
+        for v in data.get("Versions", []) if v.get("Key") == key
+    )
+
+
+def last_version_per_day(versions):
+    """One version per calendar day -- the last, matching upsert-by-date."""
+    chosen = {}
+    for ts, vid in versions:
+        chosen[ts[:10]] = vid
+    return [(day, chosen[day]) for day in sorted(chosen)]
+
+
+def fetch_report(bucket, key, version_id):
+    """Download one stored version to a temp file and parse it.
+
+    get-object writes the body to a path and its own metadata to stdout, so a
+    real file keeps the two from being interleaved.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".json") as tmp:
+        subprocess.run(
+            ["aws", "s3api", "get-object", "--bucket", bucket, "--key", key,
+             "--version-id", version_id, tmp.name],
+            capture_output=True, check=True,
+        )
+        return json.loads(Path(tmp.name).read_text())
+
+
+def reconstruct(bucket, key):
+    versions = list_report_versions(bucket, key)
+    if not versions:
+        return [], 0
+    points, skipped, seen = [], 0, set()
+    for day, vid in last_version_per_day(versions):
+        try:
+            point = _builder.point_from_report(fetch_report(bucket, key, vid))
+        except Exception as e:  # noqa: BLE001 - one bad version must not abort the rest
+            print(f"backfill: skipping {day} ({type(e).__name__})", file=sys.stderr)
+            skipped += 1
+            continue
+        # An object version's timestamp and the report's own emitted_at can
+        # straddle midnight; the report's own date is authoritative.
+        if point["date"] in seen:
+            continue
+        seen.add(point["date"])
+        points.append(point)
+    points.sort(key=lambda p: p["date"])
+    return points, skipped
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--bucket", help="reconstruct mode: bucket holding the report versions")
+    ap.add_argument("--key", default=REPORT_KEY)
+    ap.add_argument("--out", help="reconstruct mode: where to write the points file")
+    ap.add_argument("--points", help="merge mode: reviewed points file to merge")
+    ap.add_argument("--trend", help="merge mode: ledger to merge into")
+    ap.add_argument("--keep-days", type=int, default=190)
+    a = ap.parse_args()
+
+    if a.bucket or a.out:
+        if not (a.bucket and a.out):
+            ap.error("reconstruct mode needs both --bucket and --out")
+        points, skipped = reconstruct(a.bucket, a.key)
+        if not points:
+            print(f"backfill: no stored versions of {a.key}; nothing to reconstruct")
+            return 0
+        Path(a.out).write_text(json.dumps(
+            {"source": f"s3://{a.bucket}/{a.key} object versions",
+             "note": "Reconstructed RA-5(6) trend points. Merged into the published "
+                     "ledger by the pipeline; existing points always win.",
+             "points": points}, indent=2) + "\n")
+        print(f"backfill: wrote {len(points)} point(s) to {a.out} "
+              f"({points[0]['date']} .. {points[-1]['date']}, {skipped} unreadable)")
+        return 0
+
+    if not (a.points and a.trend):
+        ap.error("merge mode needs both --points and --trend")
+
+    pp = Path(a.points)
+    if not pp.exists():
+        print(f"backfill: no points file at {a.points}; nothing to merge")
+        return 0
+    incoming = json.loads(pp.read_text()).get("points", [])
+
+    tp = Path(a.trend)
+    trend = json.loads(tp.read_text()) if tp.exists() else {"points": []}
+    existing = trend.get("points", [])
+    before = {p["date"] for p in existing if p.get("date")}
+
+    # Existing points win: merge_points lets `incoming` overwrite, so feed the
+    # reconstruction first and the live points second.
+    points = _builder.merge_points(incoming, existing, a.keep_days)
+    added = len([p for p in points if p["date"] not in before])
+
+    trend["points"] = points
+    trend.setdefault("control", "RA-5(6) — automated vulnerability trend analysis")
+    tp.write_text(json.dumps(trend, indent=2) + "\n")
+    print(f"backfill: merged {added} reconstructed point(s); ledger now "
+          f"{len(points)} point(s), {points[0]['date']} .. {points[-1]['date']}"
+          if points else "backfill: ledger empty")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build-vdr-trend.py
+++ b/scripts/build-vdr-trend.py
@@ -19,19 +19,16 @@ import json
 from pathlib import Path
 
 
-def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--report", default="website/.well-known/vdr-report.json")
-    ap.add_argument("--trend", default="website/.well-known/vdr-trend.json")
-    ap.add_argument("--keep-days", type=int, default=190)
-    a = ap.parse_args()
-
-    rpt = json.loads(Path(a.report).read_text())
+# The published point shape. Exported so backfill-vdr-trend.py reconstructs
+# historical points through exactly this function — a second implementation
+# would drift from the live one silently, and the ledger is meant to be one
+# comparable series, not two shapes concatenated at a seam.
+def point_from_report(rpt):
     s = rpt.get("summary", {})
     date = (rpt.get("emitted_at") or "")[:10]
     if not date:
         raise SystemExit("VDR report has no emitted_at date")
-    point = {
+    return {
         "date": date,
         "unique_cves": s.get("unique_cves", 0),
         "open_cves": s.get("unique_cves_open", 0),
@@ -42,12 +39,31 @@ def main():
         "risk_accepted": s.get("risk_accepted", 0),
     }
 
+
+# Upsert by date, chronological, trimmed to the rolling window. Shared with the
+# backfill so both paths order and trim identically.
+def merge_points(existing, incoming, keep_days):
+    by_date = {p["date"]: p for p in existing if p.get("date")}
+    for p in incoming:
+        by_date[p["date"]] = p
+    points = sorted(by_date.values(), key=lambda p: p["date"])
+    return points[-keep_days:]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--report", default="website/.well-known/vdr-report.json")
+    ap.add_argument("--trend", default="website/.well-known/vdr-trend.json")
+    ap.add_argument("--keep-days", type=int, default=190)
+    a = ap.parse_args()
+
+    rpt = json.loads(Path(a.report).read_text())
+    point = point_from_report(rpt)
+    date = point["date"]
+
     tp = Path(a.trend)
     trend = json.loads(tp.read_text()) if tp.exists() else {"points": []}
-    points = [p for p in trend.get("points", []) if p.get("date") != date]   # upsert by date
-    points.append(point)
-    points.sort(key=lambda p: p["date"])
-    points = points[-a.keep_days:]                                            # rolling window
+    points = merge_points(trend.get("points", []), [point], a.keep_days)
 
     trend["system_id"] = rpt.get("system_id")
     trend["control"] = "RA-5(6) — automated vulnerability trend analysis"

--- a/tests/test_vdr_trend_backfill.py
+++ b/tests/test_vdr_trend_backfill.py
@@ -1,0 +1,134 @@
+"""Reconstructed trend points merge without ever rewriting live history.
+
+The ledger lost three months of points to a sync ordering bug. The daily data
+survived as vdr-report.json object versions, and scripts/backfill-vdr-trend.py
+rebuilds points from them through the live builder's own point_from_report(), so
+a reconstructed point and a live one are the same function of the same input.
+
+The merge runs on every deploy. That is only safe because existing points always
+win: a reconstruction can fill gaps but must never overwrite what the pipeline
+actually recorded, and re-running must change nothing.
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "backfill-vdr-trend.py"
+DATA = REPO / "data" / "vdr-trend-backfill.json"
+WORKFLOW = REPO / ".github" / "workflows" / "deploy-with-opa.yml"
+
+_spec = importlib.util.spec_from_file_location(
+    "vdr_trend_builder", REPO / "scripts" / "build-vdr-trend.py"
+)
+builder = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(builder)
+
+
+def run_merge(points_file, trend_file):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--points", str(points_file), "--trend", str(trend_file)],
+        capture_output=True, text=True, check=True,
+    )
+
+
+def point(date, **kw):
+    base = {"date": date, "unique_cves": 0, "open_cves": 0, "blocking": 0,
+            "kev": 0, "by_pain": {}, "total_findings": 0, "risk_accepted": 0}
+    base.update(kw)
+    return base
+
+
+def write(path, obj):
+    path.write_text(json.dumps(obj))
+    return path
+
+
+# --- merge semantics --------------------------------------------------------
+
+def test_gaps_are_filled(tmp_path):
+    pts = write(tmp_path / "p.json", {"points": [point("2026-06-01"), point("2026-06-02")]})
+    led = write(tmp_path / "t.json", {"points": [point("2026-06-03")]})
+    run_merge(pts, led)
+    got = json.loads(led.read_text())
+    assert [p["date"] for p in got["points"]] == ["2026-06-01", "2026-06-02", "2026-06-03"]
+
+
+def test_live_points_are_never_overwritten(tmp_path):
+    """The reconstruction must lose every collision with recorded history."""
+    pts = write(tmp_path / "p.json", {"points": [point("2026-06-01", risk_accepted=99)]})
+    led = write(tmp_path / "t.json", {"points": [point("2026-06-01", risk_accepted=13)]})
+    run_merge(pts, led)
+    got = json.loads(led.read_text())
+    assert len(got["points"]) == 1
+    assert got["points"][0]["risk_accepted"] == 13, "live point must win"
+
+
+def test_merge_is_idempotent(tmp_path):
+    pts = write(tmp_path / "p.json", {"points": [point("2026-06-01"), point("2026-06-02")]})
+    led = write(tmp_path / "t.json", {"points": [point("2026-06-03")]})
+    run_merge(pts, led)
+    first = led.read_text()
+    run_merge(pts, led)
+    assert led.read_text() == first
+
+
+def test_missing_points_file_is_not_an_error(tmp_path):
+    led = write(tmp_path / "t.json", {"points": [point("2026-06-03")]})
+    r = run_merge(tmp_path / "absent.json", led)
+    assert "nothing to merge" in r.stdout
+    assert json.loads(led.read_text())["points"] == [point("2026-06-03")]
+
+
+def test_rolling_window_is_respected(tmp_path):
+    many = [point(f"2026-01-{d:02d}") for d in range(1, 29)]
+    pts = write(tmp_path / "p.json", {"points": many})
+    led = write(tmp_path / "t.json", {"points": []})
+    subprocess.run([sys.executable, str(SCRIPT), "--points", str(pts),
+                    "--trend", str(led), "--keep-days", "10"], check=True, capture_output=True)
+    got = json.loads(led.read_text())
+    assert len(got["points"]) == 10
+    assert got["points"][-1]["date"] == "2026-01-28"  # keeps the most recent
+
+
+def test_points_stay_chronological(tmp_path):
+    pts = write(tmp_path / "p.json", {"points": [point("2026-06-05"), point("2026-06-01")]})
+    led = write(tmp_path / "t.json", {"points": [point("2026-06-03")]})
+    run_merge(pts, led)
+    dates = [p["date"] for p in json.loads(led.read_text())["points"]]
+    assert dates == sorted(dates)
+
+
+def test_mode_arguments_are_mutually_required(tmp_path):
+    r = subprocess.run([sys.executable, str(SCRIPT), "--bucket", "b"],
+                       capture_output=True, text=True)
+    assert r.returncode != 0 and "--bucket and --out" in r.stderr
+
+
+# --- the committed reconstruction ------------------------------------------
+
+def test_committed_backfill_matches_the_published_point_shape():
+    """A reconstructed point must be indistinguishable from a live one."""
+    data = json.loads(DATA.read_text())
+    expected = set(builder.point_from_report(
+        {"emitted_at": "2026-01-01T00:00:00Z", "summary": {}}
+    ).keys())
+    assert data["points"], "the committed reconstruction is empty"
+    for p in data["points"]:
+        assert set(p.keys()) == expected, f"point {p.get('date')} has a different shape"
+
+
+def test_committed_backfill_is_sorted_and_unique():
+    dates = [p["date"] for p in json.loads(DATA.read_text())["points"]]
+    assert dates == sorted(dates)
+    assert len(dates) == len(set(dates))
+
+
+def test_pipeline_merges_before_appending_today():
+    """Order matters: today's point must be the last word, not the backfill's."""
+    text = WORKFLOW.read_text()
+    assert "backfill-vdr-trend.py" in text, "the pipeline must merge the reconstruction"
+    assert text.index("backfill-vdr-trend.py") < text.index("build-vdr-trend.py --report")

--- a/tests/test_vdr_trend_ledger.py
+++ b/tests/test_vdr_trend_ledger.py
@@ -93,10 +93,15 @@ def sync_step_body():
 
 
 def test_content_sync_excludes_the_accumulating_ledger():
-    """Without this exclusion the sync replaces the live ledger with the seed."""
+    """Without this exclusion the sync replaces the live ledger with the seed.
+
+    Either the specific key or the whole prefix satisfies the invariant; the
+    prefix form is what ships, and it also closes the --delete window on every
+    other published artifact.
+    """
     body = sync_step_body()
-    assert f'--exclude "{LEDGER_KEY}"' in body, (
-        f"`aws s3 sync website/ ... --delete` must exclude {LEDGER_KEY}; the "
+    assert f'--exclude "{LEDGER_KEY}"' in body or '--exclude ".well-known/*"' in body, (
+        f"`aws s3 sync website/ ... --delete` must not touch {LEDGER_KEY}; the "
         "published object is the source of truth for this file and the sync "
         "would otherwise overwrite it with the committed seed."
     )

--- a/tests/test_wellknown_publish.py
+++ b/tests/test_wellknown_publish.py
@@ -1,0 +1,78 @@
+"""Everything under /.well-known/ must be published deliberately, not swept.
+
+The content sync used to run `aws s3 sync website/ --delete` over the whole
+bucket. Generated artifacts are gitignored, so they are absent from website/ and
+`--delete` removed 48 published objects on every deploy; the explicit upload
+steps put them back about three minutes later. For those minutes a third party
+got a 404 for the compliance artifacts and for runtime-signing-pubkey.pem -- the
+key needed to verify the runtime signal. A system whose claim is "verify this
+yourself, any time" should not be unverifiable for several minutes a day.
+
+The prefix is now excluded from the sync, which moves the risk: anything
+genuinely served from .well-known/ must be published by an explicit step, and
+forgetting one would silently stop serving it. This file is that guard.
+"""
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO / ".github" / "workflows" / "deploy-with-opa.yml"
+WELL_KNOWN = REPO / "website" / ".well-known"
+
+# The accumulating ledger is deliberately never uploaded from website/: its
+# history lives in the published object and the trend step republishes it.
+LEDGER = "vdr-trend.json"
+
+
+def workflow_text():
+    return WORKFLOW.read_text()
+
+
+def sync_step_body():
+    wf = yaml.safe_load(workflow_text())
+    for job in wf["jobs"].values():
+        for step in job.get("steps", []):
+            if "aws s3 sync website/" in (step.get("run") or ""):
+                return step["run"]
+    pytest.fail("no step running `aws s3 sync website/` was found")
+
+
+def tracked_well_known_files():
+    if not WELL_KNOWN.is_dir():
+        return []
+    return sorted(p.name for p in WELL_KNOWN.iterdir() if p.is_file())
+
+
+def test_sync_excludes_the_whole_well_known_prefix():
+    assert '--exclude ".well-known/*"' in sync_step_body(), (
+        "`aws s3 sync website/ ... --delete` must exclude .well-known/*; without "
+        "it, every generated artifact is deleted and re-uploaded on each deploy, "
+        "leaving a window where published evidence 404s."
+    )
+
+
+@pytest.mark.parametrize("name", tracked_well_known_files())
+def test_every_committed_well_known_file_has_a_publish_step(name):
+    """A file in website/.well-known/ is no longer published by the sync.
+
+    If it is committed there, some step must copy it explicitly, or it silently
+    stops being served the next time the site deploys.
+    """
+    if name == LEDGER:
+        pytest.skip("the trend ledger is republished by the RA-5(6) trend step, not from website/")
+    text = workflow_text()
+    assert f".well-known/{name}" in text, (
+        f"website/.well-known/{name} is committed but no workflow step publishes "
+        f"it, and the content sync now skips the whole prefix, so it would stop "
+        f"being served. Add an explicit `aws s3 cp` for it."
+    )
+
+
+def test_security_txt_is_published_with_the_content_type_rfc9116_requires():
+    body = sync_step_body()
+    assert ".well-known/security.txt" in body
+    assert "text/plain" in body, "RFC 9116 requires security.txt to be served as text/plain"


### PR DESCRIPTION
## Changed

Two follow-ons from #261, both rooted in the same content sync.

### Closing the `--delete` window

Everything under `/.well-known/` is a generated, signed artifact published by an explicit `aws s3 cp` later in the deploy. None of it lives in `website/`, because `.gitignore` keeps generated artifacts out of the tree — so `aws s3 sync website/ --delete` removed **48 published objects on every run**, and the upload steps restored them about three minutes later.

For those minutes a third party fetching the artifacts got a 404 — including for `runtime-signing-pubkey.pem`, the key needed to verify the runtime signal. A system whose claim is that anyone can verify it at any time should not be unverifiable for several minutes a day.

The whole prefix is now excluded. That **moves** the risk rather than removing it: anything genuinely served from there must be published explicitly. So `security.txt` gains its own upload (`text/plain`, per RFC 9116), and `tests/test_wellknown_publish.py` fails if a committed file under `website/.well-known/` has no publish step — the new failure mode can't happen silently.

### Rebuilding the lost history

The three missing months were never lost, only unaccumulated: every deploy also published a signed `vdr-report.json`, and the bucket is versioned.

`scripts/backfill-vdr-trend.py` splits into two modes deliberately:

- **reconstruct** (`--bucket --out`) reads stored object versions and writes a plain points file. Needs `s3:ListBucketVersions` + `s3:GetObjectVersion`, which an operator has and **the deploy role does not** (confirmed via `iam simulate-principal-policy`: both `implicitDeny`). Run by hand; output committed for review.
- **merge** (`--points --trend`) reads no AWS API, so the pipeline absorbs it with **no new IAM permission**, and the repaired ledger is signed by the same run that builds it.

That split is the point. Uploading a rebuilt ledger by hand would have published an object disagreeing with its signature until the next deploy re-signed it — and committing the reconstruction means it's reviewable in this diff rather than materialising from an S3 listing nobody sees.

Points are rebuilt through the live builder's own `point_from_report()`, factored out for the purpose, so a reconstructed point and a live one are the same function of the same input. Existing points always win: idempotent, safe on every deploy, and self-healing if the ledger is ever reset again.

## Verified

**Live dry run of the new sync** — operations touching `.well-known/`: **0** (before this change: 48 deletions).

**Delete markers confirm the window was real**, latest dated to the most recent deploy:

| key | delete markers |
|---|---|
| `ksi-signal-runtime.json` | 156 |
| `runtime-signing-pubkey.pem` | 101 |
| `policy-index.md` | 86 |
| `ksi-signal.json.intoto.jsonl` | 61 |

Measured restore gap on 2026-08-06: DELETE `10:06:43` → PUT `10:09:57`.

**Reconstruction against live history**: 62 stored days, **0 unreadable**, spanning `2026-05-08 .. 2026-08-06`.

**Full pipeline sequence simulated against the live ledger** — fetch, merge, append, in workflow order:

```
BEFORE: 2 points
backfill: merged 60 reconstructed point(s); ledger now 62, 2026-05-08 .. 2026-08-06
vdr-trend: 62 point(s); latest 2026-08-06
re-run:   merged 0 reconstructed point(s); ledger now 62      <- idempotent
```

The reconstructed series carries real signal, not a flat line: `risk_accepted` moves across 3, 5, 10, 12, 13, 14, 15 and 18 over the window.

19 new tests (merge semantics, live-points-win, idempotence, rolling window, chronology, the committed file's shape against the builder's own, and the `.well-known/` publish guard). Full suite 205 passed / 19 skipped; `ruff`, `mypy`, `regal` clean; workflow YAML parses.

## Residual / needs human

- **The recoverable window is eroding.** The bucket has a 90-day `NoncurrentVersionExpiration`, so the oldest reconstructable points expire daily — `2026-05-08` is already at the boundary. What is captured in this PR is captured permanently; anything not merged before it expires is gone. Worth merging sooner rather than later, though nothing breaks if you don't.
- **Two genuine gaps in the reconstruction**, not defects: `2026-05-09..2026-06-03` (no stored report versions — the VDR publish path likely predates daily operation) and `2026-06-19..2026-06-21`. That second gap **matches the three-day gap in the runtime signal series exactly**, so it looks like one real pipeline outage rather than two independent artefacts.
- **The deploy role still cannot read object versions.** Not needed by this design, but if you ever want reconstruction to run in CI rather than by hand, that is a bootstrap IAM change and therefore an operator-applied one.

## Couldn't verify

- **Post-merge behaviour of the sync change.** The dry run proves no `.well-known/` operations against the live bucket, but only a real deploy proves nothing that should be served stopped being served. Worth a `curl` of `security.txt` and `runtime-signing-pubkey.pem` afterwards — both are now published by paths this PR changed.
- **That the ledger reaches 62 points in production.** Simulated exactly, against the live ledger and live report, but not executed by the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
