### PR TITLE
ci: scan the compliance Lambda's dependencies, not just Silk Reeling's

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -855,16 +855,29 @@ jobs:
 
     # -------------------------------------------------------------------------
     # SCAN SILK REELING DEPENDENCIES (Software Composition Analysis) — closes the
-    # VDR-CSO-DET gap for the Silk Reeling app. Dependabot watches only this
-    # repo's npm/Terraform/Actions manifests; the app's dep manifests live in the
-    # separate silk-reeling-mirror repo and reach production via the slim Lambda
-    # zip (_pkg) and the SPA bundle. Syft inventories both dependency trees and
-    # Grype maps them to CVEs/GHSAs. The VDR aggregator (downstream) is what
+    # Dependency SCA for everything that reaches production. Three trees, and
+    # they get here by different routes:
+    #
+    #   _pkg               Silk Reeling's Python deps, staged for its Lambda zip.
+    #   _silk_src/frontend Silk Reeling's SPA. Both manifests live in the separate
+    #                      silk-reeling-mirror repo, so Dependabot never sees them
+    #                      — this scan is the only CVE coverage they get.
+    #   lambda             The compliance/KSI Lambda's own npm tree. Dependabot
+    #                      DOES watch this manifest, but Dependabot alerts are not
+    #                      the VDR: until this scan existed, 106 of the inventory's
+    #                      140 dependency components were in the canonical
+    #                      inventory and in the authorization boundary while never
+    #                      being CVE-mapped into the published vulnerability
+    #                      report. The coverage table claimed Grype covered the
+    #                      dependency set; it covered 34 of it.
+    #
+    # Syft inventories each tree and Grype maps them to CVEs/GHSAs. The VDR
+    # aggregator (downstream) is what
     # evaluates and enforces the Class C remediation SLAs, so this step never
     # fails the build on findings — it only has to emit a valid grype.json.
     # Runs unconditionally on the deploy path, mirroring the build step above.
     # -------------------------------------------------------------------------
-    - name: Scan Silk Reeling dependencies (Syft SBOM + Grype)
+    - name: Scan application and Lambda dependencies (Syft SBOM + Grype)
       working-directory: infrastructure
       run: |
         set +e   # SCA findings must never fail the build; the VDR gate does that
@@ -885,19 +898,28 @@ jobs:
         # golang/stdlib findings that are in neither the Lambda nor the browser.
         syft dir:_pkg               -o cyclonedx-json=sbom-python.json --select-catalogers python     || true
         syft dir:_silk_src/frontend -o cyclonedx-json=sbom-js.json     --select-catalogers javascript || true
+        # The compliance Lambda's own tree. node_modules is present because the
+        # "Install Lambda dependencies" step above ran `npm ci --omit=dev` in this
+        # same job. It has no devDependencies, so the installed tree and the
+        # lockfile the canonical inventory reads are the same set — the scan
+        # covers exactly the components the inventory names, not a superset.
+        syft dir:lambda             -o cyclonedx-json=sbom-lambda.json --select-catalogers javascript || true
         # Grype each SBOM. `|| true` so a scan error still leaves a file behind.
         grype sbom:sbom-python.json -o json > grype-python.json || true
         grype sbom:sbom-js.json     -o json > grype-js.json     || true
+        grype sbom:sbom-lambda.json -o json > grype-lambda.json || true
         # Normalize: any file that is missing/invalid/lacking .matches becomes an
         # empty match set so the merge below cannot fail and ingest_grype always
         # gets a valid top-level .matches[] array.
-        for f in grype-python.json grype-js.json; do
+        for f in grype-python.json grype-js.json grype-lambda.json; do
           jq -e '.matches' "$f" >/dev/null 2>&1 || echo '{"matches":[]}' > "$f"
         done
         # Merge the two scans into one grype.json (single .matches[] array) that
         # --grype reads. The aggregator is what classifies and gates them.
-        jq -s '{matches: (map(.matches) | add)}' grype-python.json grype-js.json > grype.json
-        echo "grype.json: $(jq '.matches | length' grype.json) match(es) across Python + JS deps"
+        jq -s '{matches: (map(.matches) | add)}' \
+          grype-python.json grype-js.json grype-lambda.json > grype.json
+        echo "grype.json: $(jq '.matches | length' grype.json) match(es) across Silk Reeling Python + JS and the compliance Lambda"
+        echo "  silk-python: $(jq '.matches | length' grype-python.json)  silk-js: $(jq '.matches | length' grype-js.json)  lambda: $(jq '.matches | length' grype-lambda.json)"
 
     # -------------------------------------------------------------------------
     # IMPORT SILK REELING RESOURCES (if they exist) — local state isn't


### PR DESCRIPTION
Closes a gap between what the coverage table claimed and what the pipeline did.

## Changed

Syft was pointed at `_pkg` and `_silk_src/frontend`. Both are **Silk Reeling** — the Python backend staged for its zip, and the SPA. The compliance Lambda's own npm tree was never scanned.

| Tree | Components | Grype before | Grype after |
|---|---|---|---|
| Silk Reeling Python (`_pkg`) + SPA (`_silk_src/frontend`) | 34 | ✅ | ✅ |
| Compliance Lambda (`infrastructure/lambda`) | 106 | ❌ | ✅ |

Those 106 are in the canonical inventory and inside the authorization boundary. Dependabot watched them, but a Dependabot alert is not the VDR — so the daily rebuild against a freshly pulled vulnerability database, the strongest continuous-monitoring claim the project makes, was reaching **34 of the 140** components it appeared to reach.

Adds a third Syft pass and merges its Grype output into the same `grype.json` the aggregator already reads. Nothing downstream changes: the aggregator still classifies and gates, and this step still cannot fail the build.

Also corrects a comment calling `_pkg` "the Lambda zip". In this repo "the Lambda" means the compliance Lambda, and `_pkg` is Silk Reeling's. That naming is most of why this survived review.

## Verified

Run locally with the pinned versions (Syft v1.45.1, Grype v0.114.0) against a vulnerability database built the same day:

- **Syft catalogues 108 components** from the Lambda tree.
- **Grype returns zero matches.** This widens coverage without adding a single finding to disposition, so it cannot block the deploy gate on merge.
- **Zero was not taken on trust.** The identical tool pair over `tools/a11y` returns four matches — `ip-address` ×3 and `js-yaml` ×1 — which are precisely the four advisories Dependabot reports on that lockfile. Two tools agreeing independently, so the zero above is a real result and not a silent no-op. (A first attempt did return a false zero from a year-stale database; that was caught and the database refreshed before the numbers above were taken.)
- Ordering holds: `npm ci --omit=dev` runs in the same job before the scan, and the package has no devDependencies, so the installed tree and the lockfile the inventory reads are the same 112 entries. The scan covers exactly the components the inventory names, not a superset.
- YAML parses.

## Residual / needs human

- **The coverage table needs rewriting to match.** It is currently a placeholder (#280), so nothing overstated is live, but the claim should not come back in its old form when the paper is rewritten. After this merges, Grype genuinely covers 140 of 140.
- `tools/a11y` is deliberately not scanned here. It is being inventoried as build-time in a follow-up, and its scan belongs with that change rather than smuggled into this one.

## Couldn't verify

- Behaviour in CI. The scan was reproduced locally against the same trees with the same pinned tools, but the runner installs Syft and Grype fresh and pulls its own database, so the first CI run is the real test. Since the step is `set +e` throughout and cannot fail the build, a surprise there degrades to an empty match set rather than a broken deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)