### PR TITLE
ci: make the compliance gate plan what the deploy actually applies

### DIFF
--- a/.github/workflows/deploy-with-opa.yml
+++ b/.github/workflows/deploy-with-opa.yml
@@ -322,6 +322,8 @@ jobs:
         manage_dns = ${{ vars.MANAGE_DNS || 'true' }}
         compliance_check_schedule = "${{ vars.COMPLIANCE_SCHEDULE || 'rate(1 day)' }}"
         section_508_compliance_level = "${{ vars.SECTION_508_LEVEL || 'AA' }}"
+        create_silk_reeling = true
+        silk_reeling_package_path = "./silk-reeling.zip"
         EOF
 
     # -------------------------------------------------------------------------
@@ -402,6 +404,39 @@ jobs:
     # serializes runs on the SAME ref, so plans from different open PRs can
     # race for the lock. -lock-timeout makes a contending plan wait its turn
     # instead of failing the check.
+    # The Silk Reeling resources are gated behind create_silk_reeling, and this
+    # job now sets it true so the plan describes the same resource set the deploy
+    # job applies. Without that the count collapsed to zero and EVERY pull
+    # request planned to destroy 19 live resources — identically, whether the PR
+    # touched infrastructure or bumped a GitHub Action. The gate passed anyway,
+    # so it was evaluating a configuration that would tear down the app, and
+    # returning the same answer regardless of its input.
+    #
+    # Turning the flag on needs a file to exist: the Lambda computes
+    # source_code_hash = filebase64sha256(var.silk_reeling_package_path), which
+    # terraform evaluates at PLAN time and errors on if the path is missing. This
+    # job cannot build the real package — that needs the mirror repository, whose
+    # token is not available here and is not in the Dependabot secret store at
+    # all, so dependency PRs could never build it. A placeholder satisfies the
+    # hash so the other resources plan against their real configuration.
+    #
+    # Consequence to expect, and to leave alone: the Lambda itself shows a diff
+    # on filename/source_code_hash, because the placeholder is not the deployed
+    # package. That is one known-noisy resource in exchange for the rest planning
+    # honestly. This job never applies — the only terraform apply is in the
+    # deploy job, which builds the real package first.
+    - name: Stage a placeholder Silk Reeling package for planning
+      working-directory: infrastructure
+      run: |
+        set -euo pipefail
+        rm -rf _silk_stub silk-reeling.zip
+        mkdir -p _silk_stub
+        printf 'def handler(event, context):\n    raise RuntimeError("plan-only placeholder")\n' \
+          > _silk_stub/lambda_handler.py
+        ( cd _silk_stub && zip -qr ../silk-reeling.zip . )
+        rm -rf _silk_stub
+        test -s silk-reeling.zip && echo "placeholder staged for plan only (never applied)"
+
     - name: Terraform Plan
       working-directory: infrastructure
       run: terraform plan -lock-timeout=300s -out=tfplan


### PR DESCRIPTION
Every pull request's compliance gate planned to destroy 19 live resources, and passed.

## What was happening

The Silk Reeling resources are gated behind `create_silk_reeling`. The deploy job sets it `true`. The compliance-check job never set it, and `variables.tf` defaults it to `false` — so `count` collapsed to zero and the Lambda, Cognito user pool, API Gateway, KMS key, secret and log groups all planned for destruction.

It is not specific to any change. Three PRs, identical plans:

| PR | Changes | Plan |
|---|---|---|
| #278 | `actions/checkout` bump, no infrastructure | `0 to add, 2 to change, 19 to destroy` |
| #285 | an npm SDK bump | `0 to add, 2 to change, 19 to destroy` |
| #284 | AWS provider `~> 5.0` → `~> 6.58` | `0 to add, 2 to change, 19 to destroy` |

**Nothing was ever at risk of being destroyed.** This job only plans. The single `terraform apply` is in the deploy job, which runs its own `terraform plan -out=tfplan` first and overwrites the downloaded artifact.

**The damage was to the signal.** The gate was evaluating a configuration that would tear down the application, and returning the same answer regardless of what the PR contained — so a dangerous infrastructure change and a dependency bump were indistinguishable at exactly the point that exists to tell them apart.

## Changed

- The compliance-check job now sets `create_silk_reeling = true` and `silk_reeling_package_path`, matching the deploy job.
- A new step stages a placeholder package before planning.

**Why the placeholder is necessary.** `source_code_hash = filebase64sha256(var.silk_reeling_package_path)` is evaluated at **plan time** and errors on a missing path — so simply flipping the flag turns a misleading-but-green gate into a broken one. This job cannot build the real package: that needs the mirror repository, whose token is not present in this job and is absent from the Dependabot secret store entirely, so dependency PRs could never build it.

**The trade, documented in the step so nobody "fixes" it later:** the Lambda itself will show a diff on `filename`/`source_code_hash`, because the placeholder is not the deployed package. One known-noisy resource in exchange for the rest planning honestly.

## Verified

- Traced the full plan/apply path: compliance-check uploads `tfplan`; deploy downloads it, then re-plans at line 1058 and applies **its own** plan at 1062. There is exactly one `terraform apply` in the workflow. This change cannot reach an apply.
- `scripts/terraform-plan.sh` deletes and regenerates the plan itself from the same `terraform.tfvars`, so the change reaches the plan OPA actually evaluates, and the placeholder persists in the working directory for it.
- The 19 resources were identified from the plan log as `silk_reeling`/`opa_compliance` with `[0]` count indices, all refreshing successfully — present in both state and AWS.
- Placeholder zip verified locally as a real archive with a computable `filebase64sha256`.
- YAML parses.

## Residual / needs human

- **This PR's own CI is the test.** The gate will now evaluate 16 Silk Reeling resources against policy for the first time on a pull request. If any violate, this PR goes red — and that is a finding worth having, not a defect in the change. Read a red result here as the gate finally doing its job.
- Expect the plan summary to move from `19 to destroy` to roughly `0 to destroy` with a small number of changes, one of which is the placeholder-induced Lambda diff.
- Unrelated but adjacent: batch re-runs on this repo contend for the Terraform state lock. The workflow's per-ref concurrency prevents cancellation, not contention, and `-lock-timeout=300s` is the only thing absorbing it. Seven simultaneous re-runs exceeded it earlier today.

## Couldn't verify

- Whether the Silk Reeling resources pass the OPA policy. That cannot be determined without running the gate against a plan that includes them, which is precisely what this PR causes to happen for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)