### PR TITLE
inventory: carry the accessibility scanner as build-time components

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,23 @@ updates:
       prefix: "deps(lambda)"
       include: "scope"
 
+  # The accessibility scanner. Security alerts already reached this lockfile
+  # (Dependabot raises those against every manifest it detects), but routine
+  # version updates did not, because only configured directories get them. That
+  # asymmetry is how it ended up three advisories behind on a transitive
+  # dependency with nobody bumping it.
+  - package-ecosystem: "npm"
+    directory: "/tools/a11y"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "build-tooling"
+    commit-message:
+      prefix: "deps(a11y)"
+      include: "scope"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -904,22 +904,28 @@ jobs:
         # lockfile the canonical inventory reads are the same set — the scan
         # covers exactly the components the inventory names, not a superset.
         syft dir:lambda             -o cyclonedx-json=sbom-lambda.json --select-catalogers javascript || true
+        # The accessibility scanner. Build tooling, so it never deploys, but its
+        # output is policy input to the deploy gate and it is inventoried as a
+        # build-time component — anything the inventory names should be scannable
+        # against the same database on the same day.
+        syft dir:../tools/a11y      -o cyclonedx-json=sbom-a11y.json   --select-catalogers javascript || true
         # Grype each SBOM. `|| true` so a scan error still leaves a file behind.
         grype sbom:sbom-python.json -o json > grype-python.json || true
         grype sbom:sbom-js.json     -o json > grype-js.json     || true
         grype sbom:sbom-lambda.json -o json > grype-lambda.json || true
+        grype sbom:sbom-a11y.json   -o json > grype-a11y.json   || true
         # Normalize: any file that is missing/invalid/lacking .matches becomes an
         # empty match set so the merge below cannot fail and ingest_grype always
         # gets a valid top-level .matches[] array.
-        for f in grype-python.json grype-js.json grype-lambda.json; do
+        for f in grype-python.json grype-js.json grype-lambda.json grype-a11y.json; do
           jq -e '.matches' "$f" >/dev/null 2>&1 || echo '{"matches":[]}' > "$f"
         done
         # Merge the two scans into one grype.json (single .matches[] array) that
         # --grype reads. The aggregator is what classifies and gates them.
         jq -s '{matches: (map(.matches) | add)}' \
-          grype-python.json grype-js.json grype-lambda.json > grype.json
+          grype-python.json grype-js.json grype-lambda.json grype-a11y.json > grype.json
         echo "grype.json: $(jq '.matches | length' grype.json) match(es) across Silk Reeling Python + JS and the compliance Lambda"
-        echo "  silk-python: $(jq '.matches | length' grype-python.json)  silk-js: $(jq '.matches | length' grype-js.json)  lambda: $(jq '.matches | length' grype-lambda.json)"
+        echo "  silk-python: $(jq '.matches | length' grype-python.json)  silk-js: $(jq '.matches | length' grype-js.json)  lambda: $(jq '.matches | length' grype-lambda.json)  a11y: $(jq '.matches | length' grype-a11y.json)"
 
     # -------------------------------------------------------------------------
     # IMPORT SILK REELING RESOURCES (if they exist) — local state isn't

--- a/scripts/build-ksi-signal.py
+++ b/scripts/build-ksi-signal.py
@@ -870,8 +870,24 @@ def build_live_log_groups(existing_components, region="us-east-2"):
     return new
 
 
-def build_npm_components(lock_path):
-    """Read package-lock.json (lockfileVersion 3) and emit npm components."""
+def build_npm_components(lock_path, function=None, lifecycle="runtime",
+                         existing_components=None):
+    """Read package-lock.json (lockfileVersion 3) and emit npm components.
+
+    lifecycle distinguishes what a package is doing here. "runtime" means it
+    ships and executes in the deployed system. "build-time" means it runs only
+    in CI and is never deployed — build tooling whose output the pipeline
+    nonetheless trusts, which is why it is inventoried rather than ignored.
+
+    function overrides the per-type IIW default, which is written for the
+    compliance Lambda and is false for anything else; passing the wrong one
+    silently mislabels every component from that tree.
+
+    existing_components dedupes by PURL across sources, because the same
+    package@version can appear in more than one lockfile and the inventory holds
+    one component per PURL. Earlier callers win, so a package that is both
+    shipped and used at build time keeps its runtime classification.
+    """
     if not lock_path.exists():
         return []
     try:
@@ -880,7 +896,8 @@ def build_npm_components(lock_path):
         print(f"warning: could not parse {lock_path}", file=sys.stderr)
         return []
     components = []
-    seen = set()
+    seen = {c.get("global_id", {}).get("purl")
+            for c in (existing_components or [])} - {None}
     for path, info in (lock.get("packages") or {}).items():
         if path == "":
             # The root package is the Lambda itself, not a dependency.
@@ -913,6 +930,9 @@ def build_npm_components(lock_path):
         apply_mas_defaults(component)
         apply_iiw_defaults(component)
         apply_classification_defaults(component)
