### PR TITLE
deps(a11y): refresh ip-address to clear three transitive advisories

### DIFF
--- a/tools/a11y/package-lock.json
+++ b/tools/a11y/package-lock.json
@@ -679,9 +679,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"


### PR DESCRIPTION
Closes three open Dependabot alerts that never got a PR of their own.

## Changed

`tools/a11y/package-lock.json`, one package, three lines: `ip-address` 10.2.0 → 10.5.0.

**Why there was no Dependabot PR.** `ip-address` is transitive, reached through `socks`. No manifest declares it, so there is nothing for Dependabot to open a version bump against. It also does not need one — `socks` already requires `^10.1.1`, and the fixes land in 10.2.1, 10.2.2 and 10.3.1, so the existing range permits all three. A lockfile refresh is the entire fix.

| Alert | Severity | Fixed in | Issue |
|---|---|---|---|
| #3 | high | 10.3.1 | Leading-zero octets decoded as decimal where resolvers decode octal — SSRF bypass |
| #2 | medium | 10.2.2 | A CIDR suffix suppresses special-use classification — SSRF / trust-boundary bypass |
| #1 | medium | 10.2.1 | IPv4-mapped and NAT64 IPv6 addresses misclassified — trust-boundary bypass |

## Verified

- `npm update ip-address --package-lock-only` moved exactly one package. Diff is version, tarball URL and integrity hash.
- `npm ci --dry-run` resolves the tree; 10.5.0 satisfies `socks`' `^10.1.1`.
- `npm audit` now reports the three `ip-address` advisories gone, with js-yaml as the only survivor.

## Residual / needs human

- **js-yaml is deliberately not folded in.** It has its own PR (#270), which is the fix for a **high** advisory despite carrying only the `dependencies` label. Merging both clears all four alerts on this lockfile.
- **These packages are outside the canonical inventory.** The KSI signal holds 113 npm components and none of them is `ip-address` or `js-yaml`, so this fix will not appear in the VDR. Being looked at separately; flagged here so the gap is on the record rather than inferred from silence.
- **Every Dependabot PR on this repo is currently red for an unrelated reason.** `existing_cloudfront_distribution_id` reads from an Actions secret, and Dependabot-triggered runs use the separate Dependabot secret store, so it interpolates to empty and terraform fails on `reading CloudFront Distribution ()`. Worth fixing so dependency PRs give honest signal.

## Couldn't verify

- That pa11y still runs end to end. It needs Chrome and a built site, neither available here. The change is a patch-range bump of a transitive address parser and the tree resolves, but the scanner has not been executed against this lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)