### PR TITLE
ci: cancel a run when a job never gets a runner

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -105,6 +105,62 @@ permissions:
 
 jobs:
   # ===========================================================================
+  # JOB -1: QUEUE WATCHDOG
+  # ===========================================================================
+  # `timeout-minutes` bounds a job that is RUNNING. It does nothing for a job
+  # that never gets a runner, and GitHub has no queue timeout of its own. On
+  # 2026-08-06 the compliance job sat in `queued` for 48 minutes with zero steps
+  # while its two siblings picked up runners and finished normally; the run hung
+  # until GitHub garbage-collected it, and the merged research paper sat
+  # undeployed the whole time.
+  #
+  # This waits for the three independent jobs to be picked up and cancels the
+  # run if any of them is still queued after the grace period, turning an
+  # open-ended hang into a fast, re-runnable failure.
+  #
+  # `deploy` and `notify` are deliberately not watched: they are queued waiting
+  # on their dependencies, which is correct behaviour and not a stuck runner.
+  #
+  # Known limitation: this job needs a runner too, so it cannot help when
+  # allocation fails completely. It covers the partial case actually observed,
+  # where some jobs get runners and others do not.
+  # ===========================================================================
+  queue-watchdog:
+    name: Queue watchdog
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: write   # cancel this run; nothing else
+    steps:
+    - name: Cancel the run if a job never gets a runner
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GRACE_MINUTES: '12'
+      run: |
+        set -euo pipefail
+        # Watch by exclusion, not by listing the jobs to watch. `deploy` and
+        # `notify` are queued waiting on their dependencies, which is correct;
+        # everything else queued has no runner. Excluding is the fail-safe
+        # direction: renaming a watched job would silently drop it from an
+        # inclusion list, whereas here it stays watched, and only a NEW dependent
+        # job could cause a false cancel — which is loud and gets noticed.
+        DEPENDENT='["Deploy Infrastructure","Notify on Failure","Queue watchdog"]'
+        stuck=''
+        for _ in $(seq 1 $(( GRACE_MINUTES * 2 ))); do
+          stuck=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs" \
+                    --jq "[.jobs[] | select(.status == \"queued\") | .name] - $DEPENDENT | join(\", \")")
+          if [ -z "$stuck" ]; then
+            echo "All independent jobs have runners."
+            exit 0
+          fi
+          sleep 30
+        done
+        echo "::error::No runner after ${GRACE_MINUTES}m, still queued: ${stuck}"
+        echo "Cancelling so this fails fast and can be re-run."
+        gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/cancel"
+        exit 1
+
+  # ===========================================================================
   # JOB 0: TEST GATE
   # ===========================================================================
   # Runs the Python unit suite and the OPA policy tests on every push and PR.


### PR DESCRIPTION
## Changed

`timeout-minutes` bounds a job that is *running*. It does nothing for a job that never gets a runner, and GitHub has no queue timeout of its own.

Today the `OPA Compliance Check` job sat in `queued` for 48 minutes with **zero steps recorded**, while `Unit tests` and `Security Scan` picked up runners within 30 seconds and completed normally. Neither existing mitigation could fire — the job's `timeout-minutes: 25` and the credential step's `timeout-minutes: 6` both apply only once a job is executing. The run hung until GitHub garbage-collected it, and a merged change sat undeployed for hours behind a workflow that looked like it was still working.

Adds a `queue-watchdog` job that polls this run and cancels it if anything is still queued after a grace period (12 minutes), converting an open-ended hang into a fast, re-runnable failure. It exits as soon as every job has a runner, so a healthy run pays about a second.

**It watches by exclusion.** `deploy` and `notify` are queued waiting on their dependencies, which is correct behaviour; anything else queued has no runner. Excluding is the fail-safe direction — renaming a watched job would silently drop it out of an inclusion list, whereas here it stays watched, and only a *new dependent job* could cause a false cancel, which is loud and gets noticed immediately.

**Cancelling, not failing.** `notify` fires on a `failure` result and creates a GitHub issue; a cancelled run produces `cancelled`, so the watchdog does not generate issue noise.

## Verified

- **The detection query was run against real data, not reasoned about.** Against the actually-stuck run it returns `OPA Compliance Check`; against a healthy run it returns empty.
- **An earlier version of this query was broken and would have shipped broken.** The first attempt matched job names with a regex, and `\(` is string interpolation in jq, so it failed to parse. Caught by testing it against the API rather than by reading it. The shipped version uses array subtraction and needs no escaping.
- The extracted step passes `bash -n`, and the full workflow parses as YAML with the expected six jobs.
- End-to-end dry run against both a stuck and a healthy run: the stuck case emits the error annotation and issues the cancel call, the healthy case reports all jobs have runners and exits 0.
- **CodeGuard ran** (CI/CD and IaC rulesets, plus the always-apply credential rules). Clean: no `${{ }}` interpolated into a shell — the classic Actions script-injection vector — with values arriving via `env` instead; `actions: write` granted at job level only, not workflow-wide, and the workflow still grants no `actions` permission globally; no third-party actions introduced; no hardcoded credentials.

## Residual / needs human

The watchdog needs a runner too, so it cannot help when allocation fails completely. It covers the partial case actually observed, where some jobs get runners and others do not. This is stated in the job's own comments so the next person does not over-trust it.

The 12-minute grace period is a judgement call. Normal pickup is under 30 seconds, so it is generous; if runs are being cancelled during ordinary GitHub slowness it should go up.

## Couldn't verify

Its behaviour in a live run. GitHub Actions has been in major outage since 15:22 UTC, so this PR's own checks may not execute either — and if they do, this workflow change is exactly what would be exercising the failure it was written for.