+        component["attributes"]["lifecycle"] = lifecycle
+        if function:
+            component["attributes"]["function"] = function
         components.append(component)
     return components
 
@@ -1375,6 +1395,7 @@ def main():
     repo_root = cwd.parent
     website_root = repo_root / "website"
     lambda_lock = cwd / "lambda" / "package-lock.json"
+    a11y_lock = repo_root / "tools" / "a11y" / "package-lock.json"
     # CycloneDX SBOMs written by the deploy workflow's Syft SCA step (run from
     # this same infrastructure/ directory) for the Silk Reeling app's dependency
     # trees. Absent when that app wasn't built — build_sbom_components no-ops.
@@ -1406,6 +1427,19 @@ def main():
     # missed.
     components.extend(build_live_log_groups(components))
     components.extend(build_npm_components(lambda_lock))
+    # The accessibility scanner is build tooling: it never deploys and holds no
+    # data. It is inventoried anyway because it is not inert. Its own manifest
+    # calls it a "fact-producer for the OPA gate" — pa11y emits the facts that
+    # infrastructure/policy/accessibility.rego makes a pass/fail decision on, so
+    # a compromised dependency there could make a failing site pass a compliance
+    # gate. That is an integrity path into a control decision, and a supply
+    # chain that can influence a gate belongs in the inventory that the gate is
+    # reconciled against. Marked build-time so it never reads as deployed.
+    components.extend(build_npm_components(
+        a11y_lock,
+        function="Build-time dependency of the accessibility fact-producer (npm)",
+        lifecycle="build-time",
+        existing_components=components))
     # Ingest the Silk Reeling app's resolved dependency trees from the Syft
     # CycloneDX SBOMs so the canonical inventory covers its Python (PyPI) and
     # SPA (npm) packages, not just the compliance Lambda's npm packages. Each

--- a/scripts/build-oscal-ssp.py
+++ b/scripts/build-oscal-ssp.py
@@ -1226,7 +1226,16 @@ def build_system_implementation(signal):
         })
 
     # Summary of software components (npm packages from the Lambda runtime).
-    npm_count = sum(1 for c in signal.get("components", []) if c.get("type") == "npm_package")
+    # Build-time packages are inventoried too (the accessibility scanner), and
+    # they are NOT part of the Lambda's runtime stack: counting them here would
+    # describe CI tooling as running inside the deployed function.
+    npm_runtime = [c for c in signal.get("components", [])
+                   if c.get("type") == "npm_package"
+                   and c.get("attributes", {}).get("lifecycle", "runtime") != "build-time"]
+    npm_build = [c for c in signal.get("components", [])
+                 if c.get("type") == "npm_package"
+                 and c.get("attributes", {}).get("lifecycle") == "build-time"]
+    npm_count = len(npm_runtime)
     if npm_count:
         components.append({
             "uuid": stable_uuid("component:lambda-software-stack"),
@@ -1243,6 +1252,33 @@ def build_system_implementation(signal):
             "props": [
                 {"name": "package-count", "value": str(npm_count)},
                 {"name": "ecosystem", "value": "npm"},
+                {"name": "inventory-source", "value": "/.well-known/ksi-signal.json"},
+            ],
+            "status": {"state": "operational"},
+        })
+
+    # Build-time software: inventoried, not deployed. Kept as its own component
+    # so a reader can see that the boundary distinction is deliberate rather
+    # than inferring it from a count that does not add up.
+    if npm_build:
+        components.append({
+            "uuid": stable_uuid("component:build-time-software-stack"),
+            "type": "software",
+            "title": "Build-time software stack",
+            "description": (
+                f"Aggregated software components ({len(npm_build)} npm packages) "
+                "that run only in the build pipeline and are never deployed. "
+                "Currently the accessibility scanner, whose output the deploy "
+                "gate evaluates as policy input, which is why it is inventoried "
+                "rather than treated as out of scope. The full PURL-identified "
+                "enumeration is in the canonical inventory at "
+                "/.well-known/ksi-signal.json (components[] where type == "
+                "'npm_package' and attributes.lifecycle == 'build-time')."
+            ),
+            "props": [
+                {"name": "package-count", "value": str(len(npm_build))},
+                {"name": "ecosystem", "value": "npm"},
+                {"name": "lifecycle", "value": "build-time"},
                 {"name": "inventory-source", "value": "/.well-known/ksi-signal.json"},
             ],
             "status": {"state": "operational"},

--- a/scripts/inject-figures.py
+++ b/scripts/inject-figures.py
@@ -145,7 +145,16 @@ def _coverage_layers(components):
     for c in components:
         by_type.setdefault(c.get("type", "unknown"), []).append(c)
 
-    deps = sum(len(v) for t, v in by_type.items() if t in {"npm_package", "pypi_package"})
+    # deps_scanned counts what ships. Build-time packages are inventoried but
+    # are not part of the deployed dependency set, and folding them in would
+    # move a published figure without the thing it measures having changed.
+    dep_types = {"npm_package", "pypi_package"}
+    deps = sum(1 for c in components
+               if c.get("type") in dep_types
+               and c.get("attributes", {}).get("lifecycle", "runtime") != "build-time")
+    build_deps = sum(1 for c in components
+                     if c.get("type") in dep_types
+                     and c.get("attributes", {}).get("lifecycle") == "build-time")
     content = len(by_type.get("html_artifact", []))
     cloud_types = {t: v for t, v in by_type.items() if t not in NON_RUNTIME_TYPES}
     cloud = sum(len(v) for v in cloud_types.values())
@@ -158,6 +167,7 @@ def _coverage_layers(components):
     return {
         "total": len(components),
         "deps": deps,
+        "build_deps": build_deps,
         "content": content,
         "cloud": cloud,
         "cloud_types": len(cloud_types),
@@ -202,6 +212,7 @@ def compute_figures():
         # adequacy of the continuous checks
         "inventory_total": str(lay["total"]),
         "deps_scanned": str(lay["deps"]),
+        "build_deps_scanned": str(lay["build_deps"]),
         "content_hashed": str(lay["content"]),
         "cloud_components": str(lay["cloud"]),
         "cloud_types": str(lay["cloud_types"]),


### PR DESCRIPTION
Stacked on #282. Base is `ci/grype-covers-lambda-deps`; retarget to `main` once that merges.

## Changed

The a11y scanner's 112 npm packages were in no inventory, no SBOM and no scan. Dependabot raised security alerts against its lockfile — it does that for every manifest it detects — but the canonical inventory never named one of them, so the VDR never could either.

It is build tooling and never deploys, which is a fair reason to leave it out of a *system* inventory. It is not inert, though. Its own `package.json` calls it a **"fact-producer for the OPA gate"**: pa11y emits the facts that `accessibility.rego` makes a pass/fail decision on, so a compromised dependency there could make a failing site pass a compliance gate. A supply chain that can influence a gate belongs in the inventory the gate is reconciled against.

Adds `attributes.lifecycle` (`runtime` / `build-time`). **Three things follow that would otherwise have gone wrong quietly:**

- The npm IIW default writes `function` as *"Runtime dependency of the compliance/KSI Lambda"*. Ingesting a second tree under the same type would have stamped that false statement onto 112 components. `build_npm_components` now takes the function text and lifecycle from its caller.
- It now dedupes by PURL against components already collected — the pattern `build_sbom_components` already used. **One package appears in both lockfiles**; without this it produces a duplicate `component_id` and fails the inventory gate's uniqueness check.
- The SSP's *"Lambda runtime software stack"* counted every npm component and described them as running inside the deployed function. **It would have described 111 CI-only packages as running in production, in a signed artifact.** Now split, with build-time software as its own component.

`deps_scanned` **stays runtime-only and holds at 140**, per your call. Build-time packages get `build_deps_scanned` instead.

Also: `tools/a11y` joins the Grype scan, and joins `dependabot.yml`. That second one is *why* it fell three advisories behind — security alerts reach every manifest, routine version updates only reach configured directories.

## Verified

| Check | Result |
|---|---|
| Components resolved | 106 runtime, 112 build-time |
| `component_id` collisions | **0** |
| PURL collisions | **0** (1 overlap correctly suppressed) |
| Inventory gate on spliced result | PURLs valid, native_id unique, typing consistent |
| `deps_scanned` | **140, unchanged** |
| SSP software stacks | 113 runtime / 111 build-time (was: 224 all claimed runtime) |
| Unit tests | 252 passed, 17 skipped |
| Essay gates, figure freshness | green |
| YAML | both files parse |

Changes to the generators are additive: the five removed lines are the four signatures/expressions being widened plus one `seen = set()`.

## Residual / needs human

- **Retarget to `main` when #282 merges.**
- **`build_deps_scanned` is computed but stamped nowhere**, so the figure gate lists it as unstamped. That is expected while the paper is a placeholder; it exists so the number is available when the coverage table is rewritten.
- **The coverage table will need a third row** when the paper comes back: 140 runtime dependencies, 111 build-time, and what reaches each.
- The four packages carrying open advisories in this tree are fixed by #281 and #270. Merging those first means this ingests a clean tree.

## Couldn't verify

- **The full signal could not be rebuilt locally.** Initialising the remote backend asks for an interactive state migration, which I did not answer. Every number above comes from running the generator's own functions against the real lockfiles and splicing the result into the existing signal, so the npm delta is authoritative; absolute totals from the local signal are not, because that local artifact is a stale build that still contains an HTML component from a since-closed branch. CI rebuilds the whole signal and re-checks, which is the real test.
- Behaviour of the a11y Grype pass in CI. Reproduced locally with the pinned tools — it returns the four known advisories — but the runner installs its own tools and database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)